### PR TITLE
fix(opencti): inject admin token into connectors

### DIFF
--- a/kubernetes/apps/security/opencti/app/helmrelease.yaml
+++ b/kubernetes/apps/security/opencti/app/helmrelease.yaml
@@ -83,6 +83,15 @@ spec:
         memory: 4Gi
 
     # ===================
+    # Connectors global — inject token from secret
+    # ===================
+    connectorsGlobal:
+      envFromSecrets:
+        OPENCTI_TOKEN:
+          name: opencti-secrets
+          key: OPENCTI_ADMIN_TOKEN
+
+    # ===================
     # Ready checker — wait for deps before starting server
     # ===================
     readyChecker:


### PR DESCRIPTION
Connectors receive OPENCTI_TOKEN from env literal ('changeme-replaced-by-secret'), not from envFromSecrets which only applies to the server. Use connectorsGlobal.envFromSecrets to inject the real token.