### PR TITLE
feat(opencti): switch to dapperdivers/helm-opencti chart

### DIFF
--- a/kubernetes/apps/security/opencti/app/helmrelease.yaml
+++ b/kubernetes/apps/security/opencti/app/helmrelease.yaml
@@ -8,11 +8,10 @@ spec:
   interval: 30m
   chart:
     spec:
-      chart: opencti
-      version: 2.3.2
+      chart: charts/opencti
       sourceRef:
-        kind: HelmRepository
-        name: opencti
+        kind: GitRepository
+        name: helm-opencti
         namespace: flux-system
       interval: 15m
   maxHistory: 2
@@ -30,99 +29,55 @@ spec:
     keepHistory: false
   values:
     # ===================
-    # OpenCTI Platform
+    # Core Config — single source of truth
     # ===================
     fullnameOverride: opencti
 
-    env:
-      APP__ADMIN__EMAIL: "admin@chelonianlabs.com"
-      APP__ADMIN__PASSWORD: "changeme-replaced-by-secret"
-      APP__ADMIN__TOKEN: "changeme-replaced-by-secret"
-      APP__BASE_PATH: "/"
-      NODE_OPTIONS: "--max-old-space-size=4096"
-      PROVIDERS__LOCAL__STRATEGY: LocalStrategy
-      APP__TELEMETRY__METRICS__ENABLED: true
-      APP__HEALTH_ACCESS_KEY: "changeme-replaced-by-secret"
-      # OpenSearch
-      ELASTICSEARCH__URL: http://opensearch-cluster-master:9200
-      # MinIO (file storage)
-      MINIO__ENDPOINT: opencti-minio
-      MINIO__PORT: 9000
-      MINIO__USE_SSL: false
-      MINIO__BUCKET_NAME: opencti-bucket
-      # RabbitMQ
-      RABBITMQ__HOSTNAME: opencti-rabbitmq
-      RABBITMQ__PORT: 5672
-      RABBITMQ__PORT_MANAGEMENT: 15672
-      RABBITMQ__USERNAME: user
-      RABBITMQ__PASSWORD: ChangeMe
-      # Redis — external Dragonfly
-      REDIS__HOSTNAME: dragonfly.database.svc.cluster.local
-      REDIS__PORT: 6379
-      REDIS__MODE: single
-
-    envFromSecrets:
-      APP__ADMIN__PASSWORD:
-        name: opencti-secrets
-        key: OPENCTI_ADMIN_PASSWORD
-      APP__ADMIN__TOKEN:
+    opencti:
+      adminEmail: admin@chelonianlabs.com
+      adminTokenExistingSecret:
         name: opencti-secrets
         key: OPENCTI_ADMIN_TOKEN
-      MINIO__ACCESS_KEY:
-        name: opencti-minio
-        key: rootUser
-      MINIO__SECRET_KEY:
-        name: opencti-minio
-        key: rootPassword
-
-    resources:
-      requests:
-        cpu: 1000m
-        memory: 2Gi
-      limits:
-        memory: 4Gi
+      adminPasswordExistingSecret:
+        name: opencti-secrets
+        key: OPENCTI_ADMIN_PASSWORD
 
     # ===================
-    # Connectors global — inject token from secret
+    # External Redis → Dragonfly (database namespace)
     # ===================
-    connectorsGlobal:
-      envFromSecrets:
-        OPENCTI_TOKEN:
-          name: opencti-secrets
-          key: OPENCTI_CONNECTOR_TOKEN
-
-    # ===================
-    # Ready checker — wait for deps before starting server
-    # ===================
-    readyChecker:
+    externalRedis:
       enabled: true
-      retries: 60
-      timeout: 5
-      services:
-        - name: elasticsearch
-          port: 9200
-          address: opensearch-cluster-master
-        - name: minio
-          port: 9000
-          address: opencti-minio
-        - name: rabbitmq
-          port: 5672
-          address: opencti-rabbitmq
+      hostname: dragonfly.database.svc.cluster.local
+      port: 6379
+      mode: single
 
-    ingress:
-      enabled: true
-      ingressClassName: internal-nginx
-      annotations:
-        cert-manager.io/cluster-issuer: letsencrypt-production
-      hosts:
-        - host: opencti.chelonianlabs.com
-          paths:
-            - path: /
-              pathType: Prefix
-      tls:
-        - hosts:
-            - opencti.chelonianlabs.com
-          secretName: opencti-tls
+    # ===================
+    # Server
+    # ===================
+    server:
+      replicaCount: 1
+      nodeOptions: "--max-old-space-size=4096"
+      resources:
+        requests:
+          cpu: 1000m
+          memory: 2Gi
+        limits:
+          memory: 4Gi
+
+      ingress:
+        enabled: true
+        className: internal-nginx
+        annotations:
+          cert-manager.io/cluster-issuer: letsencrypt-production
+        hosts:
+          - host: opencti.chelonianlabs.com
+            paths:
+              - path: /
+                pathType: Prefix
+        tls:
+          - hosts:
+              - opencti.chelonianlabs.com
+            secretName: opencti-tls
 
     # ===================
     # Workers
@@ -130,10 +85,6 @@ spec:
     worker:
       enabled: true
       replicaCount: 3
-      envFromSecrets:
-        OPENCTI_TOKEN:
-          name: opencti-secrets
-          key: OPENCTI_ADMIN_TOKEN
       resources:
         requests:
           cpu: 250m
@@ -142,15 +93,73 @@ spec:
           memory: 1Gi
 
     # ===================
-    # Connectors (list format for chart v2.x)
+    # OpenSearch (dedicated instance)
+    # ===================
+    opensearch:
+      enabled: true
+      replicas: 1
+      opensearchJavaOpts: "-Xms2g -Xmx2g"
+      resources:
+        requests:
+          cpu: 1000m
+          memory: 4Gi
+        limits:
+          memory: 4Gi
+      persistence:
+        enabled: true
+        size: 100Gi
+        storageClass: ceph-rbd
+      config:
+        opensearch.yml: |
+          cluster.name: opencti
+          network.host: 0.0.0.0
+          plugins.security.disabled: true
+
+    # ===================
+    # RabbitMQ (dedicated instance)
+    # ===================
+    rabbitmq:
+      enabled: true
+      auth:
+        username: user
+        password: ChangeMe
+      persistence:
+        enabled: true
+        size: 10Gi
+        storageClass: ceph-rbd
+      resources:
+        requests:
+          cpu: 250m
+          memory: 1Gi
+        limits:
+          memory: 1Gi
+
+    # ===================
+    # MinIO (dedicated instance)
+    # ===================
+    minio:
+      enabled: true
+      persistence:
+        enabled: true
+        size: 20Gi
+        storageClass: ceph-rbd
+      resources:
+        requests:
+          cpu: 100m
+          memory: 256Mi
+        limits:
+          memory: 512Mi
+
+    # ===================
+    # Connectors
     # ===================
     connectors:
       # --- CISA Known Exploited Vulnerabilities ---
-      - name: cisa-kev
+      cisa-kev:
         enabled: true
         image:
           repository: opencti/connector-cisa-known-exploited-vulnerabilities
-          tag: 6.9.16
+          tag: "6.9.16"
         env:
           CONNECTOR_ID: "cisa-kev-001"
           CONNECTOR_NAME: "CISA Known Exploited Vulnerabilities"
@@ -166,11 +175,11 @@ spec:
             memory: 512Mi
 
       # --- CVE / NVD ---
-      - name: cve
+      cve:
         enabled: true
         image:
           repository: opencti/connector-cve
-          tag: 6.9.16
+          tag: "6.9.16"
         env:
           CONNECTOR_ID: "cve-001"
           CONNECTOR_NAME: "Common Vulnerabilities and Exposures"
@@ -191,11 +200,11 @@ spec:
             memory: 512Mi
 
       # --- MITRE ATT&CK ---
-      - name: mitre
+      mitre:
         enabled: true
         image:
           repository: opencti/connector-mitre
-          tag: 6.9.16
+          tag: "6.9.16"
         env:
           CONNECTOR_ID: "mitre-001"
           CONNECTOR_NAME: "MITRE ATT&CK"
@@ -214,11 +223,11 @@ spec:
             memory: 512Mi
 
       # --- EPSS Scores ---
-      - name: epss
+      epss:
         enabled: true
         image:
           repository: opencti/connector-first-epss-bulk
-          tag: 6.9.16
+          tag: "6.9.16"
         env:
           CONNECTOR_ID: "epss-001"
           CONNECTOR_NAME: "FIRST EPSS"
@@ -234,11 +243,11 @@ spec:
             memory: 512Mi
 
       # --- Abuse.ch URLhaus ---
-      - name: urlhaus
+      urlhaus:
         enabled: true
         image:
           repository: opencti/connector-urlhaus
-          tag: 6.9.16
+          tag: "6.9.16"
         env:
           CONNECTOR_ID: "urlhaus-001"
           CONNECTOR_NAME: "URLhaus"
@@ -256,11 +265,11 @@ spec:
             memory: 512Mi
 
       # --- Abuse.ch ThreatFox ---
-      - name: threatfox
+      threatfox:
         enabled: true
         image:
           repository: opencti/connector-threatfox
-          tag: 6.9.16
+          tag: "6.9.16"
         env:
           CONNECTOR_ID: "threatfox-001"
           CONNECTOR_NAME: "ThreatFox"
@@ -278,59 +287,12 @@ spec:
           limits:
             memory: 512Mi
 
-      # --- Abuse.ch SSL Blacklist ---
-      # DEPRECATED: abuse.ch SSL blacklist deprecated 2025-01-03 (see OpenCTI-Platform/connectors#3967)
-      - name: abuse-ssl
-        enabled: false
-        image:
-          repository: opencti/connector-abuse-ssl
-          tag: 6.9.16
-        env:
-          CONNECTOR_ID: "abuse-ssl-001"
-          CONNECTOR_NAME: "Abuse.ch SSL Blacklist"
-          CONNECTOR_SCOPE: "abusessl"
-          CONNECTOR_LOG_LEVEL: "info"
-          CONNECTOR_DURATION_PERIOD: "PT2H"
-          CONNECTOR_CONFIDENCE_LEVEL: "40"
-          ABUSESSL_URL: "https://sslbl.abuse.ch/blacklist/sslblacklist.csv"
-        resources:
-          requests:
-            cpu: 100m
-            memory: 256Mi
-          limits:
-            memory: 512Mi
-
-      # --- Abuse.ch Malware Bazaar Recent ---
-      - name: malwarebazaar
-        enabled: true
-        image:
-          repository: opencti/connector-malwarebazaar-recent-additions
-          tag: 6.9.16
-        env:
-          CONNECTOR_ID: "malwarebazaar-001"
-          CONNECTOR_NAME: "Malware Bazaar Recent Additions"
-          CONNECTOR_SCOPE: "malwarebazaar"
-          CONNECTOR_LOG_LEVEL: "info"
-          CONNECTOR_DURATION_PERIOD: "PT2H"
-          CONNECTOR_CONFIDENCE_LEVEL: "50"
-          MALWAREBAZAAR_RECENT_ADDITIONS_API_URL: "https://mb-api.abuse.ch/api/v1/"
-        envFromSecrets:
-          MALWAREBAZAAR_RECENT_ADDITIONS_API_KEY:
-            name: opencti-secrets
-            key: OPENCTI_MALWAREBAZAAR_API_KEY
-        resources:
-          requests:
-            cpu: 100m
-            memory: 256Mi
-          limits:
-            memory: 512Mi
-
       # --- AlienVault OTX ---
-      - name: alienvault
+      alienvault:
         enabled: true
         image:
           repository: opencti/connector-alienvault
-          tag: 6.9.16
+          tag: "6.9.16"
         env:
           CONNECTOR_ID: "alienvault-001"
           CONNECTOR_NAME: "AlienVault OTX"
@@ -360,74 +322,27 @@ spec:
           limits:
             memory: 512Mi
 
-    # ===================
-    # OpenSearch (dedicated instance)
-    # ===================
-    opensearch:
-      enabled: true
-      singleNode: true
-      replicas: 1
-      resources:
-        requests:
-          cpu: 1000m
-          memory: 4Gi
-        limits:
-          memory: 4Gi
-      persistence:
+      # --- Malware Bazaar ---
+      malwarebazaar:
         enabled: true
-        size: 100Gi
-        storageClass: ceph-rbd
-      config:
-        opensearch.yml: |
-          cluster.name: opencti
-          network.host: 0.0.0.0
-          plugins.security.disabled: true
-      env:
-        OPENSEARCH_JAVA_OPTS: "-Xms2g -Xmx2g"
-
-    # ===================
-    # RabbitMQ
-    # ===================
-    rabbitmq:
-      enabled: true
-      auth:
-        username: user
-        password: ChangeMe
-      persistence:
-        enabled: true
-        size: 10Gi
-        storageClass: ceph-rbd
-      resources:
-        requests:
-          cpu: 250m
-          memory: 1Gi
-        limits:
-          memory: 1Gi
-
-    # ===================
-    # Redis — disable subchart, use external Dragonfly
-    # ===================
-    redis:
-      enabled: false
-
-    # ===================
-    # MinIO — dedicated instance for OpenCTI
-    # ===================
-    minio:
-      enabled: true
-      persistence:
-        enabled: true
-        size: 20Gi
-        storageClass: ceph-rbd
-      resources:
-        requests:
-          cpu: 100m
-          memory: 256Mi
-        limits:
-          memory: 512Mi
-
-    # ===================
-    # ECK Stack — not needed
-    # ===================
-    eck-stack:
-      enabled: false
+        image:
+          repository: opencti/connector-malwarebazaar-recent-additions
+          tag: "6.9.16"
+        env:
+          CONNECTOR_ID: "malwarebazaar-001"
+          CONNECTOR_NAME: "Malware Bazaar Recent Additions"
+          CONNECTOR_SCOPE: "malwarebazaar"
+          CONNECTOR_LOG_LEVEL: "info"
+          CONNECTOR_DURATION_PERIOD: "PT2H"
+          CONNECTOR_CONFIDENCE_LEVEL: "50"
+          MALWAREBAZAAR_RECENT_ADDITIONS_API_URL: "https://mb-api.abuse.ch/api/v1/"
+        envFromSecrets:
+          MALWAREBAZAAR_RECENT_ADDITIONS_API_KEY:
+            name: opencti-secrets
+            key: OPENCTI_MALWAREBAZAAR_API_KEY
+        resources:
+          requests:
+            cpu: 100m
+            memory: 256Mi
+          limits:
+            memory: 512Mi

--- a/kubernetes/flux/meta/repositories/git/helm-opencti.yaml
+++ b/kubernetes/flux/meta/repositories/git/helm-opencti.yaml
@@ -1,0 +1,11 @@
+---
+apiVersion: source.toolkit.fluxcd.io/v1
+kind: GitRepository
+metadata:
+  name: helm-opencti
+  namespace: flux-system
+spec:
+  interval: 30m
+  url: https://github.com/dapperdivers/helm-opencti
+  ref:
+    branch: main

--- a/kubernetes/flux/meta/repositories/git/kustomization.yaml
+++ b/kubernetes/flux/meta/repositories/git/kustomization.yaml
@@ -1,0 +1,5 @@
+---
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+resources:
+  - helm-opencti.yaml

--- a/kubernetes/flux/meta/repositories/kustomization.yaml
+++ b/kubernetes/flux/meta/repositories/kustomization.yaml
@@ -4,3 +4,4 @@ apiVersion: kustomize.config.k8s.io/v1beta1
 kind: Kustomization
 resources:
   - ./helm
+  - ./git


### PR DESCRIPTION
## The Big Switch 🔥

Replace `devops-ia/helm-opencti` with our own chart at `dapperdivers/helm-opencti`.

### Why?
The upstream chart requires manual env override hell for every install. Our chart:
- **Auto-wires** all service URLs from subchart state
- **Single admin token** — auto-propagated to server, workers, connectors
- **External service config blocks** — `externalRedis:`, not raw env vars
- **readyChecker enabled by default** — no more crashloop ordering issues
- **Structured values** — `server:`/`worker:`/`connectors:` hierarchy

### What Changes
- HelmRelease now sources from GitRepository (`dapperdivers/helm-opencti`)
- Values restructured to match our chart's cleaner format
- Added GitRepository source in `flux/meta/repositories/git/`
- All 8 connectors preserved (CISA KEV, CVE, MITRE, EPSS, URLhaus, ThreatFox, AlienVault, MalwareBazaar)
- ExternalSecret unchanged

### ⚠️ Important
This is a chart swap — the Helm release will effectively be recreated. Existing PVCs (OpenSearch, RabbitMQ, MinIO) should persist if `fullnameOverride: opencti` keeps service names consistent. Monitor the rollout.

**Chart repo:** https://github.com/dapperdivers/helm-opencti