### PR TITLE
feat(ai): Update OpenClaw to latest with Opus 4.6 support

### DIFF
--- a/kubernetes/apps/ai/munin/app/helmrelease.yaml
+++ b/kubernetes/apps/ai/munin/app/helmrelease.yaml
@@ -28,7 +28,7 @@ spec:
           install-tools:
             image:
               repository: ghcr.io/openclaw/openclaw
-              tag: 2026.2.3@sha256:acc3631077173c8050278a44896947b6052dd5c8ebace4ee1a452a276bd28bab
+              tag: latest@sha256:0d7a2cf20aa7d402449c3f72f677c83e8a3cf43bbb507318a7c61195b273b291
             command:
               - /bin/sh
               - -c
@@ -96,7 +96,7 @@ spec:
           app:
             image:
               repository: ghcr.io/openclaw/openclaw
-              tag: 2026.2.3@sha256:acc3631077173c8050278a44896947b6052dd5c8ebace4ee1a452a276bd28bab
+              tag: latest@sha256:0d7a2cf20aa7d402449c3f72f677c83e8a3cf43bbb507318a7c61195b273b291
             command:
               - /bin/sh
               - -c

--- a/kubernetes/apps/ai/openclaw/app/helmrelease.yaml
+++ b/kubernetes/apps/ai/openclaw/app/helmrelease.yaml
@@ -28,7 +28,7 @@ spec:
           install-tools:
             image:
               repository: ghcr.io/openclaw/openclaw
-              tag: 2026.2.3@sha256:acc3631077173c8050278a44896947b6052dd5c8ebace4ee1a452a276bd28bab
+              tag: latest@sha256:0d7a2cf20aa7d402449c3f72f677c83e8a3cf43bbb507318a7c61195b273b291
             command:
               - /bin/sh
               - -c
@@ -100,7 +100,7 @@ spec:
           app:
             image:
               repository: ghcr.io/openclaw/openclaw
-              tag: 2026.2.3@sha256:acc3631077173c8050278a44896947b6052dd5c8ebace4ee1a452a276bd28bab
+              tag: latest@sha256:0d7a2cf20aa7d402449c3f72f677c83e8a3cf43bbb507318a7c61195b273b291
             command:
               - /bin/sh
               - -c


### PR DESCRIPTION
## Summary
Updates molt (Tim) and munin to latest OpenClaw build that includes Claude Opus 4.6 in the model catalog.

## Changes
- `ghcr.io/openclaw/openclaw:latest@sha256:0d7a2cf20aa7d402449c3f72f677c83e8a3cf43bbb507318a7c61195b273b291`

## Why
OpenClaw commit [eb80b9a](https://github.com/openclaw/openclaw/commit/eb80b9a) added Opus 4.6 to the built-in model catalog:
```
feat: add Claude Opus 4.6 to built-in model catalog (#9853)
```

Anthropic announced Opus 4.6 on Feb 5, 2026 with:
- 1M token context window (beta)
- Improved agentic coding & planning
- Better debugging and code review
- State-of-the-art on Terminal-Bench 2.0, Humanity's Last Exam, BrowseComp

## Testing
- [ ] Pods restart successfully
- [ ] `openclaw models list --all | grep opus-4-6` shows the model
- [ ] Can switch to `anthropic/claude-opus-4-6` without errors

---
*PR created by Tim the Enchanter 🔥*