### PR TITLE
fix: git-sync GITSYNC_PERIOD needs time unit (300s)

### DIFF
--- a/kubernetes/apps/roundtable/galahad/app/helmrelease.yaml
+++ b/kubernetes/apps/roundtable/galahad/app/helmrelease.yaml
@@ -111,7 +111,7 @@ spec:
               GITSYNC_REPO: https://github.com/dapperdivers/roundtable-arsenal
               GITSYNC_REF: main
               GITSYNC_ROOT: /skills
-              GITSYNC_PERIOD: "300"
+              GITSYNC_PERIOD: "300s"
             resources:
               requests:
                 cpu: 10m


### PR DESCRIPTION
git-sync v4 requires duration strings. `300` → `300s`