### PR TITLE
fix(opencti): bump chart to 0.2.1 — OpenSearch service name fix

### DIFF
--- a/kubernetes/apps/security/opencti/app/helmrelease.yaml
+++ b/kubernetes/apps/security/opencti/app/helmrelease.yaml
@@ -9,7 +9,7 @@ spec:
   chart:
     spec:
       chart: opencti
-      version: 0.2.0
+      version: 0.2.1
       sourceRef:
         kind: HelmRepository
         name: opencti


### PR DESCRIPTION
Ready checker was looking for `opencti-opensearch:9200` but the OpenSearch subchart creates `opensearch-cluster-master:9200`. Fixed in chart 0.2.1.