### PR TITLE
feat(molt): Add Chrome stealth flags for bot detection bypass

### DIFF
--- a/kubernetes/apps/ai/openclaw/app/helmrelease.yaml
+++ b/kubernetes/apps/ai/openclaw/app/helmrelease.yaml
@@ -134,6 +134,9 @@ spec:
               - --remote-debugging-port=9222
               - --no-sandbox
               - --disable-dev-shm-usage
+              # Stealth flags to reduce bot detection
+              - --disable-blink-features=AutomationControlled
+              - --user-agent=Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/124.0.0.0 Safari/537.36
             env:
               TZ: ${TIME_ZONE}
             resources:


### PR DESCRIPTION
## Summary
Adds browser automation stealth flags to the Chrome sidecar container to reduce bot detection on real estate sites.

## Changes
- `--disable-blink-features=AutomationControlled`: Removes the `navigator.webdriver=true` flag that sites check
- Custom User-Agent: Replaces 'HeadlessChrome' with a normal Chrome UA string

## Why
The house hunting automation has been failing because sites like Zillow, Redfin, and Realtor.com detect the headless Chrome browser and block access. These flags should help bypass basic bot detection.

## Testing
After merge and deployment:
1. Flux will reconcile the HelmRelease
2. Pod will restart with new Chrome flags
3. Test with: `browser action=open url=https://www.zillow.com/johns-creek-ga/`

## Notes
This won't make the browser 100% undetectable (determined sites can still fingerprint), but it should pass the basic checks that were blocking us.

---
*PR created by Tim 🔥*