### PR TITLE
fix(opencti): chart v0.3.2 — fix MinIO endpoint/port

### DIFF
--- a/kubernetes/apps/security/opencti/app/helmrelease.yaml
+++ b/kubernetes/apps/security/opencti/app/helmrelease.yaml
@@ -9,7 +9,7 @@ spec:
   chart:
     spec:
       chart: opencti
-      version: 0.3.1
+      version: 0.3.2
       sourceRef:
         kind: HelmRepository
         name: opencti


### PR DESCRIPTION
Separates MINIO__ENDPOINT (hostname) and MINIO__PORT for OpenCTI 6.9.x compat.