### PR TITLE
fix(opencti): configure MinIO + RabbitMQ + increase timeout

### DIFF
--- a/kubernetes/apps/security/opencti/app/helmrelease.yaml
+++ b/kubernetes/apps/security/opencti/app/helmrelease.yaml
@@ -16,6 +16,7 @@ spec:
         namespace: flux-system
       interval: 15m
   maxHistory: 2
+  timeout: 15m
   install:
     crds: CreateReplace
     remediation:
@@ -44,6 +45,16 @@ spec:
       APP__HEALTH_ACCESS_KEY: "changeme-replaced-by-secret"
       # OpenSearch
       ELASTICSEARCH__URL: http://opensearch-cluster-master:9200
+      # MinIO (file storage)
+      MINIO__ENDPOINT: opencti-minio
+      MINIO__PORT: 9000
+      MINIO__USE_SSL: false
+      MINIO__BUCKET_NAME: opencti-bucket
+      # RabbitMQ
+      RABBITMQ__HOSTNAME: opencti-rabbitmq
+      RABBITMQ__PORT: 5672
+      RABBITMQ__USERNAME: guest
+      RABBITMQ__PASSWORD: guest
       # Redis — external Dragonfly
       REDIS__HOSTNAME: dragonfly.database.svc.cluster.local
       REDIS__PORT: 6379
@@ -56,6 +67,12 @@ spec:
       APP__ADMIN__TOKEN:
         name: opencti-secrets
         key: OPENCTI_ADMIN_TOKEN
+      MINIO__ACCESS_KEY:
+        name: opencti-minio
+        key: rootUser
+      MINIO__SECRET_KEY:
+        name: opencti-minio
+        key: rootPassword
 
     resources:
       requests:


### PR DESCRIPTION
Server crashes because it can't find MinIO (Invalid URL) or RabbitMQ. Configure explicit connection details. Also increase timeout from 5m→15m to allow subcharts to start.