### PR TITLE
fix: CLAWDBOT_GATEWAY_TOKEN (enables /v1/chat/completions API)

### DIFF
--- a/kubernetes/apps/roundtable/galahad/app/externalsecret.yaml
+++ b/kubernetes/apps/roundtable/galahad/app/externalsecret.yaml
@@ -13,6 +13,7 @@ spec:
       engineVersion: v2
       data:
         OPENCLAW_GATEWAY_TOKEN: "{{ .OPENCLAW_GATEWAY_TOKEN }}"
+        CLAWDBOT_GATEWAY_TOKEN: "{{ .OPENCLAW_GATEWAY_TOKEN }}"
         ANTHROPIC_API_KEY: "{{ .OPENCLAW_ANTHROPIC_API_KEY }}"
   dataFrom:
     - find:


### PR DESCRIPTION
OpenClaw expects `CLAWDBOT_GATEWAY_TOKEN` — without it the chat completions API returns 405 and nats-bridge can't forward tasks to the knight.