### PR TITLE
fix(wazuh): use admin credentials for dashboard API connection

### DIFF
--- a/kubernetes/apps/security/wazuh/app/wazuh-repo.yaml
+++ b/kubernetes/apps/security/wazuh/app/wazuh-repo.yaml
@@ -68,8 +68,8 @@ data:
       - default:
           url: https://wazuh-manager
           port: 55000
-          username: wazuh-wui
-          password: wazuh-wui
+          username: admin
+          password: admin
           run_as: false
 
   # Manager ossec.conf - Core configuration


### PR DESCRIPTION
The wazuh-wui user doesn't exist in the default Wazuh setup. Using admin/admin which is the default API user.