### PR TITLE
fix(opencti): chart v0.3.1 — fix MinIO endpoint URL scheme

### DIFF
--- a/kubernetes/apps/security/opencti/app/helmrelease.yaml
+++ b/kubernetes/apps/security/opencti/app/helmrelease.yaml
@@ -9,7 +9,7 @@ spec:
   chart:
     spec:
       chart: opencti
-      version: 0.3.0
+      version: 0.3.1
       sourceRef:
         kind: HelmRepository
         name: opencti


### PR DESCRIPTION
OpenCTI 6.9.x requires http:// on MinIO endpoint. Chart v0.3.1 fixes this.