### PR TITLE
fix(opencti): configure OpenSearch connection URL

### DIFF
--- a/kubernetes/apps/security/opencti/app/helmrelease.yaml
+++ b/kubernetes/apps/security/opencti/app/helmrelease.yaml
@@ -42,6 +42,8 @@ spec:
       PROVIDERS__LOCAL__STRATEGY: LocalStrategy
       APP__TELEMETRY__METRICS__ENABLED: true
       APP__HEALTH_ACCESS_KEY: "changeme-replaced-by-secret"
+      # OpenSearch
+      ELASTICSEARCH__URL: http://opensearch-cluster-master:9200
       # Redis — external Dragonfly
       REDIS__HOSTNAME: dragonfly.database.svc.cluster.local
       REDIS__PORT: 6379


### PR DESCRIPTION
Server couldn't find search engine - default hostname was `release-name-elasticsearch`. Point at `opensearch-cluster-master:9200`.