### PR TITLE
feat(molt): add voice recordings PVC for Second Brain ingestion

### DIFF
--- a/kubernetes/apps/ai/openclaw/app/helmrelease.yaml
+++ b/kubernetes/apps/ai/openclaw/app/helmrelease.yaml
@@ -269,3 +269,13 @@ spec:
           syncthing:
             app:
               - path: /config
+      voice-recordings:
+        enabled: true
+        existingClaim: molt-voice-recordings
+        advancedMounts:
+          molt:
+            app:
+              - path: /home/node/voice-recordings
+          syncthing:
+            app:
+              - path: /data/voice_recordings

--- a/kubernetes/apps/ai/openclaw/app/pvc.yaml
+++ b/kubernetes/apps/ai/openclaw/app/pvc.yaml
@@ -20,3 +20,14 @@ spec:
     requests:
       storage: 1Gi
   storageClassName: ceph-rbd
+---
+apiVersion: v1
+kind: PersistentVolumeClaim
+metadata:
+  name: molt-voice-recordings
+spec:
+  accessModes: ["ReadWriteMany"]
+  resources:
+    requests:
+      storage: 5Gi
+  storageClassName: cephfs-shared


### PR DESCRIPTION
## What
Adds a shared CephFS PVC for voice recordings, mounted to both Syncthing and Tim's workspace.

## Why
Part of the Voice Ingestion Pipeline — Derek records voice memos on his phone, Syncthing syncs them to `/data/voice_recordings`, Tim picks them up from `/home/node/voice-recordings` for STT processing and vault routing.

## Changes
- **New PVC:** `molt-voice-recordings` (5Gi, CephFS shared, ReadWriteMany)
- **Syncthing mount:** `/data/voice_recordings` — available as a folder to sync with phone
- **Tim mount:** `/home/node/voice-recordings` — ingestion pipeline reads from here

## After Merge
1. Flux deploys the PVC and restarts the pod
2. In Syncthing UI, add `/data/voice_recordings` as a new shared folder
3. Connect it to Derek's phone Syncthing
4. Voice pipeline is ready for files