### PR TITLE
fix(wazuh): add manual init job

### DIFF
--- a/kubernetes/apps/security/wazuh/app/init-job.yaml
+++ b/kubernetes/apps/security/wazuh/app/init-job.yaml
@@ -1,0 +1,63 @@
+---
+# Manual init job for OpenSearch security initialization
+# Apply once after initial deployment: kubectl apply -f <this-file>
+# Can be deleted after successful completion
+apiVersion: batch/v1
+kind: Job
+metadata:
+  name: wazuh-indexer-init
+  namespace: security
+  labels:
+    app.kubernetes.io/name: wazuh
+    app.kubernetes.io/component: indexer-init
+spec:
+  backoffLimit: 6
+  ttlSecondsAfterFinished: 300
+  template:
+    spec:
+      restartPolicy: OnFailure
+      containers:
+        - name: securityadmin
+          image: wazuh/wazuh-indexer:4.14.1
+          command: ["sh"]
+          args:
+            - /usr/share/wazuh-indexer/plugins/opensearch-security/tools/securityadmin.sh
+            - -cd
+            - /usr/share/wazuh-indexer/config/opensearch-security/
+            - -nhnv
+            - -cacert
+            - /usr/share/wazuh-indexer/config/certs/root-ca.pem
+            - -cert
+            - /usr/share/wazuh-indexer/config/certs/admin.pem
+            - -key
+            - /usr/share/wazuh-indexer/config/certs/admin-key.pem
+            - -p
+            - "9200"
+            - -icl
+            - -h
+            - wazuh-indexer
+          env:
+            - name: JAVA_HOME
+              value: /usr/share/wazuh-indexer/jdk/
+          volumeMounts:
+            - mountPath: /usr/share/wazuh-indexer/config/certs/root-ca.pem
+              name: node-certs
+              subPath: ca.crt
+            - mountPath: /usr/share/wazuh-indexer/config/certs/admin.pem
+              name: admin-certs
+              subPath: tls.crt
+            - mountPath: /usr/share/wazuh-indexer/config/certs/admin-key.pem
+              name: admin-certs
+              subPath: tls.key
+            - name: indexer-conf
+              mountPath: /usr/share/wazuh-indexer/config/opensearch-security/
+      volumes:
+        - name: admin-certs
+          secret:
+            secretName: admin-tls
+        - name: node-certs
+          secret:
+            secretName: node-tls
+        - name: indexer-conf
+          configMap:
+            name: wazuh-indexer-config


### PR DESCRIPTION
Adds a manual init job for OpenSearch security initialization since the Helm hook times out.