### PR TITLE
fix(wazuh): correct cert mount path for indexer

### DIFF
--- a/kubernetes/apps/security/wazuh/app/wazuh-indexer.yaml
+++ b/kubernetes/apps/security/wazuh/app/wazuh-indexer.yaml
@@ -94,7 +94,7 @@ spec:
               mountPath: /usr/share/wazuh-indexer/opensearch.yml
               subPath: opensearch.yml
             - name: certs
-              mountPath: /usr/share/wazuh-indexer/certs
+              mountPath: /usr/share/wazuh-indexer/config/certs
               readOnly: true
       volumes:
         - name: config


### PR DESCRIPTION
## Problem
Wazuh indexer was serving demo certs (`CN=demo.indexer`) instead of cert-manager certs.

## Root Cause
Certs were mounted to: `/usr/share/wazuh-indexer/certs/`
But opensearch.yml expects: `/usr/share/wazuh-indexer/config/certs/`

## Fix
Update mount path to match what the config expects.

## Verified
Derek confirmed:
- Mounted cert has correct CN (`wazuh-indexer`)
- Served cert has wrong CN (`demo.indexer`)
- Config path shows `config/certs/` not `certs/`