### PR TITLE
feat(ai/openclaw): add cluster read-only RBAC for Tim

### DIFF
--- a/kubernetes/apps/ai/openclaw/app/kustomization.yaml
+++ b/kubernetes/apps/ai/openclaw/app/kustomization.yaml
@@ -6,3 +6,4 @@ resources:
   - ./externalsecret.yaml
   - ./helmrelease.yaml
   - ./pvc.yaml
+  - ./rbac.yaml

--- a/kubernetes/apps/ai/openclaw/app/rbac.yaml
+++ b/kubernetes/apps/ai/openclaw/app/rbac.yaml
@@ -1,0 +1,93 @@
+---
+# Tim the Enchanter - Cluster Read-Only RBAC
+# Gives the default ServiceAccount in the 'ai' namespace
+# read-only access to monitor cluster health.
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRole
+metadata:
+  name: tim-cluster-reader
+  labels:
+    app.kubernetes.io/name: openclaw
+    app.kubernetes.io/component: tim
+rules:
+  # Cluster-level resources (read-only)
+  - apiGroups: [""]
+    resources:
+      - nodes
+      - namespaces
+      - persistentvolumes
+    verbs: ["get", "list", "watch"]
+  # Namespace-scoped resources (read-only)
+  - apiGroups: [""]
+    resources:
+      - pods
+      - pods/log
+      - services
+      - endpoints
+      - persistentvolumeclaims
+      - configmaps
+      - events
+    verbs: ["get", "list", "watch"]
+  # Apps (deployments, statefulsets, etc.)
+  - apiGroups: ["apps"]
+    resources:
+      - deployments
+      - statefulsets
+      - daemonsets
+      - replicasets
+    verbs: ["get", "list", "watch"]
+  # Batch (jobs, cronjobs)
+  - apiGroups: ["batch"]
+    resources:
+      - jobs
+      - cronjobs
+    verbs: ["get", "list", "watch"]
+  # Networking
+  - apiGroups: ["networking.k8s.io"]
+    resources:
+      - ingresses
+      - networkpolicies
+    verbs: ["get", "list", "watch"]
+  # Storage
+  - apiGroups: ["storage.k8s.io"]
+    resources:
+      - storageclasses
+    verbs: ["get", "list", "watch"]
+  # Flux GitOps
+  - apiGroups: ["source.toolkit.fluxcd.io"]
+    resources:
+      - gitrepositories
+      - helmrepositories
+      - helmcharts
+    verbs: ["get", "list", "watch"]
+  - apiGroups: ["kustomize.toolkit.fluxcd.io"]
+    resources:
+      - kustomizations
+    verbs: ["get", "list", "watch"]
+  - apiGroups: ["helm.toolkit.fluxcd.io"]
+    resources:
+      - helmreleases
+    verbs: ["get", "list", "watch"]
+  # Ceph/Rook storage
+  - apiGroups: ["ceph.rook.io"]
+    resources:
+      - cephclusters
+      - cephblockpools
+      - cephfilesystems
+    verbs: ["get", "list", "watch"]
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRoleBinding
+metadata:
+  name: tim-cluster-reader
+  labels:
+    app.kubernetes.io/name: openclaw
+    app.kubernetes.io/component: tim
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: ClusterRole
+  name: tim-cluster-reader
+subjects:
+  - kind: ServiceAccount
+    name: default
+    namespace: ai


### PR DESCRIPTION
## Summary

Adds ClusterRole and ClusterRoleBinding to give the default ServiceAccount in the `ai` namespace read-only access for Tim's HomeLab Sentinel morning job.

## What Tim Can See 👀
- Nodes, namespaces, PVs (cluster health)
- Pods, deployments, services (workload status)  
- Flux resources (GitOps sync status)
- Ceph resources (storage health)
- Events, logs (debugging)

## What Tim Cannot Do 🛡️
- ❌ Modify any resources
- ❌ Access secrets
- ❌ Delete anything
- ❌ Exec into pods

## Why
Enables the HomeLab Sentinel morning job to report on cluster health without any write access. Part of Tim's morning briefing pipeline.

---
*PR created by Tim the Enchanter 🔥*