### PR TITLE
fix: nats-bridge IPv6 connection refused (localhost → 127.0.0.1)

### DIFF
--- a/kubernetes/apps/roundtable/galahad/app/helmrelease.yaml
+++ b/kubernetes/apps/roundtable/galahad/app/helmrelease.yaml
@@ -61,7 +61,7 @@ spec:
               tag: latest
             env:
               NATS_URL: nats://nats.database.svc:4222
-              OPENCLAW_WEBHOOK_URL: http://localhost:18789/hooks/agent
+              OPENCLAW_WEBHOOK_URL: http://127.0.0.1:18789/hooks/agent
               AGENT_ID: galahad
               FLEET_ID: fleet-a
               SUBSCRIBE_TOPICS: "fleet-a.tasks.security.>"


### PR DESCRIPTION
Go resolves `localhost` to `[::1]` (IPv6) first, but OpenClaw binds IPv4. Use `127.0.0.1` explicitly.