### PR TITLE
fix(opencti): inject admin token into workers

### DIFF
--- a/kubernetes/apps/security/opencti/app/helmrelease.yaml
+++ b/kubernetes/apps/security/opencti/app/helmrelease.yaml
@@ -130,6 +130,10 @@ spec:
     worker:
       enabled: true
       replicaCount: 3
+      envFromSecrets:
+        OPENCTI_TOKEN:
+          name: opencti-secrets
+          key: OPENCTI_ADMIN_TOKEN
       resources:
         requests:
           cpu: 250m


### PR DESCRIPTION
Workers failing with AUTH_REQUIRED. Same issue as connectors — need token from secret, not env literal.