### PR TITLE
fix(opencti): correct value types for chart schema validation

### DIFF
--- a/kubernetes/apps/security/opencti/app/helmrelease.yaml
+++ b/kubernetes/apps/security/opencti/app/helmrelease.yaml
@@ -40,11 +40,11 @@ spec:
       APP__BASE_PATH: "/"
       NODE_OPTIONS: "--max-old-space-size=4096"
       PROVIDERS__LOCAL__STRATEGY: LocalStrategy
-      APP__TELEMETRY__METRICS__ENABLED: "true"
+      APP__TELEMETRY__METRICS__ENABLED: true
       APP__HEALTH_ACCESS_KEY: "changeme-replaced-by-secret"
       # Redis — external Dragonfly
       REDIS__HOSTNAME: dragonfly.database.svc.cluster.local
-      REDIS__PORT: "6379"
+      REDIS__PORT: 6379
       REDIS__MODE: single
 
     envFromSecrets:


### PR DESCRIPTION
Chart v2.3.2 enforces JSON schema types:
- `REDIS__PORT`: string → integer
- `APP__TELEMETRY__METRICS__ENABLED`: string → boolean

Fixes install failure from #2278.