### PR TITLE
feat(ai): add Munin agent - Tim's raven familiar

### DIFF
--- a/kubernetes/apps/ai/kustomization.yaml
+++ b/kubernetes/apps/ai/kustomization.yaml
@@ -7,6 +7,7 @@ components:
   - ../../flux/components/common
 resources:
   - ./archon/ks.yaml
+  - ./munin/ks.yaml
   - ./openclaw/ks.yaml
   # - ./open-webui/ks.yaml
   # - ./n8n/ks.yaml

--- a/kubernetes/apps/ai/munin/app/externalsecret.yaml
+++ b/kubernetes/apps/ai/munin/app/externalsecret.yaml
@@ -1,0 +1,20 @@
+---
+apiVersion: external-secrets.io/v1
+kind: ExternalSecret
+metadata:
+  name: munin
+spec:
+  secretStoreRef:
+    kind: ClusterSecretStore
+    name: infisical
+  target:
+    name: munin-secret
+    template:
+      engineVersion: v2
+      data:
+        # Gateway token for authentication
+        CLAWDBOT_GATEWAY_TOKEN: "{{ .MUNIN_GATEWAY_TOKEN }}"
+  dataFrom:
+    - find:
+        name:
+          regexp: ^MUNIN.*

--- a/kubernetes/apps/ai/munin/app/helmrelease.yaml
+++ b/kubernetes/apps/ai/munin/app/helmrelease.yaml
@@ -1,0 +1,148 @@
+---
+# yaml-language-server: $schema=https://raw.githubusercontent.com/bjw-s/helm-charts/main/charts/other/app-template/schemas/helmrelease-helm-v2.schema.json
+apiVersion: helm.toolkit.fluxcd.io/v2
+kind: HelmRelease
+metadata:
+  name: munin
+spec:
+  interval: 30m
+  chartRef:
+    kind: OCIRepository
+    name: app-template
+  install:
+    remediation:
+      retries: 3
+  upgrade:
+    cleanupOnFail: true
+    remediation:
+      strategy: rollback
+      retries: 3
+  uninstall:
+    keepHistory: false
+  values:
+    controllers:
+      munin:
+        annotations:
+          reloader.stakater.com/auto: "true"
+        initContainers:
+          install-tools:
+            image:
+              repository: ghcr.io/openclaw/openclaw
+              tag: main@sha256:0a4695c499e194971de9dae51b201f3108c988c75038d3f62a28c8f723f3f197
+            command:
+              - /bin/sh
+              - -c
+              - |
+                set -e
+                mkdir -p /home/node/.local/bin
+
+                # Install gh CLI if not present
+                if [ ! -f /home/node/.local/bin/gh ]; then
+                  echo "Installing gh CLI..."
+                  cd /tmp
+                  curl -fsSL https://github.com/cli/cli/releases/download/v2.61.0/gh_2.61.0_linux_amd64.tar.gz -o gh.tar.gz
+                  tar xzf gh.tar.gz
+                  cp gh_2.61.0_linux_amd64/bin/gh /home/node/.local/bin/
+                  rm -rf gh.tar.gz gh_2.61.0_linux_amd64
+                fi
+
+                echo "Tool installation complete"
+            env:
+              HOME: /home/node
+        containers:
+          app:
+            image:
+              repository: ghcr.io/openclaw/openclaw
+              tag: main@sha256:0a4695c499e194971de9dae51b201f3108c988c75038d3f62a28c8f723f3f197
+            command:
+              - /bin/sh
+              - -c
+              - |
+                ln -sf /app/openclaw.mjs /home/node/.local/bin/openclaw
+                exec node dist/index.js gateway --bind lan --port 18789 --allow-unconfigured
+            resources:
+              requests:
+                cpu: 250m
+                memory: 256Mi
+              limits:
+                cpu: 1000m
+                memory: 1Gi
+            env:
+              TZ: ${TIME_ZONE}
+              HOME: /home/node
+              TERM: xterm-256color
+              PATH: /home/node/.local/bin:/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin
+              PIP_BREAK_SYSTEM_PACKAGES: "1"
+              BROWSER_WS_ENDPOINT: "ws://localhost:9222"
+            envFrom:
+              - secretRef:
+                  name: munin-secret
+          chrome:
+            image:
+              repository: zenika/alpine-chrome
+              tag: with-node
+            command:
+              - chromium-browser
+              - --headless=new
+              - --disable-gpu
+              - --remote-debugging-address=0.0.0.0
+              - --remote-debugging-port=9222
+              - --no-sandbox
+              - --disable-dev-shm-usage
+            env:
+              TZ: ${TIME_ZONE}
+            resources:
+              requests:
+                cpu: 50m
+                memory: 128Mi
+              limits:
+                cpu: 500m
+                memory: 512Mi
+    defaultPodOptions:
+      shareProcessNamespace: true
+      securityContext:
+        runAsUser: 1000
+        runAsGroup: 1000
+        fsGroup: 1000
+        fsGroupChangePolicy: OnRootMismatch
+    service:
+      app:
+        controller: munin
+        ports:
+          http:
+            port: 18789
+    ingress:
+      app:
+        annotations:
+          external-dns.alpha.kubernetes.io/target: "internal.${SECRET_DOMAIN}"
+        className: internal
+        hosts:
+          - host: &host "munin.${SECRET_DOMAIN}"
+            paths:
+              - path: /
+                service:
+                  identifier: app
+                  port: http
+        tls:
+          - hosts:
+              - *host
+            secretName: ${SECRET_DOMAIN/./-}-tls
+    persistence:
+      config:
+        enabled: true
+        existingClaim: munin
+        advancedMounts:
+          munin:
+            install-tools:
+              - path: /home/node
+            app:
+              - path: /home/node
+      # Read-only access to Tim's vault
+      vault:
+        enabled: true
+        existingClaim: molt-vault
+        advancedMounts:
+          munin:
+            app:
+              - path: /home/node/obsidian-vault
+                readOnly: true

--- a/kubernetes/apps/ai/munin/app/kustomization.yaml
+++ b/kubernetes/apps/ai/munin/app/kustomization.yaml
@@ -1,0 +1,7 @@
+---
+# yaml-language-server: $schema=https://json.schemastore.org/kustomization
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+resources:
+  - ./externalsecret.yaml
+  - ./helmrelease.yaml

--- a/kubernetes/apps/ai/munin/ks.yaml
+++ b/kubernetes/apps/ai/munin/ks.yaml
@@ -1,0 +1,39 @@
+---
+# yaml-language-server: $schema=https://kubernetes-schemas.pages.dev/kustomize.toolkit.fluxcd.io/kustomization_v1.json
+apiVersion: kustomize.toolkit.fluxcd.io/v1
+kind: Kustomization
+metadata:
+  name: &app munin
+  namespace: &namespace ai
+spec:
+  targetNamespace: *namespace
+  commonMetadata:
+    labels:
+      app.kubernetes.io/name: *app
+  components:
+    - ../../../../flux/components/gatus/guarded
+    - ../../../../flux/components/volsync/repository
+    - ../../../../flux/components/volsync/operations
+  dependsOn:
+    - name: volsync
+      namespace: storage
+    - name: external-secrets-stores
+      namespace: external-secrets
+    - name: openclaw
+      namespace: ai
+  path: ./kubernetes/apps/ai/munin/app
+  prune: true
+  sourceRef:
+    kind: GitRepository
+    name: flux-system
+    namespace: flux-system
+  wait: true
+  interval: 30m
+  retryInterval: 1m
+  timeout: 10m
+  postBuild:
+    substitute:
+      APP: munin
+      GATUS_SUBDOMAIN: munin
+      GATUS_DOMAIN: ${SECRET_DOMAIN}
+      VOLSYNC_CAPACITY: 5Gi


### PR DESCRIPTION
## Summary

Adds **Munin**, a scout/apprentice agent for Tim the Enchanter.

### What is Munin?

Named after Odin's memory raven, Munin is a lightweight OpenClaw agent that:
- 🔍 Handles research and data gathering
- 📡 Monitors feeds and reports back to Tim
- 🪶 Executes grunt work so Tim can focus on wizardry

### What's included

- OpenClaw gateway with headless Chrome sidecar
- Read-only access to Tim's vault (`molt-vault`)
- Lighter resource footprint than molt (no syncthing, no ssh)
- Depends on `openclaw` (Tim) being deployed first
- VolSync for persistent storage

### Before deploying

Create these secrets in Infisical under the `ai` namespace:
- `MUNIN_GATEWAY_TOKEN` - Gateway authentication token
- Any other `MUNIN_*` secrets needed for API access

### Architecture

```
Tim (molt) ──────────────────────────────────────────┐
    │                                                │
    │ sessions_send(label="munin", ...)              │
    ▼                                                │
Munin ◄──────────────────────────────────────────────┤
    │                                                │
    ├── Read-only vault access                       │
    └── Reports findings back to Tim                 │
```

*Caw.* 🪶