### PR TITLE
fix(wazuh): set vm.max_map_count in Talos config

### DIFF
--- a/kubernetes/apps/security/wazuh/app/helmrelease.yaml
+++ b/kubernetes/apps/security/wazuh/app/helmrelease.yaml
@@ -51,9 +51,9 @@ spec:
           memory: 2Gi
       cred:
         existingSecret: wazuh-passwords
-      # Enable sysctl init container to set vm.max_map_count
+      # Sysctl set at Talos node level (machine-sysctls.yaml)
       sysctlImage:
-        enabled: true
+        enabled: false
 
     # Dashboard configuration
     dashboard:

--- a/kubernetes/bootstrap/talos/patches/global/machine-sysctls.yaml
+++ b/kubernetes/bootstrap/talos/patches/global/machine-sysctls.yaml
@@ -19,3 +19,4 @@ machine:
     net.ipv4.tcp_keepalive_probes: "6"
     # VM tuning
     vm.swappiness: "10"
+    vm.max_map_count: "262144"  # OpenSearch/Elasticsearch requirement


### PR DESCRIPTION
Add vm.max_map_count=262144 to Talos machine config instead of using privileged init container.

**After merging:** Apply the Talos config to nodes:
```bash
task talos:apply
```