### PR TITLE
fix(opencti): chart 0.2.2 — OpenSearch 3.4.0 compat

### DIFF
--- a/kubernetes/apps/security/opencti/app/helmrelease.yaml
+++ b/kubernetes/apps/security/opencti/app/helmrelease.yaml
@@ -9,7 +9,7 @@ spec:
   chart:
     spec:
       chart: opencti
-      version: 0.2.1
+      version: 0.2.2
       sourceRef:
         kind: HelmRepository
         name: opencti


### PR DESCRIPTION
OpenSearch data was created by v3.4.0, chart was shipping v2.18.0. Bump to match.