### PR TITLE
fix(opencti): bump chart to v0.3.0 — OpenCTI 6.9.17

### DIFF
--- a/kubernetes/apps/security/opencti/app/helmrelease.yaml
+++ b/kubernetes/apps/security/opencti/app/helmrelease.yaml
@@ -9,7 +9,7 @@ spec:
   chart:
     spec:
       chart: opencti
-      version: 0.2.2
+      version: 0.3.0
       sourceRef:
         kind: HelmRepository
         name: opencti


### PR DESCRIPTION
OpenCTI 6.4.12 images no longer exist on Docker Hub — server is `ImagePullBackOff`.

Bumps to chart v0.3.0 which sets appVersion to 6.9.17 (latest stable).

**Depends on:** dapperdivers/helm-opencti#4 being merged + CI publishing v0.3.0 to OCI registry first.