### PR TITLE
fix(opencti): add NVD API key to CVE connector

### DIFF
--- a/kubernetes/apps/security/opencti/app/helmrelease.yaml
+++ b/kubernetes/apps/security/opencti/app/helmrelease.yaml
@@ -175,6 +175,10 @@ spec:
           CONNECTOR_DURATION_PERIOD: "PT24H"
           CONNECTOR_CONFIDENCE_LEVEL: "75"
           CVE__NVD_DATA_FEED: "https://nvd.nist.gov/feeds/json/cve/1.1/nvdcve-1.1-recent.json.gz"
+        envFromSecrets:
+          CVE__API_KEY:
+            name: opencti-secrets
+            key: OPENCTI_NVD_API_KEY
         resources:
           requests:
             cpu: 100m


### PR DESCRIPTION
CVE connector requires an API key. Inject from Infisical secret.