### PR TITLE
fix(opencti): use SECRET_DOMAIN for ingress hostname

### DIFF
--- a/kubernetes/apps/security/opencti/app/helmrelease.yaml
+++ b/kubernetes/apps/security/opencti/app/helmrelease.yaml
@@ -68,13 +68,13 @@ spec:
       annotations:
         cert-manager.io/cluster-issuer: letsencrypt-production
       hosts:
-        - host: opencti.${CLUSTER_DOMAIN}
+        - host: opencti.${SECRET_DOMAIN}
           paths:
             - path: /
               pathType: Prefix
       tls:
         - hosts:
-            - opencti.${CLUSTER_DOMAIN}
+            - opencti.${SECRET_DOMAIN}
           secretName: opencti-tls
 
     # ===================


### PR DESCRIPTION
CLUSTER_DOMAIN resolved empty → invalid host `opencti.`

All other apps use `SECRET_DOMAIN`. Fixes ingress validation error from #2279.