### PR TITLE
fix(roundtable): Pin knight-agent to fb5f071 (hardened runtime)

### DIFF
--- a/kubernetes/apps/roundtable/galahad/app/helmrelease.yaml
+++ b/kubernetes/apps/roundtable/galahad/app/helmrelease.yaml
@@ -60,7 +60,7 @@ spec:
           app:
             image:
               repository: ghcr.io/dapperdivers/knight-agent
-              tag: latest
+              tag: fb5f071
               pullPolicy: Always
             env:
               # ── Runtime ──

--- a/kubernetes/apps/roundtable/percival/app/helmrelease.yaml
+++ b/kubernetes/apps/roundtable/percival/app/helmrelease.yaml
@@ -49,7 +49,7 @@ spec:
           app:
             image:
               repository: ghcr.io/dapperdivers/knight-agent
-              tag: latest
+              tag: fb5f071
               pullPolicy: Always
             env:
               WORKSPACE_DIR: /workspace


### PR DESCRIPTION
Pin both Galahad and Percival to SHA tag `fb5f071` instead of `:latest`.

The `:latest` tag has stale compiled output missing `fixOAuthEnv()` — the function that routes OAuth tokens correctly for Claude Code CLI. The `fb5f071` image is verified working (Percival's first successful task: 18s, $0.07).

This also aligns with our decision to pin to SHA tags for control.