### PR TITLE
fix(opencti): disable Malware Bazaar connector pending API key

### DIFF
--- a/kubernetes/apps/security/opencti/app/helmrelease.yaml
+++ b/kubernetes/apps/security/opencti/app/helmrelease.yaml
@@ -300,8 +300,9 @@ spec:
             memory: 512Mi
 
       # --- Abuse.ch Malware Bazaar Recent ---
+      # TODO: Needs API key from https://bazaar.abuse.ch/api/#auth_key - add to Infisical as OPENCTI_MALWAREBAZAAR_API_KEY
       - name: malwarebazaar
-        enabled: true
+        enabled: false
         image:
           repository: opencti/connector-malwarebazaar-recent-additions
           tag: 6.9.16


### PR DESCRIPTION
Malware Bazaar connector requires an API key (free from abuse.ch). Disabled until key is provisioned. Other 2 new connectors (SSL Blacklist, AlienVault) confirmed running.