### PR TITLE
fix(opencti): correct ingress class to 'internal'

### DIFF
--- a/kubernetes/apps/security/opencti/app/helmrelease.yaml
+++ b/kubernetes/apps/security/opencti/app/helmrelease.yaml
@@ -74,7 +74,7 @@ spec:
 
       ingress:
         enabled: true
-        className: internal-nginx
+        className: internal
         annotations:
           cert-manager.io/cluster-issuer: letsencrypt-production
         hosts:


### PR DESCRIPTION
Cluster uses `internal` not `internal-nginx` for the internal ingress controller.