### PR TITLE
feat(ai): Update OpenClaw to 2026.2.3 for Opus 4.6 support

### DIFF
--- a/kubernetes/apps/ai/munin/app/helmrelease.yaml
+++ b/kubernetes/apps/ai/munin/app/helmrelease.yaml
@@ -28,7 +28,7 @@ spec:
           install-tools:
             image:
               repository: ghcr.io/openclaw/openclaw
-              tag: 2026.2.1@sha256:51192e206fb7a3d5e7d26ddd18bbf934a85d13b4661371224d8788fc8f8fda05
+              tag: 2026.2.3@sha256:acc3631077173c8050278a44896947b6052dd5c8ebace4ee1a452a276bd28bab
             command:
               - /bin/sh
               - -c
@@ -96,7 +96,7 @@ spec:
           app:
             image:
               repository: ghcr.io/openclaw/openclaw
-              tag: 2026.2.1@sha256:51192e206fb7a3d5e7d26ddd18bbf934a85d13b4661371224d8788fc8f8fda05
+              tag: 2026.2.3@sha256:acc3631077173c8050278a44896947b6052dd5c8ebace4ee1a452a276bd28bab
             command:
               - /bin/sh
               - -c

--- a/kubernetes/apps/ai/openclaw/app/helmrelease.yaml
+++ b/kubernetes/apps/ai/openclaw/app/helmrelease.yaml
@@ -28,7 +28,7 @@ spec:
           install-tools:
             image:
               repository: ghcr.io/openclaw/openclaw
-              tag: 2026.2.1@sha256:51192e206fb7a3d5e7d26ddd18bbf934a85d13b4661371224d8788fc8f8fda05
+              tag: 2026.2.3@sha256:acc3631077173c8050278a44896947b6052dd5c8ebace4ee1a452a276bd28bab
             command:
               - /bin/sh
               - -c
@@ -100,7 +100,7 @@ spec:
           app:
             image:
               repository: ghcr.io/openclaw/openclaw
-              tag: 2026.2.1@sha256:51192e206fb7a3d5e7d26ddd18bbf934a85d13b4661371224d8788fc8f8fda05
+              tag: 2026.2.3@sha256:acc3631077173c8050278a44896947b6052dd5c8ebace4ee1a452a276bd28bab
             command:
               - /bin/sh
               - -c


### PR DESCRIPTION
## Summary
Updates both Tim (molt) and Munin to OpenClaw 2026.2.3 which includes support for Claude Opus 4.6.

## Changes
| Component | Old | New |
|-----------|-----|-----|
| molt (Tim) | `2026.2.1@sha256:51192e20...` | `2026.2.3@sha256:acc3631077173c8050278a44896947b6052dd5c8ebace4ee1a452a276bd28bab` |
| munin | `2026.2.1@sha256:51192e20...` | `2026.2.3@sha256:acc3631077173c8050278a44896947b6052dd5c8ebace4ee1a452a276bd28bab` |

## Opus 4.6 Features
- **1 million token context** (up from 200K)
- **128K token output** (up from 8K)
- Enhanced planning and self-correction
- Native agent teams support
- Better sustained agentic task performance

## Post-Merge Steps
1. Wait for Flux reconciliation
2. Pods will restart with new image
3. Configure Opus 4.6 as default model (optional)

## References
- [Anthropic Opus 4.6 Announcement](https://www.anthropic.com/news/claude-opus-4-6)
- [OpenClaw GitHub PR #9853](https://github.com/openclaw/openclaw/pull/9853)