### PR TITLE
fix(opencti): use admin token for connectors temporarily

### DIFF
--- a/kubernetes/apps/security/opencti/app/helmrelease.yaml
+++ b/kubernetes/apps/security/opencti/app/helmrelease.yaml
@@ -44,9 +44,9 @@ spec:
         key: OPENCTI_ADMIN_TOKEN
       basePath: "/"
       healthAccessKey: "opencti-health-check-key"
-      connectorTokenExistingSecret:
-        name: opencti-secrets
-        key: OPENCTI_CONNECTOR_TOKEN
+      # connectorTokenExistingSecret:  # TODO: recreate dedicated connector user, then re-enable
+      #   name: opencti-secrets
+      #   key: OPENCTI_CONNECTOR_TOKEN
       metrics:
         enabled: true
 


### PR DESCRIPTION
Fresh 6.9.17 database has no dedicated connector user. Fall back to admin token until we recreate users via GraphQL.