### PR TITLE
fix(opencti): disable deprecated SSL blacklist connector

### DIFF
--- a/kubernetes/apps/security/opencti/app/helmrelease.yaml
+++ b/kubernetes/apps/security/opencti/app/helmrelease.yaml
@@ -279,8 +279,9 @@ spec:
             memory: 512Mi
 
       # --- Abuse.ch SSL Blacklist ---
+      # DEPRECATED: abuse.ch SSL blacklist deprecated 2025-01-03 (see OpenCTI-Platform/connectors#3967)
       - name: abuse-ssl
-        enabled: true
+        enabled: false
         image:
           repository: opencti/connector-abuse-ssl
           tag: 6.9.16


### PR DESCRIPTION
Abuse.ch SSL blacklist deprecated 2025-01-03. Connector crashloops on startup. See OpenCTI-Platform/connectors#3967.