### PR TITLE
fix(opencti): allow insecure images for bitnamilegacy rabbitmq

### DIFF
--- a/kubernetes/apps/security/opencti/app/helmrelease.yaml
+++ b/kubernetes/apps/security/opencti/app/helmrelease.yaml
@@ -137,6 +137,10 @@ spec:
     # ===================
     # RabbitMQ subchart
     # ===================
+    global:
+      security:
+        allowInsecureImages: true
+
     rabbitmq:
       enabled: true
       image:


### PR DESCRIPTION
Bitnami chart v16.0.14 has image verification that rejects non-`bitnami/*` registry images. Since we're using `bitnamilegacy/rabbitmq` (because Bitnami removed images from Docker Hub), we need `global.security.allowInsecureImages: true`.

Error was:
```
⚠ ERROR: Original containers have been substituted for unrecognized ones.
Unrecognized images: docker.io/bitnamilegacy/rabbitmq:4.1.3-debian-12-r1
```