### PR TITLE
fix: update ExternalSecret for OPENCLAW_GATEWAY_TOKEN rename

### DIFF
--- a/kubernetes/apps/ai/openclaw/app/externalsecret.yaml
+++ b/kubernetes/apps/ai/openclaw/app/externalsecret.yaml
@@ -13,10 +13,13 @@ spec:
       engineVersion: v2
       data:
         # Gateway token for authentication
-        CLAWDBOT_GATEWAY_TOKEN: "{{ .MOLT_GATEWAY_TOKEN }}"
+        CLAWDBOT_GATEWAY_TOKEN: "{{ .OPENCLAW_GATEWAY_TOKEN }}"
         # Home Assistant token for ha-mcp sidecar
         HOMEASSISTANT_TOKEN: "{{ .MOLT_HOMEASSISTANT_TOKEN }}"
   dataFrom:
+    - find:
+        name:
+          regexp: ^OPENCLAW.*
     - find:
         name:
           regexp: ^MOLT.*


### PR DESCRIPTION
MOLT_GATEWAY_TOKEN was renamed to OPENCLAW_GATEWAY_TOKEN in Infisical.

Updates the ExternalSecret template mapping. Keeps both regexes (`OPENCLAW_*` + `MOLT_*`) since MOLT_HOMEASSISTANT_TOKEN still uses the old prefix.

⚠️ Will trigger Tim's pod restart when the secret syncs.