### PR TITLE
feat: migrate Galahad from OpenClaw to knight-agent

### DIFF
--- a/kubernetes/apps/roundtable/galahad/app/configmap.yaml
+++ b/kubernetes/apps/roundtable/galahad/app/configmap.yaml
@@ -4,68 +4,6 @@ kind: ConfigMap
 metadata:
   name: galahad-config
 data:
-  openclaw.json: |
-    {
-      "auth": {
-        "profiles": {
-          "anthropic:default": {
-            "provider": "anthropic",
-            "mode": "token"
-          }
-        }
-      },
-      "browser": {
-        "enabled": true,
-        "attachOnly": true,
-        "defaultProfile": "sidecar",
-        "profiles": {
-          "sidecar": {
-            "cdpUrl": "http://localhost:9222",
-            "color": "#4285F4"
-          }
-        }
-      },
-      "agents": {
-        "defaults": {
-          "model": {
-            "primary": "anthropic/claude-sonnet-4-5"
-          },
-          "workspace": "/home/node/galahad",
-          "maxConcurrent": 2,
-          "subagents": {
-            "maxConcurrent": 4
-          }
-        },
-        "list": [
-          {
-            "id": "main"
-          }
-        ]
-      },
-      "gateway": {
-        "port": 18789,
-        "mode": "local",
-        "bind": "lan",
-        "controlUi": {
-          "enabled": true,
-          "allowInsecureAuth": true
-        },
-        "auth": {
-          "mode": "token"
-        },
-        "trustedProxies": [
-          "10.0.0.0/8",
-          "172.16.0.0/12",
-          "192.168.0.0/16"
-        ]
-      },
-      "skills": {
-        "load": {
-          "extraDirs": ["/home/node/galahad/skills"]
-        }
-      }
-    }
-
   SOUL.md: |
     # SOUL.md — Sir Galahad, the Security Knight
 
@@ -86,24 +24,29 @@ data:
     - Brief in reports but comprehensive in analysis
 
     ## Communication
-    - You receive tasks via NATS from Tim
-    - You respond via NATS using the nats-comms skill
+    - You receive tasks via NATS JetStream
+    - You respond via NATS — results are published directly
     - You NEVER deliver messages to chat channels
     - You NEVER interact with humans directly
     - Tim is your sole interface to the Round Table
 
     ## How You Work
-    1. Task arrives via NATS → webhook → your session
+    1. Task arrives via NATS JetStream subscription
     2. You read the task, plan your approach
     3. Execute using your skills and tools
     4. Package results as structured JSON
-    5. Send back via `nats-respond.sh` with your findings
+    5. Results are published back to NATS automatically
 
     ## Standards
     - Always include a `summary` field in results
     - Flag severity levels: critical, high, medium, low, info
     - When uncertain, say so — false confidence is a vulnerability
     - Document your reasoning, not just conclusions
+
+  IDENTITY.md: |
+    - **Name:** Sir Galahad
+    - **Emoji:** 🛡️
+    - **Creature:** Security knight of the Round Table
 
   AGENTS.md: |
     # AGENTS.md — Knight Workspace
@@ -112,103 +55,89 @@ data:
 
     ## Every Task
 
-    When you receive a task via NATS (webhook), you MUST:
-    1. Read TOOLS.md for available tools
-    2. Complete the requested work
-    3. **Send results back via NATS** using the nats-comms skill
-
-    Your task message will include a TASK METADATA section with:
-    - `task ID` — unique identifier for this task
-    - `domain` — your domain (e.g., "security")
-
-    ## Responding to Tasks
-
-    Always send results back using:
-    ```bash
-    bash /home/node/galahad/skills/roundtable-arsenal/skills/shared/nats-comms/scripts/nats-respond.sh '<task-id>' '<domain>' '{"summary":"...","details":"..."}'
-    ```
-
-    The payload MUST be valid JSON. Structure your results as:
-    ```json
-    {
-      "summary": "One-line summary of result",
-      "details": "Detailed findings or response",
-      "status": "complete|partial|error"
-    }
-    ```
-
-    Include additional fields as appropriate for the task.
+    When you receive a task:
+    1. Read TOOLS.md for available tools and endpoints
+    2. Check /workspace/skills/ for relevant skills
+    3. Complete the requested work
+    4. Return structured results (the runtime handles NATS publishing)
 
     ## Skills
 
-    Skills are at `/home/node/galahad/skills/roundtable-arsenal/skills/`.
-    Key skills:
-    - `shared/nats-comms/` — NATS communication (REQUIRED for every task)
-    - `security/` — Security-domain tools
+    Skills are auto-discovered from /workspace/skills/:
+    - `shared/` — Base capabilities (web-search, web-fetch, report-generator)
+    - `security/` — Your domain (opencti-intel, threat-briefing, cve-deep-dive, rss-analyzer)
+
+    Each skill has a SKILL.md with instructions and scripts/ with helpers.
+
+    ## Installing Tools
+
+    You can install tools that persist across restarts:
+    - **Python packages:** `pip install --user <package>` (persists on PVC)
+    - **Custom scripts:** Save to `~/.local/bin/` (on PATH, persists)
+    - **Local skills:** Create in /workspace/local-skills/ (agentskills.io format)
 
     ## Memory
 
     - Write daily notes to `memory/YYYY-MM-DD.md`
-    - Files are your continuity between sessions
+    - Update `MEMORY.md` with long-term learnings
+    - Files persist on PVC — they are your continuity
 
     ## Rules
 
     - You serve Tim the Enchanter — he dispatches your tasks
     - You never interact with humans directly
-    - Always respond via NATS, never via chat delivery
+    - Return structured JSON results
     - Document significant findings in memory
 
   TOOLS.md: |
-    # TOOLS.md — Knight Tools
+    # TOOLS.md — Galahad's Toolkit
+
+    ## Pre-installed
+    jq, yq, curl, wget, git, python3, pip, kubectl, gh, nats, rg, tree
 
     ## Web Search (SearXNG)
-
-    Self-hosted search engine. Use this for ALL web searches.
-
     ```bash
-    curl -s "http://searxng.selfhosted.svc.cluster.local:8080/search?q=QUERY&format=json" | python3 -c "
-    import sys, json
-    data = json.load(sys.stdin)
-    for r in data.get('results', [])[:10]:
-        print(f\"### {r.get('title', 'No title')}\")
-        print(f\"URL: {r.get('url', '')}\")
-        print(f\"{r.get('content', 'No snippet')}\")
-        print()
-    "
+    # Quick search
+    bash /workspace/skills/shared/web-search/scripts/search.sh "query here"
+
+    # Direct API
+    curl -s "http://searxng.selfhosted.svc.cluster.local:8080/search?q=QUERY&format=json" | jq '.results[:5]'
     ```
 
-    **Quick one-liner:**
+    ## Web Fetch
     ```bash
-    curl -s "http://searxng.selfhosted.svc.cluster.local:8080/search?q=QUERY+HERE&format=json" | python3 -c "import sys,json;[print(r['title'],r['url']) for r in json.load(sys.stdin).get('results',[])[:5]]"
+    bash /workspace/skills/shared/web-fetch/scripts/fetch.sh "https://example.com"
     ```
 
-    ## NATS Communication
-
-    See skill at `/home/node/galahad/skills/roundtable-arsenal/skills/shared/nats-comms/`
-
-    - **Respond to tasks:** `bash .../nats-comms/scripts/nats-respond.sh <task-id> <domain> '<json>'`
-    - **Bridge info:** `curl -s http://localhost:8080/info`
-    - **Bridge health:** `curl -s http://localhost:8080/healthz`
-
-    ## Fetch Web Pages
-
+    ## OpenCTI
     ```bash
-    curl -sL "URL" | python3 -c "
-    import sys
-    from html.parser import HTMLParser
-    class T(HTMLParser):
-        def __init__(self):
-            super().__init__()
-            self.text = []
-            self.skip = False
-        def handle_starttag(self, tag, _):
-            if tag in ('script','style'): self.skip = True
-        def handle_endtag(self, tag):
-            if tag in ('script','style'): self.skip = False
-        def handle_data(self, data):
-            if not self.skip: self.text.append(data.strip())
-    t = T()
-    t.feed(sys.stdin.read())
-    print('\n'.join(line for line in t.text if line)[:5000])
-    "
+    # Platform stats
+    bash /workspace/skills/security/opencti-intel/scripts/platform-stats.sh
+
+    # Daily briefing data
+    bash /workspace/skills/security/opencti-intel/scripts/daily-brief.sh
+
+    # Custom GraphQL query
+    bash /workspace/skills/security/opencti-intel/scripts/opencti-query.sh '{about{version}}'
+    ```
+
+    Environment: OPENCTI_TOKEN is injected via secret.
+    Endpoint: http://opencti-server.security.svc.cluster.local/graphql
+
+    ## Kubernetes (read-only)
+    ```bash
+    kubectl get pods -n roundtable
+    kubectl get pods -n security
+    ```
+
+    ## GitHub
+    ```bash
+    gh issue list --repo dapperdivers/dapper-cluster
+    gh pr list --repo dapperdivers/roundtable-arsenal
+    ```
+
+    ## NATS (direct queries)
+    ```bash
+    nats -s nats://nats.database.svc:4222 stream ls
+    nats -s nats://nats.database.svc:4222 stream info fleet_a_tasks
     ```

--- a/kubernetes/apps/roundtable/galahad/app/externalsecret.yaml
+++ b/kubernetes/apps/roundtable/galahad/app/externalsecret.yaml
@@ -12,10 +12,7 @@ spec:
     template:
       engineVersion: v2
       data:
-        OPENCLAW_GATEWAY_TOKEN: "{{ .OPENCLAW_GATEWAY_TOKEN }}"
-        CLAWDBOT_GATEWAY_TOKEN: "{{ .OPENCLAW_GATEWAY_TOKEN }}"
         ANTHROPIC_API_KEY: "{{ .OPENCLAW_ANTHROPIC_API_KEY }}"
-        OPENCLAW_HOOK_TOKEN: "{{ .OPENCLAW_GATEWAY_TOKEN }}"
         OPENCTI_TOKEN: "{{ .OPENCTI_ADMIN_TOKEN }}"
   dataFrom:
     - find:

--- a/kubernetes/apps/roundtable/galahad/app/helmrelease.yaml
+++ b/kubernetes/apps/roundtable/galahad/app/helmrelease.yaml
@@ -30,21 +30,21 @@ spec:
           # Only writes files that don't already exist (preserves knight memory).
           seed-workspace:
             image:
-              repository: ghcr.io/openclaw/openclaw
-              tag: 2026.2.6-3@sha256:0ecbdbda258bc82eb3ab7f142dcfbbb2f309f21583489c0eb6a68a6debed1310
+              repository: busybox
+              tag: "1.37"
             command:
               - /bin/sh
               - -c
               - |
                 set -e
-                WORKSPACE=/home/node/galahad
-                CONFIG=/home/node/.openclaw
+                WORKSPACE=/workspace
 
                 # Create directories
-                mkdir -p "$WORKSPACE/memory" "$CONFIG" /home/node/.local/bin
+                mkdir -p "$WORKSPACE/memory" "$WORKSPACE/local-skills"
+                mkdir -p /home/knight/.local/bin
 
-                # Seed workspace files (only if missing — preserves knight edits)
-                for f in SOUL.md AGENTS.md TOOLS.md; do
+                # Seed workspace files from ConfigMap (only if missing)
+                for f in SOUL.md AGENTS.md IDENTITY.md TOOLS.md; do
                   if [ ! -f "$WORKSPACE/$f" ]; then
                     cp "/seed/$f" "$WORKSPACE/$f"
                     echo "Seeded $f"
@@ -53,67 +53,37 @@ spec:
                   fi
                 done
 
-                # Seed openclaw.json (only if missing — token is written at runtime)
-                if [ ! -f "$CONFIG/openclaw.json" ]; then
-                  cp /seed/openclaw.json "$CONFIG/openclaw.json"
-                  echo "Seeded openclaw.json"
-                else
-                  echo "openclaw.json already exists, skipping"
-                fi
-
                 echo "Workspace ready"
         containers:
-          # ── OpenClaw Gateway ────────────────────────────────────────
+          # ── Knight Agent ────────────────────────────────────────────
+          # Lightweight runtime: Claude Agent SDK + native NATS
           app:
             image:
-              repository: ghcr.io/openclaw/openclaw
-              tag: 2026.2.6-3@sha256:0ecbdbda258bc82eb3ab7f142dcfbbb2f309f21583489c0eb6a68a6debed1310
-            command:
-              - /bin/sh
-              - -c
-              - |
-                mkdir -p /home/node/.local/bin
-                ln -sf /app/openclaw.mjs /home/node/.local/bin/openclaw
-                exec node --max-old-space-size=1536 dist/index.js gateway --bind lan --port 18789 --allow-unconfigured
+              repository: ghcr.io/dapperdivers/knight-agent
+              tag: latest
+            env:
+              # Runtime
+              WORKSPACE_DIR: /workspace
+              MODEL: claude-sonnet-4-5-20250514
+              KNIGHT_NAME: Galahad
+              LOG_LEVEL: info
+              PORT: "18789"
+              TZ: America/Chicago
+              # NATS (native — no sidecar needed)
+              NATS_URL: nats://nats.database.svc:4222
+              FLEET_ID: fleet-a
+              AGENT_ID: galahad
+              SUBSCRIBE_TOPICS: "fleet-a.tasks.security.>"
+            envFrom:
+              - secretRef:
+                  name: galahad-secret
             resources:
               requests:
                 cpu: 100m
                 memory: 256Mi
               limits:
-                cpu: 1000m
-                memory: 2Gi
-            env:
-              TZ: America/Chicago
-              HOME: /home/node
-              TERM: xterm-256color
-              PATH: /home/node/.local/bin:/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin
-              BROWSER_WS_ENDPOINT: "ws://localhost:9222"
-            envFrom:
-              - secretRef:
-                  name: galahad-secret
-
-          # ── NATS Bridge Sidecar ─────────────────────────────────────
-          nats-bridge:
-            image:
-              repository: ghcr.io/dapperdivers/nats-bridge
-              tag: 5f9dd27b7b8ee734fccca2448e46659916c0cbde
-            env:
-              NATS_URL: nats://nats.database.svc:4222
-              OPENCLAW_WEBHOOK_URL: http://127.0.0.1:18789/hooks/agent
-              AGENT_ID: galahad
-              FLEET_ID: fleet-a
-              SUBSCRIBE_TOPICS: "fleet-a.tasks.security.>"
-              OPENCLAW_HOOK_TOKEN:
-                valueFrom:
-                  secretKeyRef:
-                    name: galahad-secret
-                    key: OPENCLAW_HOOK_TOKEN
-            resources:
-              requests:
-                cpu: 25m
-                memory: 32Mi
-              limits:
-                memory: 64Mi
+                cpu: "1"
+                memory: 1Gi
             probes:
               liveness:
                 enabled: true
@@ -121,32 +91,21 @@ spec:
                 spec:
                   httpGet:
                     path: /healthz
-                    port: 8080
-                  initialDelaySeconds: 5
+                    port: 18789
+                  initialDelaySeconds: 15
                   periodSeconds: 30
-
-          # ── Chrome Sidecar ──────────────────────────────────────────
-          chrome:
-            image:
-              repository: zenika/alpine-chrome
-              tag: with-node
-            command:
-              - chromium-browser
-              - --headless=new
-              - --disable-gpu
-              - --remote-debugging-address=0.0.0.0
-              - --remote-debugging-port=9222
-              - --no-sandbox
-              - --disable-dev-shm-usage
-            resources:
-              requests:
-                cpu: 50m
-                memory: 128Mi
-              limits:
-                cpu: 500m
-                memory: 512Mi
+              readiness:
+                enabled: true
+                custom: true
+                spec:
+                  httpGet:
+                    path: /readyz
+                    port: 18789
+                  initialDelaySeconds: 10
+                  periodSeconds: 15
 
           # ── Git-Sync Sidecar ────────────────────────────────────────
+          # Pulls skills from arsenal repo (shared + security tiers)
           git-sync:
             image:
               repository: registry.k8s.io/git-sync/git-sync
@@ -164,7 +123,6 @@ spec:
                 memory: 64Mi
 
     defaultPodOptions:
-      shareProcessNamespace: true
       securityContext:
         runAsUser: 1000
         runAsGroup: 1000
@@ -177,8 +135,6 @@ spec:
         ports:
           http:
             port: 18789
-          bridge-health:
-            port: 8080
 
     ingress:
       app:
@@ -199,15 +155,19 @@ spec:
 
     persistence:
       # Knight workspace (persistent across restarts)
-      config:
+      data:
         enabled: true
         existingClaim: galahad
         advancedMounts:
           galahad:
             seed-workspace:
-              - path: /home/node
+              - path: /workspace
+              - path: /home/knight
+                subPath: home
             app:
-              - path: /home/node
+              - path: /workspace
+              - path: /home/knight
+                subPath: home
 
       # ConfigMap with workspace seed files
       seed:
@@ -227,7 +187,7 @@ spec:
         advancedMounts:
           galahad:
             app:
-              - path: /home/node/galahad/skills
+              - path: /workspace/skills
                 readOnly: true
             git-sync:
               - path: /skills


### PR DESCRIPTION
## The Moment of Truth 🔥

Migrate Galahad from full OpenClaw gateway to lightweight knight-agent runtime.

### Before → After

| | OpenClaw | knight-agent |
|---|---|---|
| **Containers** | 4 (app + nats-bridge + chrome + git-sync) | 2 (app + git-sync) |
| **Memory** | 256Mi-2Gi | 256Mi-1Gi |
| **Image** | ~1.5GB (OpenClaw) | ~600MB (knight-agent) |
| **NATS** | HTTP sidecar bridge | Native nats.js client |
| **Tools** | No jq, no kubectl | jq, yq, kubectl, gh, nats, python3, rg |
| **Skills** | OpenClaw skill loading | agentskills.io standard |
| **Self-extending** | No | pip install, local-skills, custom scripts |

### Changes
- ghcr.io/dapperdivers/knight-agent:latest replaces OpenClaw image
- Native NATS JetStream subscription (no nats-bridge sidecar)
- Chrome sidecar removed
- ServiceAccount + scoped RBAC (read-only roundtable + security namespaces)
- ConfigMap updated: IDENTITY.md added, openclaw.json removed
- AGENTS.md/TOOLS.md rewritten for knight-agent runtime
- ExternalSecret simplified (only ANTHROPIC_API_KEY + OPENCTI_TOKEN)

### Repos
- Runtime: https://github.com/dapperdivers/knight-agent
- Skills: https://github.com/dapperdivers/roundtable-arsenal