### PR TITLE
feat(ai): deploy voice-ingest microservice

### DIFF
--- a/kubernetes/apps/ai/kustomization.yaml
+++ b/kubernetes/apps/ai/kustomization.yaml
@@ -15,6 +15,7 @@ resources:
   # Voice/Speech
   - ./speaches/ks.yaml
   - ./wyoming-whisper/ks.yaml
+  - ./voice-ingest/ks.yaml
   
   # LLM Inference Stack
   - ./ollama/ks.yaml

--- a/kubernetes/apps/ai/voice-ingest/app/externalsecret.yaml
+++ b/kubernetes/apps/ai/voice-ingest/app/externalsecret.yaml
@@ -1,0 +1,17 @@
+---
+# yaml-language-server: $schema=https://kubernetes-schemas.pages.dev/external-secrets.io/externalsecret_v1beta1.json
+apiVersion: external-secrets.io/v1beta1
+kind: ExternalSecret
+metadata:
+  name: voice-ingest
+spec:
+  secretStoreRef:
+    kind: ClusterSecretStore
+    name: infisical
+  target:
+    name: voice-ingest-secret
+    creationPolicy: Owner
+  data:
+    - secretKey: OPENCLAW_HOOK_TOKEN
+      remoteRef:
+        key: VOICE_INGEST_HOOK_TOKEN

--- a/kubernetes/apps/ai/voice-ingest/app/helmrelease.yaml
+++ b/kubernetes/apps/ai/voice-ingest/app/helmrelease.yaml
@@ -1,0 +1,74 @@
+---
+# yaml-language-server: $schema=https://raw.githubusercontent.com/bjw-s/helm-charts/main/charts/other/app-template/schemas/helmrelease-helm-v2.schema.json
+apiVersion: helm.toolkit.fluxcd.io/v2
+kind: HelmRelease
+metadata:
+  name: voice-ingest
+spec:
+  interval: 30m
+  chartRef:
+    kind: OCIRepository
+    name: app-template
+  install:
+    remediation:
+      retries: 3
+  upgrade:
+    cleanupOnFail: true
+    remediation:
+      strategy: rollback
+      retries: 3
+  values:
+    controllers:
+      voice-ingest:
+        annotations:
+          reloader.stakater.com/auto: "true"
+        containers:
+          app:
+            image:
+              repository: ghcr.io/dapperdivers/voice-ingest
+              tag: main
+            env:
+              TZ: ${TIME_ZONE}
+              WATCH_DIR: /data/voice
+              STT_URL: https://speaches.chelonianlabs.com/v1/audio/transcriptions
+              STT_MODEL: deepdml/faster-whisper-large-v3-turbo-ct2
+              OPENCLAW_URL: http://molt.ai.svc.cluster.local:18789
+              OPENCLAW_HOOK_PATH: /hooks/agent
+              DELETE_AFTER_TRANSCRIBE: "true"
+              MIN_FILE_AGE: "10"
+              LOG_LEVEL: INFO
+            envFrom:
+              - secretRef:
+                  name: voice-ingest-secret
+            resources:
+              requests:
+                cpu: 50m
+                memory: 64Mi
+              limits:
+                cpu: 500m
+                memory: 256Mi
+            securityContext:
+              allowPrivilegeEscalation: false
+              readOnlyRootFilesystem: true
+              capabilities: { drop: ["ALL"] }
+    defaultPodOptions:
+      securityContext:
+        runAsNonRoot: true
+        runAsUser: 1000
+        runAsGroup: 1000
+        fsGroup: 1000
+        fsGroupChangePolicy: OnRootMismatch
+        seccompProfile: { type: RuntimeDefault }
+    persistence:
+      voice:
+        existingClaim: molt-voice-recordings
+        globalMounts:
+          - path: /data/voice
+      state:
+        type: emptyDir
+        globalMounts:
+          - path: /data/state
+      tmp:
+        type: emptyDir
+        globalMounts:
+          - path: /tmp

--- a/kubernetes/apps/ai/voice-ingest/app/kustomization.yaml
+++ b/kubernetes/apps/ai/voice-ingest/app/kustomization.yaml
@@ -1,0 +1,6 @@
+---
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+resources:
+  - externalsecret.yaml
+  - helmrelease.yaml

--- a/kubernetes/apps/ai/voice-ingest/ks.yaml
+++ b/kubernetes/apps/ai/voice-ingest/ks.yaml
@@ -1,0 +1,24 @@
+---
+# yaml-language-server: $schema=https://kubernetes-schemas.pages.dev/kustomize.toolkit.fluxcd.io/kustomization_v1.json
+apiVersion: kustomize.toolkit.fluxcd.io/v1
+kind: Kustomization
+metadata:
+  name: &app voice-ingest
+  namespace: &namespace ai
+spec:
+  targetNamespace: *namespace
+  commonMetadata:
+    labels:
+      app.kubernetes.io/name: *app
+  dependsOn:
+    - name: molt
+  path: ./kubernetes/apps/ai/voice-ingest/app
+  prune: true
+  sourceRef:
+    kind: GitRepository
+    name: flux-system
+    namespace: flux-system
+  wait: true
+  interval: 30m
+  retryInterval: 1m
+  timeout: 10m


### PR DESCRIPTION
## Voice Ingestion Pipeline — Kubernetes Deployment

Deploys the `voice-ingest` microservice to the `ai` namespace.

### Architecture
```
Phone → Samsung Voice Recorder → Syncthing → PVC → voice-ingest → Speaches STT → OpenClaw webhook → Tim routes to vault
```

### What's Deployed
- **voice-ingest** container watching `molt-voice-recordings` PVC
- Transcribes via Speaches STT (internal)
- Sends to OpenClaw `/hooks/agent` for AI classification & vault routing
- Deletes audio after successful processing
- ExternalSecret for webhook token (Infisical: `VOICE_INGEST_HOOK_TOKEN`)

### Prerequisites
- [x] `molt-voice-recordings` PVC (PR #2242)
- [x] Syncthing ingress (PR #2243)  
- [x] OpenClaw webhooks enabled
- [ ] **Infisical secret `VOICE_INGEST_HOOK_TOKEN`** — needs to be created

### Image
`ghcr.io/dapperdivers/voice-ingest:main` — built from https://github.com/dapperdivers/voice-ingest