### PR TITLE
fix(wazuh): enable sysctl init for vm.max_map_count

### DIFF
--- a/kubernetes/apps/security/wazuh/app/helmrelease.yaml
+++ b/kubernetes/apps/security/wazuh/app/helmrelease.yaml
@@ -51,6 +51,9 @@ spec:
           memory: 2Gi
       cred:
         existingSecret: wazuh-passwords
+      # Enable sysctl init container to set vm.max_map_count
+      sysctlImage:
+        enabled: true
 
     # Dashboard configuration
     dashboard:


### PR DESCRIPTION
OpenSearch requires vm.max_map_count >= 262144. Enable the chart's sysctl init container.