### PR TITLE
feat(roundtable): declarative knight config via ConfigMap + initContainer

### DIFF
--- a/kubernetes/apps/roundtable/galahad/app/configmap.yaml
+++ b/kubernetes/apps/roundtable/galahad/app/configmap.yaml
@@ -1,0 +1,218 @@
+---
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: galahad-config
+data:
+  openclaw.json: |
+    {
+      "auth": {
+        "profiles": {
+          "anthropic:default": {
+            "provider": "anthropic",
+            "mode": "token"
+          }
+        }
+      },
+      "browser": {
+        "enabled": true,
+        "attachOnly": true,
+        "defaultProfile": "sidecar",
+        "profiles": {
+          "sidecar": {
+            "cdpUrl": "http://localhost:9222",
+            "color": "#4285F4"
+          }
+        }
+      },
+      "hooks": {
+        "enabled": true,
+        "path": "/hooks"
+      },
+      "agents": {
+        "defaults": {
+          "model": {
+            "primary": "anthropic/claude-sonnet-4-5"
+          },
+          "workspace": "/home/node/galahad",
+          "maxConcurrent": 2,
+          "subagents": {
+            "maxConcurrent": 4
+          }
+        },
+        "list": [
+          {
+            "id": "main"
+          }
+        ]
+      },
+      "gateway": {
+        "port": 18789,
+        "mode": "local",
+        "bind": "lan",
+        "controlUi": {
+          "enabled": true,
+          "allowInsecureAuth": true
+        },
+        "auth": {
+          "mode": "token"
+        },
+        "trustedProxies": [
+          "10.0.0.0/8",
+          "172.16.0.0/12",
+          "192.168.0.0/16"
+        ]
+      },
+      "skills": {
+        "load": {
+          "extraDirs": ["/home/node/galahad/skills"]
+        }
+      }
+    }
+
+  SOUL.md: |
+    # SOUL.md — Sir Galahad, the Security Knight
+
+    ## Identity
+    - **Name:** Sir Galahad
+    - **Title:** Knight of Security
+    - **Emoji:** 🛡️
+    - **Reports to:** Tim the Enchanter 🔥
+    - **Fleet:** fleet-a (Round Table)
+    - **Domain:** Security operations, threat intelligence, vulnerability management, CVE analysis
+
+    ## Personality
+    You are Sir Galahad, the purest and most vigilant knight of the Round Table.
+    - Paranoid and proud of it — trust nothing, verify everything
+    - Thorough — you interrogate, not just scan
+    - Dry-witted with a knight's sense of duty
+    - Dutiful and uncompromising on security matters
+    - Brief in reports but comprehensive in analysis
+
+    ## Communication
+    - You receive tasks via NATS from Tim
+    - You respond via NATS using the nats-comms skill
+    - You NEVER deliver messages to chat channels
+    - You NEVER interact with humans directly
+    - Tim is your sole interface to the Round Table
+
+    ## How You Work
+    1. Task arrives via NATS → webhook → your session
+    2. You read the task, plan your approach
+    3. Execute using your skills and tools
+    4. Package results as structured JSON
+    5. Send back via `nats-respond.sh` with your findings
+
+    ## Standards
+    - Always include a `summary` field in results
+    - Flag severity levels: critical, high, medium, low, info
+    - When uncertain, say so — false confidence is a vulnerability
+    - Document your reasoning, not just conclusions
+
+  AGENTS.md: |
+    # AGENTS.md — Knight Workspace
+
+    Read SOUL.md for your identity.
+
+    ## Every Task
+
+    When you receive a task via NATS (webhook), you MUST:
+    1. Read TOOLS.md for available tools
+    2. Complete the requested work
+    3. **Send results back via NATS** using the nats-comms skill
+
+    Your task message will include a TASK METADATA section with:
+    - `task ID` — unique identifier for this task
+    - `domain` — your domain (e.g., "security")
+
+    ## Responding to Tasks
+
+    Always send results back using:
+    ```bash
+    bash /home/node/galahad/skills/roundtable-arsenal/skills/shared/nats-comms/scripts/nats-respond.sh '<task-id>' '<domain>' '{"summary":"...","details":"..."}'
+    ```
+
+    The payload MUST be valid JSON. Structure your results as:
+    ```json
+    {
+      "summary": "One-line summary of result",
+      "details": "Detailed findings or response",
+      "status": "complete|partial|error"
+    }
+    ```
+
+    Include additional fields as appropriate for the task.
+
+    ## Skills
+
+    Skills are at `/home/node/galahad/skills/roundtable-arsenal/skills/`.
+    Key skills:
+    - `shared/nats-comms/` — NATS communication (REQUIRED for every task)
+    - `security/` — Security-domain tools
+
+    ## Memory
+
+    - Write daily notes to `memory/YYYY-MM-DD.md`
+    - Files are your continuity between sessions
+
+    ## Rules
+
+    - You serve Tim the Enchanter — he dispatches your tasks
+    - You never interact with humans directly
+    - Always respond via NATS, never via chat delivery
+    - Document significant findings in memory
+
+  TOOLS.md: |
+    # TOOLS.md — Knight Tools
+
+    ## Web Search (SearXNG)
+
+    Self-hosted search engine. Use this for ALL web searches.
+
+    ```bash
+    curl -s "http://searxng.selfhosted.svc.cluster.local:8080/search?q=QUERY&format=json" | python3 -c "
+    import sys, json
+    data = json.load(sys.stdin)
+    for r in data.get('results', [])[:10]:
+        print(f\"### {r.get('title', 'No title')}\")
+        print(f\"URL: {r.get('url', '')}\")
+        print(f\"{r.get('content', 'No snippet')}\")
+        print()
+    "
+    ```
+
+    **Quick one-liner:**
+    ```bash
+    curl -s "http://searxng.selfhosted.svc.cluster.local:8080/search?q=QUERY+HERE&format=json" | python3 -c "import sys,json;[print(r['title'],r['url']) for r in json.load(sys.stdin).get('results',[])[:5]]"
+    ```
+
+    ## NATS Communication
+
+    See skill at `/home/node/galahad/skills/roundtable-arsenal/skills/shared/nats-comms/`
+
+    - **Respond to tasks:** `bash .../nats-comms/scripts/nats-respond.sh <task-id> <domain> '<json>'`
+    - **Bridge info:** `curl -s http://localhost:8080/info`
+    - **Bridge health:** `curl -s http://localhost:8080/healthz`
+
+    ## Fetch Web Pages
+
+    ```bash
+    curl -sL "URL" | python3 -c "
+    import sys
+    from html.parser import HTMLParser
+    class T(HTMLParser):
+        def __init__(self):
+            super().__init__()
+            self.text = []
+            self.skip = False
+        def handle_starttag(self, tag, _):
+            if tag in ('script','style'): self.skip = True
+        def handle_endtag(self, tag):
+            if tag in ('script','style'): self.skip = False
+        def handle_data(self, data):
+            if not self.skip: self.text.append(data.strip())
+    t = T()
+    t.feed(sys.stdin.read())
+    print('\n'.join(line for line in t.text if line)[:5000])
+    "
+    ```

--- a/kubernetes/apps/roundtable/galahad/app/helmrelease.yaml
+++ b/kubernetes/apps/roundtable/galahad/app/helmrelease.yaml
@@ -24,6 +24,42 @@ spec:
       galahad:
         annotations:
           reloader.stakater.com/auto: "true"
+        initContainers:
+          # ── Workspace Seeder ────────────────────────────────────────
+          # Seeds workspace files from ConfigMap on first deploy.
+          # Only writes files that don't already exist (preserves knight memory).
+          seed-workspace:
+            image:
+              repository: ghcr.io/openclaw/openclaw
+              tag: 2026.2.6-3@sha256:0ecbdbda258bc82eb3ab7f142dcfbbb2f309f21583489c0eb6a68a6debed1310
+            command:
+              - /bin/sh
+              - -c
+              - |
+                set -e
+                WORKSPACE=/home/node/galahad
+                CONFIG=/home/node/.openclaw
+
+                # Create directories
+                mkdir -p "$WORKSPACE/memory" "$CONFIG" /home/node/.local/bin
+
+                # Seed workspace files (only if missing — preserves knight edits)
+                for f in SOUL.md AGENTS.md TOOLS.md; do
+                  if [ ! -f "$WORKSPACE/$f" ]; then
+                    cp "/seed/$f" "$WORKSPACE/$f"
+                    echo "Seeded $f"
+                  else
+                    echo "$f already exists, skipping"
+                  fi
+                done
+
+                # Always update openclaw.json from ConfigMap (config is declarative)
+                cp /seed/openclaw.json "$CONFIG/openclaw.json"
+                echo "Updated openclaw.json"
+
+                # Ensure correct ownership
+                chown -R 1000:1000 /home/node
+                echo "Workspace ready"
         containers:
           # ── OpenClaw Gateway ────────────────────────────────────────
           app:
@@ -58,7 +94,7 @@ spec:
           nats-bridge:
             image:
               repository: ghcr.io/dapperdivers/nats-bridge
-              tag: latest@sha256:02199ff5352ebe11202ccb46303150f88c6698b31107c8b3085510add1167b34
+              tag: 5f9dd27b7b8ee734fccca2448e46659916c0cbde
             env:
               NATS_URL: nats://nats.database.svc:4222
               OPENCLAW_WEBHOOK_URL: http://127.0.0.1:18789/hooks/agent
@@ -166,8 +202,21 @@ spec:
         existingClaim: galahad
         advancedMounts:
           galahad:
+            seed-workspace:
+              - path: /home/node
             app:
               - path: /home/node
+
+      # ConfigMap with workspace seed files
+      seed:
+        enabled: true
+        type: configMap
+        name: galahad-config
+        advancedMounts:
+          galahad:
+            seed-workspace:
+              - path: /seed
+                readOnly: true
 
       # Git-synced skills from arsenal repo
       skills:

--- a/kubernetes/apps/roundtable/galahad/app/kustomization.yaml
+++ b/kubernetes/apps/roundtable/galahad/app/kustomization.yaml
@@ -3,5 +3,6 @@
 apiVersion: kustomize.config.k8s.io/v1beta1
 kind: Kustomization
 resources:
+  - ./configmap.yaml
   - ./externalsecret.yaml
   - ./helmrelease.yaml


### PR DESCRIPTION
## Summary
Adds declarative configuration pattern for Round Table knights, making new knight deployments a simple copy-paste-customize operation.

## Changes
- **New ConfigMap** (`galahad-config`) with workspace files:
  - `openclaw.json` — OpenClaw gateway config (model, hooks, browser, skills)
  - `SOUL.md` — Knight personality and identity
  - `AGENTS.md` — Task handling instructions (NATS response protocol)
  - `TOOLS.md` — Available tools (SearXNG web search, NATS comms, web fetching)

- **InitContainer** (`seed-workspace`) that:
  - Seeds workspace files from ConfigMap on first deploy only (preserves knight memory/edits)
  - Always updates `openclaw.json` (config is declarative, managed by GitOps)
  - Creates required directories (`memory/`, `.openclaw/`, `.local/bin/`)

- **nats-bridge image pinned** to commit SHA `5f9dd27b` (includes `/publish` + `/info` HTTP endpoints)

## Deploy Pattern for New Knights
```bash
# 1. Copy galahad directory
cp -r kubernetes/apps/roundtable/galahad kubernetes/apps/roundtable/<new-knight>

# 2. Update names, domain, SOUL.md in configmap.yaml
# 3. Update SUBSCRIBE_TOPICS in helmrelease.yaml
# 4. Add to roundtable/kustomization.yaml
# 5. PR and merge
```

## Tested
- Full NATS bidirectional communication working (Tim → Galahad → Tim)
- Galahad produced structured security intelligence report via NATS
- ConfigMap + initContainer pattern verified locally