### PR TITLE
fix(opencti): hardcode ingress domain

### DIFF
--- a/kubernetes/apps/security/opencti/app/helmrelease.yaml
+++ b/kubernetes/apps/security/opencti/app/helmrelease.yaml
@@ -68,13 +68,13 @@ spec:
       annotations:
         cert-manager.io/cluster-issuer: letsencrypt-production
       hosts:
-        - host: opencti.${SECRET_DOMAIN}
+        - host: opencti.chelonianlabs.com
           paths:
             - path: /
               pathType: Prefix
       tls:
         - hosts:
-            - opencti.${SECRET_DOMAIN}
+            - opencti.chelonianlabs.com
           secretName: opencti-tls
 
     # ===================


### PR DESCRIPTION
Variable substitution (${SECRET_DOMAIN}) resolving empty for OpenCTI HelmRelease. Hardcode to unblock.