### PR TITLE
feat(ai): add RBAC for molt to manage munin

### DIFF
--- a/kubernetes/apps/ai/munin/app/kustomization.yaml
+++ b/kubernetes/apps/ai/munin/app/kustomization.yaml
@@ -5,3 +5,4 @@ kind: Kustomization
 resources:
   - ./externalsecret.yaml
   - ./helmrelease.yaml
+  - ./rbac.yaml

--- a/kubernetes/apps/ai/munin/app/rbac.yaml
+++ b/kubernetes/apps/ai/munin/app/rbac.yaml
@@ -1,0 +1,34 @@
+---
+# Allow molt (Tim) to manage munin (apprentice)
+# Enables exec, logs, and pod inspection
+apiVersion: rbac.authorization.k8s.io/v1
+kind: Role
+metadata:
+  name: molt-munin-access
+rules:
+  # Exec into pods (run commands in munin)
+  - apiGroups: [""]
+    resources: ["pods/exec"]
+    verbs: ["create"]
+  # Get/list pods (find munin)
+  - apiGroups: [""]
+    resources: ["pods"]
+    verbs: ["get", "list"]
+  # View logs
+  - apiGroups: [""]
+    resources: ["pods/log"]
+    verbs: ["get"]
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: RoleBinding
+metadata:
+  name: molt-munin-access
+subjects:
+  # molt's service account (default in ai namespace)
+  - kind: ServiceAccount
+    name: default
+    namespace: ai
+roleRef:
+  kind: Role
+  name: molt-munin-access
+  apiGroup: rbac.authorization.k8s.io


### PR DESCRIPTION
## Summary

Adds RBAC permissions so Tim (molt) can manage his apprentice Munin.

### Permissions granted

| Resource | Verbs | Purpose |
|----------|-------|---------|
| `pods/exec` | create | Run commands inside Munin's container |
| `pods` | get, list | Find Munin's pod |
| `pods/log` | get | View Munin's logs |

### Why

Tim needs to:
- Configure Munin's workspace and settings
- Debug issues when Munin misbehaves
- Update files and restart processes
- Monitor Munin's health

This is the master-familiar relationship — a wizard should be able to manage his raven. 🔥🪶