### PR TITLE
fix(opencti): use bitnamilegacy/rabbitmq image

### DIFF
--- a/kubernetes/apps/security/opencti/app/helmrelease.yaml
+++ b/kubernetes/apps/security/opencti/app/helmrelease.yaml
@@ -139,6 +139,9 @@ spec:
     # ===================
     rabbitmq:
       enabled: true
+      image:
+        registry: docker.io
+        repository: bitnamilegacy/rabbitmq
       auth:
         username: user
         password: ChangeMe


### PR DESCRIPTION
Bitnami deprecated Docker Hub images in Aug 2025 ([bitnami/charts#35164](https://github.com/bitnami/charts/issues/35164)). `docker.io/bitnami/rabbitmq:4.1.3-debian-12-r1` no longer exists, causing `ImagePullBackOff` on pod restarts/reschedules.

Override to `bitnamilegacy/rabbitmq` which still hosts the archived images.

**Note:** Long-term we should migrate to the official `rabbitmq` image or a different message broker, as `bitnamilegacy` won't receive updates.