### PR TITLE
fix(wazuh): add fsGroup to indexer for PVC permissions

### DIFF
--- a/kubernetes/apps/security/wazuh/app/wazuh-indexer.yaml
+++ b/kubernetes/apps/security/wazuh/app/wazuh-indexer.yaml
@@ -32,6 +32,9 @@ spec:
       labels:
         app: wazuh-indexer
     spec:
+      # fsGroup ensures PVC is mounted with correct group ownership for wazuh-indexer (UID 1000)
+      securityContext:
+        fsGroup: 1000
       # Init container to set up certificate files with correct names
       initContainers:
         - name: setup-certs


### PR DESCRIPTION
## Summary
The wazuh-indexer container runs as UID 1000 but the PVC was being mounted with root ownership, causing:
```
AccessDeniedException[/var/lib/wazuh-indexer/nodes]
```

## Changes
- Add `fsGroup: 1000` to the indexer StatefulSet pod securityContext

## Root Cause
After upgrading to Wazuh 4.14.2, the indexer process (running as UID 1000) could not create its data directory on the PVC because the volume was mounted with root ownership.

## Testing
- Manually applied via `kubectl patch` - indexer started successfully
- Agent (opnsense) registered and connected

## Related
- Wazuh 4.14.2 upgrade PRs merged earlier today