### PR TITLE
fix(opencti): disable OpenSearch sysctl init — PodSecurity violation

### DIFF
--- a/kubernetes/apps/security/opencti/app/helmrelease.yaml
+++ b/kubernetes/apps/security/opencti/app/helmrelease.yaml
@@ -115,6 +115,8 @@ spec:
     opensearch:
       enabled: true
       replicas: 1
+      sysctlInit:
+        enabled: false
       opensearchJavaOpts: "-Xms2g -Xmx2g"
       resources:
         requests:


### PR DESCRIPTION
OpenSearch sysctl init container requires privileged mode, blocked by PodSecurity baseline. Talos nodes already have vm.max_map_count=262144.