### PR TITLE
feat(roundtable): Enable Percival in namespace kustomization

### DIFF
--- a/kubernetes/apps/roundtable/kustomization.yaml
+++ b/kubernetes/apps/roundtable/kustomization.yaml
@@ -8,3 +8,4 @@ components:
 resources:
   - ./rbac/ks.yaml
   - ./galahad/ks.yaml
+  - ./percival/ks.yaml


### PR DESCRIPTION
Adds percival/ks.yaml to the roundtable namespace kustomization so Flux picks up the deployment.