### PR TITLE
feat(opencti): upgrade to chart v0.2.0 — native RabbitMQ

### DIFF
--- a/kubernetes/apps/security/opencti/app/helmrelease.yaml
+++ b/kubernetes/apps/security/opencti/app/helmrelease.yaml
@@ -9,7 +9,7 @@ spec:
   chart:
     spec:
       chart: opencti
-      version: 0.1.0
+      version: 0.2.0
       sourceRef:
         kind: HelmRepository
         name: opencti
@@ -137,15 +137,8 @@ spec:
     # ===================
     # RabbitMQ subchart
     # ===================
-    global:
-      security:
-        allowInsecureImages: true
-
     rabbitmq:
       enabled: true
-      image:
-        registry: docker.io
-        repository: bitnamilegacy/rabbitmq
       auth:
         username: user
         password: ChangeMe


### PR DESCRIPTION
Uses our custom chart v0.2.0 which replaces the Bitnami RabbitMQ subchart with native templates using the official `rabbitmq:4.1-management-alpine` image.

No more Bitnami dependency, no more image verification workarounds, no more Docker Hub deprecation issues.

## ⚠️ Pre-merge: Delete old RabbitMQ PVC

```bash
kubectl delete pvc data-opencti-rabbitmq-0 -n security
```

The old Bitnami PVC has incompatible data layout + auth. RabbitMQ is transient for OpenCTI — no data loss.

Then reconcile:
```bash
flux reconcile kustomization security --with-source
```