### PR TITLE
Configure NZBGet with ConfigMap and External Secrets

### DIFF
--- a/kubernetes/apps/media/nzbget/app/config/nzbget.conf
+++ b/kubernetes/apps/media/nzbget/app/config/nzbget.conf
@@ -1,0 +1,371 @@
+# NZBGet Configuration File
+# This configuration is managed by Kubernetes ConfigMap
+
+##############################################################################
+### PATHS                                                                  ###
+##############################################################################
+
+# Root directory for all tasks
+MainDir=/config
+
+# Destination for downloaded files
+DestDir=/safe/usenet
+
+# Temporary directory for download and unpack
+TempDir=/tmp
+
+# Directory for intermediate download files
+InterDir=/config/intermediate
+
+# Directory for incoming nzb-files
+NzbDir=/config/nzb
+
+# Directory for queued nzb-files
+QueueDir=/config/queue
+
+# Directory for downloaded nzb-files
+LogFile=/config/nzbget.log
+
+# Lock-file for daemon mode
+LockFile=/config/nzbget.lock
+
+##############################################################################
+### NEWS-SERVERS                                                           ###
+##############################################################################
+
+# News servers configuration
+# Server credentials should be added via ExternalSecret to Infisical
+# Path: /nzbget
+
+# Server1: Thundernews - UsenetExpress
+Server1.Active=yes
+Server1.Name=Thundernews - UsenetExpress
+Server1.Host=${NZBGET_SERVER1_HOST:-secure.us.thundernews.com}
+Server1.Port=${NZBGET_SERVER1_PORT:-563}
+Server1.Username=${NZBGET_SERVER1_USERNAME}
+Server1.Password=${NZBGET_SERVER1_PASSWORD}
+Server1.Encryption=yes
+Server1.Connections=20
+Server1.Retention=0
+
+# Server2: Newshosting - Omnicron
+Server2.Active=yes
+Server2.Name=Newshosting - Omnicron
+Server2.Host=${NZBGET_SERVER2_HOST:-news.newshosting.com}
+Server2.Port=${NZBGET_SERVER2_PORT:-563}
+Server2.Username=${NZBGET_SERVER2_USERNAME}
+Server2.Password=${NZBGET_SERVER2_PASSWORD}
+Server2.Encryption=yes
+Server2.Connections=20
+Server2.Retention=0
+
+# Server3: Usenetexpress
+Server3.Active=yes
+Server3.Name=Usenetexpress
+Server3.Host=${NZBGET_SERVER3_HOST:-news.usenetexpress.com}
+Server3.Port=${NZBGET_SERVER3_PORT:-563}
+Server3.Username=${NZBGET_SERVER3_USERNAME}
+Server3.Password=${NZBGET_SERVER3_PASSWORD}
+Server3.Encryption=yes
+Server3.Connections=12
+Server3.Retention=0
+
+# Server4: Newsdemon
+Server4.Active=yes
+Server4.Name=Newsdemon
+Server4.Host=${NZBGET_SERVER4_HOST:-us.newsdemon.com}
+Server4.Port=${NZBGET_SERVER4_PORT:-563}
+Server4.Username=${NZBGET_SERVER4_USERNAME}
+Server4.Password=${NZBGET_SERVER4_PASSWORD}
+Server4.Encryption=yes
+Server4.Connections=10
+Server4.Retention=0
+
+# Server5: Tweaknews
+Server5.Active=yes
+Server5.Name=Tweaknews
+Server5.Host=${NZBGET_SERVER5_HOST:-newshosting.tweaknews.eu}
+Server5.Port=${NZBGET_SERVER5_PORT:-563}
+Server5.Username=${NZBGET_SERVER5_USERNAME}
+Server5.Password=${NZBGET_SERVER5_PASSWORD}
+Server5.Encryption=yes
+Server5.Connections=40
+Server5.Retention=0
+
+# Server6: Bulknews
+Server6.Active=yes
+Server6.Name=Bulknews
+Server6.Host=${NZBGET_SERVER6_HOST:-news.bulknews.eu}
+Server6.Port=${NZBGET_SERVER6_PORT:-563}
+Server6.Username=${NZBGET_SERVER6_USERNAME}
+Server6.Password=${NZBGET_SERVER6_PASSWORD}
+Server6.Encryption=yes
+Server6.Connections=30
+Server6.Retention=0
+
+# Server7: Newsgroupdirect
+Server7.Active=yes
+Server7.Name=Newsgroupdirect
+Server7.Host=${NZBGET_SERVER7_HOST:-news.newsgroupdirect.com}
+Server7.Port=${NZBGET_SERVER7_PORT:-563}
+Server7.Username=${NZBGET_SERVER7_USERNAME}
+Server7.Password=${NZBGET_SERVER7_PASSWORD}
+Server7.Encryption=yes
+Server7.Connections=20
+Server7.Retention=0
+
+# Server8: Easynews
+Server8.Active=yes
+Server8.Name=Easynews
+Server8.Host=${NZBGET_SERVER8_HOST:-news.easynews.com}
+Server8.Port=${NZBGET_SERVER8_PORT:-563}
+Server8.Username=${NZBGET_SERVER8_USERNAME}
+Server8.Password=${NZBGET_SERVER8_PASSWORD}
+Server8.Encryption=yes
+Server8.Connections=20
+Server8.Retention=0
+
+##############################################################################
+### CATEGORIES                                                             ###
+##############################################################################
+
+# Categories from sabnzbd configuration
+Category1.Name=movies
+Category1.DestDir=/safe/usenet/movies
+Category1.PostScript=
+Category1.Priority=-100
+
+Category2.Name=tv
+Category2.DestDir=/safe/usenet/tv
+Category2.PostScript=
+
+Category3.Name=audio
+Category3.DestDir=/safe/usenet/audio
+Category3.PostScript=
+
+Category4.Name=software
+Category4.DestDir=/safe/usenet/software
+Category4.PostScript=
+
+Category5.Name=4k-movies
+Category5.DestDir=/safe/usenet/4k-movies
+Category5.PostScript=
+
+Category6.Name=4k-tv
+Category6.DestDir=/safe/usenet/4k-tv
+Category6.PostScript=
+
+Category7.Name=4k-tv-tower
+Category7.DestDir=/safe/usenet/4k-tv-tower
+Category7.PostScript=
+
+Category8.Name=tv-tower
+Category8.DestDir=/safe/usenet/tv-tower
+Category8.PostScript=
+
+Category9.Name=movies-tower
+Category9.DestDir=/safe/usenet/movies-tower
+Category9.PostScript=
+
+Category10.Name=4k-movies-tower
+Category10.DestDir=/safe/usenet/4k-movies-tower
+Category10.PostScript=
+
+Category11.Name=movies-tower-2
+Category11.DestDir=/safe/usenet/movies-tower-2
+Category11.PostScript=
+
+##############################################################################
+### INCOMING NZBS                                                          ###
+##############################################################################
+
+# Scan interval in seconds (0 disables scanning)
+NzbDirInterval=5
+
+# Check for duplicate files
+DupeCheck=yes
+
+##############################################################################
+### DOWNLOAD QUEUE                                                         ###
+##############################################################################
+
+# Save download queue to disk
+SaveQueue=yes
+
+# Reload download queue on start
+ReloadQueue=yes
+
+# Continue partial downloads
+ContinuePartial=yes
+
+# Propagation delay (minutes)
+PropagationDelay=0
+
+# Decode articles
+Decode=yes
+
+# Direct write for articles
+DirectWrite=yes
+
+# Article cache (MB)
+ArticleCache=100
+
+# Write buffer (KB)
+WriteBuffer=1024
+
+##############################################################################
+### CONNECTION                                                             ###
+##############################################################################
+
+# Article timeout (seconds)
+ArticleTimeout=60
+
+# URL timeout (seconds)
+UrlTimeout=60
+
+# Remote timeout (seconds)
+RemoteTimeout=90
+
+# Download rate limit (KB/s, 0=unlimited)
+DownloadRate=0
+
+##############################################################################
+### LOGGING                                                                ###
+##############################################################################
+
+# Write log file
+WriteLog=rotate
+
+# Rotate log when it reaches this size (KB)
+RotateLog=1024
+
+# Display crash log on start
+CrashDump=yes
+
+# Create log for broken files
+BrokenLog=yes
+
+# Create memory info log
+MemoryLog=no
+
+# Output mode (loggable, colored, curses)
+OutputMode=loggable
+
+# Log level (0=none, 1=error, 2=warning, 3=info, 4=detail, 5=debug)
+DetailTarget=both
+InfoTarget=both
+WarningTarget=both
+ErrorTarget=both
+DebugTarget=none
+
+##############################################################################
+### DISPLAY                                                                ###
+##############################################################################
+
+# Number of messages to store
+LogBuffer=1000
+
+# Number of messages to display
+NzbInfoBuffer=50
+
+##############################################################################
+### PAR CHECK/REPAIR                                                       ###
+##############################################################################
+
+# Automatic par check
+ParCheck=auto
+
+# Par repair
+ParRepair=yes
+
+# Par scan (quick, extended, full, dupe)
+ParScan=extended
+
+# Quick verification
+ParQuick=yes
+
+# Pause download during par-repair
+ParPauseQueue=no
+
+# Rename broken files
+ParRename=yes
+
+# Delete source par-files after repair
+ParCleanupQueue=yes
+
+##############################################################################
+### UNPACK                                                                 ###
+##############################################################################
+
+# Unpack downloaded archives
+Unpack=yes
+
+# Delete archive files after unpacking
+UnpackCleanupDisk=yes
+
+# Unpack passwords (comma separated)
+UnpackPassFile=
+
+##############################################################################
+### EXTENSION SCRIPTS                                                      ###
+##############################################################################
+
+# Shell override
+ShellOverride=
+
+# Extension scripts
+ScriptDir=/config/scripts
+
+# Scan interval for new scripts
+ScriptQueueInterval=60
+
+##############################################################################
+### SCHEDULER                                                              ###
+##############################################################################
+
+# Daily quota (MB, 0=unlimited)
+DailyQuota=0
+
+# Weekly quota (MB, 0=unlimited)  
+WeeklyQuota=0
+
+# Monthly quota (MB, 0=unlimited)
+MonthlyQuota=0
+
+##############################################################################
+### PERFORMANCE                                                            ###
+##############################################################################
+
+# Write article buffers (0=auto)
+ArticleInterval=0
+
+# Flush buffers (yes, no)
+FlushQueue=yes
+
+# Feed history days to keep
+FeedHistory=7
+
+##############################################################################
+### WEB INTERFACE                                                          ###
+##############################################################################
+
+# Web interface username (disabled - using proxy auth)
+ControlUsername=
+
+# Web interface password (disabled - using proxy auth)
+ControlPassword=
+
+# Web interface port
+ControlPort=6789
+
+# Allowed IP addresses (comma separated, empty=all)
+ControlIP=0.0.0.0
+
+# Use HTTPS for web interface
+SecureControl=no
+
+# Certificate file for HTTPS
+SecureCert=
+
+# Key file for HTTPS
+SecureKey=

--- a/kubernetes/apps/media/nzbget/app/externalsecret.yaml
+++ b/kubernetes/apps/media/nzbget/app/externalsecret.yaml
@@ -1,0 +1,58 @@
+---
+# yaml-language-server: $schema=https://kubernetes-schemas.pages.dev/external-secrets.io/externalsecret_v1beta1.json
+apiVersion: external-secrets.io/v1beta1
+kind: ExternalSecret
+metadata:
+  name: nzbget
+spec:
+  secretStoreRef:
+    kind: ClusterSecretStore
+    name: infisical
+  target:
+    name: nzbget-secret
+    template:
+      engineVersion: v2
+      data:
+        # Server 1 credentials
+        NZBGET_SERVER1_HOST: "{{ .NZBGET_SERVER1_HOST | default \"secure.us.thundernews.com\" }}"
+        NZBGET_SERVER1_PORT: "{{ .NZBGET_SERVER1_PORT | default \"563\" }}"
+        NZBGET_SERVER1_USERNAME: "{{ .NZBGET_SERVER1_USERNAME }}"
+        NZBGET_SERVER1_PASSWORD: "{{ .NZBGET_SERVER1_PASSWORD }}"
+        # Server 2 credentials
+        NZBGET_SERVER2_HOST: "{{ .NZBGET_SERVER2_HOST | default \"news.newshosting.com\" }}"
+        NZBGET_SERVER2_PORT: "{{ .NZBGET_SERVER2_PORT | default \"563\" }}"
+        NZBGET_SERVER2_USERNAME: "{{ .NZBGET_SERVER2_USERNAME }}"
+        NZBGET_SERVER2_PASSWORD: "{{ .NZBGET_SERVER2_PASSWORD }}"
+        # Server 3 credentials
+        NZBGET_SERVER3_HOST: "{{ .NZBGET_SERVER3_HOST | default \"news.usenetexpress.com\" }}"
+        NZBGET_SERVER3_PORT: "{{ .NZBGET_SERVER3_PORT | default \"563\" }}"
+        NZBGET_SERVER3_USERNAME: "{{ .NZBGET_SERVER3_USERNAME }}"
+        NZBGET_SERVER3_PASSWORD: "{{ .NZBGET_SERVER3_PASSWORD }}"
+        # Server 4 credentials
+        NZBGET_SERVER4_HOST: "{{ .NZBGET_SERVER4_HOST | default \"us.newsdemon.com\" }}"
+        NZBGET_SERVER4_PORT: "{{ .NZBGET_SERVER4_PORT | default \"563\" }}"
+        NZBGET_SERVER4_USERNAME: "{{ .NZBGET_SERVER4_USERNAME }}"
+        NZBGET_SERVER4_PASSWORD: "{{ .NZBGET_SERVER4_PASSWORD }}"
+        # Server 5 credentials
+        NZBGET_SERVER5_HOST: "{{ .NZBGET_SERVER5_HOST | default \"newshosting.tweaknews.eu\" }}"
+        NZBGET_SERVER5_PORT: "{{ .NZBGET_SERVER5_PORT | default \"563\" }}"
+        NZBGET_SERVER5_USERNAME: "{{ .NZBGET_SERVER5_USERNAME }}"
+        NZBGET_SERVER5_PASSWORD: "{{ .NZBGET_SERVER5_PASSWORD }}"
+        # Server 6 credentials
+        NZBGET_SERVER6_HOST: "{{ .NZBGET_SERVER6_HOST | default \"news.bulknews.eu\" }}"
+        NZBGET_SERVER6_PORT: "{{ .NZBGET_SERVER6_PORT | default \"563\" }}"
+        NZBGET_SERVER6_USERNAME: "{{ .NZBGET_SERVER6_USERNAME }}"
+        NZBGET_SERVER6_PASSWORD: "{{ .NZBGET_SERVER6_PASSWORD }}"
+        # Server 7 credentials
+        NZBGET_SERVER7_HOST: "{{ .NZBGET_SERVER7_HOST | default \"news.newsgroupdirect.com\" }}"
+        NZBGET_SERVER7_PORT: "{{ .NZBGET_SERVER7_PORT | default \"563\" }}"
+        NZBGET_SERVER7_USERNAME: "{{ .NZBGET_SERVER7_USERNAME }}"
+        NZBGET_SERVER7_PASSWORD: "{{ .NZBGET_SERVER7_PASSWORD }}"
+        # Server 8 credentials
+        NZBGET_SERVER8_HOST: "{{ .NZBGET_SERVER8_HOST | default \"news.easynews.com\" }}"
+        NZBGET_SERVER8_PORT: "{{ .NZBGET_SERVER8_PORT | default \"563\" }}"
+        NZBGET_SERVER8_USERNAME: "{{ .NZBGET_SERVER8_USERNAME }}"
+        NZBGET_SERVER8_PASSWORD: "{{ .NZBGET_SERVER8_PASSWORD }}"
+  dataFrom:
+    - extract:
+        key: /nzbget

--- a/kubernetes/apps/media/nzbget/app/helmrelease.yaml
+++ b/kubernetes/apps/media/nzbget/app/helmrelease.yaml
@@ -32,11 +32,16 @@ spec:
               tag: 25.2.0@sha256:1eea992c839f16cb23e7635b407a576eec928db1f2989f3aca801289ba782f59
             env:
               TZ: ${TIME_ZONE}
+            envFrom:
+              - secretRef:
+                  name: nzbget-secret
             resources:
               requests:
-                cpu: 8000m
+                cpu: 500m
+                memory: 512Mi
               limits:
-                memory: 80Gi
+                cpu: 2000m
+                memory: 2Gi
     defaultPodOptions:
       securityContext:
         runAsNonRoot: true
@@ -92,3 +97,10 @@ spec:
         path: /mnt/Tank/Media
         globalMounts:
           - path: /safe
+      nzbget-config:
+        type: configMap
+        name: nzbget-config
+        globalMounts:
+          - path: /config/nzbget.conf
+            subPath: nzbget.conf
+            readOnly: true

--- a/kubernetes/apps/media/nzbget/app/kustomization.yaml
+++ b/kubernetes/apps/media/nzbget/app/kustomization.yaml
@@ -3,4 +3,13 @@
 apiVersion: kustomize.config.k8s.io/v1beta1
 kind: Kustomization
 resources:
+  - ./externalsecret.yaml
   - ./helmrelease.yaml
+configMapGenerator:
+  - name: nzbget-config
+    files:
+      - nzbget.conf=./config/nzbget.conf
+generatorOptions:
+  disableNameSuffixHash: true
+  annotations:
+    kustomize.toolkit.fluxcd.io/substitute: disabled


### PR DESCRIPTION
## Summary
- Implement ConfigMap-based configuration for NZBGet
- Add ExternalSecret integration for secure credential management
- Optimize resource allocation based on actual usage needs

## Changes
- Created `nzbget.conf` ConfigMap with full configuration
- Added ExternalSecret for 8 news server credentials
- Configured all media categories matching SABnzbd setup
- Reduced resource allocation from 8CPU/80GB to 2CPU/2GB
- Disabled web interface authentication (using proxy auth)
- Added ConfigMap mount at `/config/nzbget.conf`

## Configuration Notes
- News server credentials stored securely in Infisical at `/nzbget` path
- Configuration uses environment variable substitution for secrets
- Categories match existing SABnzbd setup for consistency
- Resource limits optimized for typical NZBGet workload

## Test Plan
- [ ] Deploy and verify NZBGet starts successfully
- [ ] Confirm ConfigMap mounts correctly
- [ ] Verify news servers connect with ExternalSecret credentials
- [ ] Test download functionality with each category
- [ ] Monitor resource usage under load