### PR TITLE
feat(galahad): add OpenCTI API token

### DIFF
--- a/kubernetes/apps/roundtable/galahad/app/externalsecret.yaml
+++ b/kubernetes/apps/roundtable/galahad/app/externalsecret.yaml
@@ -16,7 +16,8 @@ spec:
         CLAWDBOT_GATEWAY_TOKEN: "{{ .OPENCLAW_GATEWAY_TOKEN }}"
         ANTHROPIC_API_KEY: "{{ .OPENCLAW_ANTHROPIC_API_KEY }}"
         OPENCLAW_HOOK_TOKEN: "{{ .OPENCLAW_GATEWAY_TOKEN }}"
+        OPENCTI_TOKEN: "{{ .GALAHAD_OPENCTI_TOKEN }}"
   dataFrom:
     - find:
         name:
-          regexp: ^OPENCLAW.*
+          regexp: ^(OPENCLAW|GALAHAD).*


### PR DESCRIPTION
Enables Galahad to query OpenCTI for threat intel. Token sourced from Infisical.