### PR TITLE
fix(wazuh): correct opensearch.yml config mount path

### DIFF
--- a/kubernetes/apps/security/wazuh/app/wazuh-indexer.yaml
+++ b/kubernetes/apps/security/wazuh/app/wazuh-indexer.yaml
@@ -91,7 +91,7 @@ spec:
             - name: data
               mountPath: /var/lib/wazuh-indexer
             - name: config
-              mountPath: /usr/share/wazuh-indexer/opensearch.yml
+              mountPath: /usr/share/wazuh-indexer/config/opensearch.yml
               subPath: opensearch.yml
             - name: certs
               mountPath: /usr/share/wazuh-indexer/config/certs

--- a/kubernetes/apps/security/wazuh/app/wazuh-repo.yaml
+++ b/kubernetes/apps/security/wazuh/app/wazuh-repo.yaml
@@ -15,15 +15,15 @@ data:
 
     # HTTP layer TLS (API access)
     plugins.security.ssl.http.enabled: true
-    plugins.security.ssl.http.pemcert_filepath: /usr/share/wazuh-indexer/certs/indexer.pem
-    plugins.security.ssl.http.pemkey_filepath: /usr/share/wazuh-indexer/certs/indexer-key.pem
-    plugins.security.ssl.http.pemtrustedcas_filepath: /usr/share/wazuh-indexer/certs/root-ca.pem
+    plugins.security.ssl.http.pemcert_filepath: /usr/share/wazuh-indexer/config/certs/indexer.pem
+    plugins.security.ssl.http.pemkey_filepath: /usr/share/wazuh-indexer/config/certs/indexer-key.pem
+    plugins.security.ssl.http.pemtrustedcas_filepath: /usr/share/wazuh-indexer/config/certs/root-ca.pem
 
     # Transport layer TLS (cluster communication)
     plugins.security.ssl.transport.enabled: true
-    plugins.security.ssl.transport.pemcert_filepath: /usr/share/wazuh-indexer/certs/indexer.pem
-    plugins.security.ssl.transport.pemkey_filepath: /usr/share/wazuh-indexer/certs/indexer-key.pem
-    plugins.security.ssl.transport.pemtrustedcas_filepath: /usr/share/wazuh-indexer/certs/root-ca.pem
+    plugins.security.ssl.transport.pemcert_filepath: /usr/share/wazuh-indexer/config/certs/indexer.pem
+    plugins.security.ssl.transport.pemkey_filepath: /usr/share/wazuh-indexer/config/certs/indexer-key.pem
+    plugins.security.ssl.transport.pemtrustedcas_filepath: /usr/share/wazuh-indexer/config/certs/root-ca.pem
     plugins.security.ssl.transport.enforce_hostname_verification: false
 
     # Security configuration


### PR DESCRIPTION
## Root Cause
Config was mounted to wrong path:
- **Was:** `/usr/share/wazuh-indexer/opensearch.yml`
- **Should be:** `/usr/share/wazuh-indexer/config/opensearch.yml`

Container ignored our ConfigMap and used bundled defaults (which expected certs at `config/certs/`).

## Changes
1. Fix config mount path to `/usr/share/wazuh-indexer/config/opensearch.yml`
2. Update cert paths in opensearch.yml to `/usr/share/wazuh-indexer/config/certs/`

## Result
- Our ConfigMap will be used
- Cert paths will match mount locations  
- TLS should work with cert-manager certs