### PR TITLE
feat(opencti): bump helm chart to 0.4.0

### DIFF
--- a/kubernetes/apps/security/opencti/app/helmrelease.yaml
+++ b/kubernetes/apps/security/opencti/app/helmrelease.yaml
@@ -9,7 +9,7 @@ spec:
   chart:
     spec:
       chart: opencti
-      version: 0.3.2
+      version: 0.4.0
       sourceRef:
         kind: HelmRepository
         name: opencti


### PR DESCRIPTION
Bumps opencti helm chart from 0.3.2 to 0.4.0. See https://github.com/dapperdivers/helm-opencti/pull/7 for full changelog.