### PR TITLE
feat(molt): expose Syncthing UI via internal ingress

### DIFF
--- a/kubernetes/apps/ai/openclaw/app/helmrelease.yaml
+++ b/kubernetes/apps/ai/openclaw/app/helmrelease.yaml
@@ -242,6 +242,21 @@ spec:
           - hosts:
               - *host
             secretName: ${SECRET_DOMAIN/./-}-tls
+      syncthing:
+        annotations:
+          external-dns.alpha.kubernetes.io/target: "internal.${SECRET_DOMAIN}"
+        className: internal
+        hosts:
+          - host: &synchost "molt-syncthing.${SECRET_DOMAIN}"
+            paths:
+              - path: /
+                service:
+                  identifier: syncthing
+                  port: http
+        tls:
+          - hosts:
+              - *synchost
+            secretName: ${SECRET_DOMAIN/./-}-tls
     persistence:
       config:
         enabled: true


### PR DESCRIPTION
Adds an internal-only ingress for the Syncthing web UI at `molt-syncthing.chelonianlabs.com`.

Needed to configure the new voice recordings folder sync between Derek's Fold 5 and the cluster.

Local network only — no public exposure.