### PR TITLE
feat: RBAC + ingress for Galahad

### DIFF
--- a/kubernetes/apps/roundtable/galahad/app/helmrelease.yaml
+++ b/kubernetes/apps/roundtable/galahad/app/helmrelease.yaml
@@ -137,6 +137,23 @@ spec:
           bridge-health:
             port: 8080
 
+    ingress:
+      app:
+        annotations:
+          external-dns.alpha.kubernetes.io/target: "internal.${SECRET_DOMAIN}"
+        className: internal
+        hosts:
+          - host: &host "galahad.${SECRET_DOMAIN}"
+            paths:
+              - path: /
+                service:
+                  identifier: app
+                  port: http
+        tls:
+          - hosts:
+              - *host
+            secretName: ${SECRET_DOMAIN/./-}-tls
+
     persistence:
       # Knight workspace (persistent across restarts)
       config:

--- a/kubernetes/apps/roundtable/galahad/app/kustomization.yaml
+++ b/kubernetes/apps/roundtable/galahad/app/kustomization.yaml
@@ -5,3 +5,4 @@ kind: Kustomization
 resources:
   - ./externalsecret.yaml
   - ./helmrelease.yaml
+  - ./rbac.yaml

--- a/kubernetes/apps/roundtable/galahad/app/rbac.yaml
+++ b/kubernetes/apps/roundtable/galahad/app/rbac.yaml
@@ -1,0 +1,33 @@
+---
+# Allow molt (Tim) full access to roundtable namespace
+# Enables exec, logs, pod management, secrets, configmaps, etc.
+apiVersion: rbac.authorization.k8s.io/v1
+kind: Role
+metadata:
+  name: molt-roundtable-access
+rules:
+  - apiGroups: [""]
+    resources: ["pods", "pods/exec", "pods/log", "services", "configmaps", "secrets", "persistentvolumeclaims", "events"]
+    verbs: ["get", "list", "watch", "create", "update", "patch", "delete"]
+  - apiGroups: ["apps"]
+    resources: ["deployments", "replicasets"]
+    verbs: ["get", "list", "watch", "update", "patch"]
+  - apiGroups: ["batch"]
+    resources: ["jobs"]
+    verbs: ["get", "list", "watch", "create", "delete"]
+  - apiGroups: ["volsync.backube"]
+    resources: ["replicationsources", "replicationdestinations"]
+    verbs: ["get", "list", "watch"]
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: RoleBinding
+metadata:
+  name: molt-roundtable-access
+subjects:
+  - kind: ServiceAccount
+    name: default
+    namespace: ai
+roleRef:
+  kind: Role
+  name: molt-roundtable-access
+  apiGroup: rbac.authorization.k8s.io


### PR DESCRIPTION
- **RBAC:** Full roundtable namespace access for Tim (exec, logs, secrets, configmaps, deployments, volsync)
- **Ingress:** galahad.${SECRET_DOMAIN} (internal, TLS) — same pattern as Munin