### PR TITLE
feat(ai): add outlook-bridge service

### DIFF
--- a/kubernetes/apps/ai/kustomization.yaml
+++ b/kubernetes/apps/ai/kustomization.yaml
@@ -15,3 +15,4 @@ resources:
   # - ./litellm/ks.yaml
   - ./speaches/ks.yaml
   - ./wyoming-whisper/ks.yaml
+  - ./outlook-bridge/ks.yaml

--- a/kubernetes/apps/ai/outlook-bridge/app/externalsecret.yaml
+++ b/kubernetes/apps/ai/outlook-bridge/app/externalsecret.yaml
@@ -1,0 +1,21 @@
+---
+apiVersion: external-secrets.io/v1
+kind: ExternalSecret
+metadata:
+  name: outlook-bridge
+spec:
+  secretStoreRef:
+    kind: ClusterSecretStore
+    name: infisical
+  target:
+    name: outlook-bridge-secret
+    template:
+      engineVersion: v2
+      data:
+        AZURE_CLIENT_ID: "{{ .OUTLOOK_BRIDGE_CLIENT_ID }}"
+        AZURE_CLIENT_SECRET: "{{ .OUTLOOK_BRIDGE_CLIENT_SECRET }}"
+        INTERNAL_TOKEN: "{{ .OUTLOOK_BRIDGE_INTERNAL_TOKEN }}"
+  dataFrom:
+    - find:
+        name:
+          regexp: ^OUTLOOK_BRIDGE.*

--- a/kubernetes/apps/ai/outlook-bridge/app/helmrelease.yaml
+++ b/kubernetes/apps/ai/outlook-bridge/app/helmrelease.yaml
@@ -1,0 +1,109 @@
+---
+# yaml-language-server: $schema=https://raw.githubusercontent.com/bjw-s/helm-charts/main/charts/other/app-template/schemas/helmrelease-helm-v2.schema.json
+apiVersion: helm.toolkit.fluxcd.io/v2
+kind: HelmRelease
+metadata:
+  name: outlook-bridge
+spec:
+  interval: 30m
+  chartRef:
+    kind: OCIRepository
+    name: app-template
+  install:
+    remediation:
+      retries: 3
+  upgrade:
+    cleanupOnFail: true
+    remediation:
+      strategy: rollback
+      retries: 3
+  uninstall:
+    keepHistory: false
+  values:
+    controllers:
+      outlook-bridge:
+        annotations:
+          reloader.stakater.com/auto: "true"
+        containers:
+          app:
+            image:
+              repository: ghcr.io/dapperdivers/outlook-bridge
+              tag: latest
+            env:
+              TZ: America/Chicago
+              TOKEN_CACHE_PATH: /data/token_cache.json
+              REDIRECT_URI: https://outlook-bridge.${SECRET_DOMAIN}/auth/callback
+            envFrom:
+              - secretRef:
+                  name: outlook-bridge-secret
+            probes:
+              liveness:
+                enabled: true
+                custom: true
+                spec:
+                  httpGet:
+                    path: /health
+                    port: 8080
+                  initialDelaySeconds: 10
+                  periodSeconds: 30
+                  timeoutSeconds: 10
+                  failureThreshold: 3
+              readiness:
+                enabled: true
+                custom: true
+                spec:
+                  httpGet:
+                    path: /health
+                    port: 8080
+                  initialDelaySeconds: 5
+                  periodSeconds: 10
+            resources:
+              requests:
+                cpu: 10m
+                memory: 128Mi
+              limits:
+                memory: 256Mi
+            securityContext:
+              allowPrivilegeEscalation: false
+              readOnlyRootFilesystem: true
+              capabilities:
+                drop:
+                  - ALL
+
+    defaultPodOptions:
+      securityContext:
+        runAsNonRoot: true
+        runAsUser: 1000
+        runAsGroup: 1000
+        fsGroup: 1000
+        fsGroupChangePolicy: OnRootMismatch
+
+    service:
+      app:
+        controller: outlook-bridge
+        ports:
+          http:
+            port: 8080
+
+    ingress:
+      app:
+        className: internal
+        annotations:
+          external-dns.alpha.kubernetes.io/target: internal.${SECRET_DOMAIN}
+        hosts:
+          - host: outlook-bridge.${SECRET_DOMAIN}
+            paths:
+              - path: /
+                service:
+                  identifier: app
+                  port: http
+
+    persistence:
+      data:
+        existingClaim: outlook-bridge-data
+        globalMounts:
+          - path: /data
+      tmp:
+        type: emptyDir
+        globalMounts:
+          - path: /tmp

--- a/kubernetes/apps/ai/outlook-bridge/app/kustomization.yaml
+++ b/kubernetes/apps/ai/outlook-bridge/app/kustomization.yaml
@@ -1,0 +1,8 @@
+---
+# yaml-language-server: $schema=https://json.schemastore.org/kustomization
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+resources:
+  - ./externalsecret.yaml
+  - ./helmrelease.yaml
+  - ./pvc.yaml

--- a/kubernetes/apps/ai/outlook-bridge/app/pvc.yaml
+++ b/kubernetes/apps/ai/outlook-bridge/app/pvc.yaml
@@ -1,0 +1,12 @@
+---
+apiVersion: v1
+kind: PersistentVolumeClaim
+metadata:
+  name: outlook-bridge-data
+spec:
+  accessModes:
+    - ReadWriteOnce
+  storageClassName: ceph-block
+  resources:
+    requests:
+      storage: 1Gi

--- a/kubernetes/apps/ai/outlook-bridge/ks.yaml
+++ b/kubernetes/apps/ai/outlook-bridge/ks.yaml
@@ -1,0 +1,25 @@
+---
+# yaml-language-server: $schema=https://kubernetes-schemas.pages.dev/kustomize.toolkit.fluxcd.io/kustomization_v1.json
+apiVersion: kustomize.toolkit.fluxcd.io/v1
+kind: Kustomization
+metadata:
+  name: &app outlook-bridge
+  namespace: &namespace ai
+spec:
+  targetNamespace: *namespace
+  commonMetadata:
+    labels:
+      app.kubernetes.io/name: *app
+  dependsOn:
+    - name: external-secrets-stores
+      namespace: external-secrets
+  path: ./kubernetes/apps/ai/outlook-bridge/app
+  prune: true
+  sourceRef:
+    kind: GitRepository
+    name: flux-system
+    namespace: flux-system
+  wait: true
+  interval: 30m
+  retryInterval: 1m
+  timeout: 10m


### PR DESCRIPTION
## Outlook Bridge

Microsoft Graph API bridge for Outlook.com email access.

### Features
- OAuth2 authentication with 90-day rolling refresh tokens
- Read/search/move/delete emails
- Send emails  
- Full inbox rules management (CRUD)
- Internal API with bearer token auth

### Components
- HelmRelease using bjw-s/app-template
- ExternalSecret pulling from Infisical
- 1Gi PVC for token cache

🔥 Tim the Enchanter