### PR TITLE
feat(roundtable): Knight infrastructure — Bedivere HA token + Tristan RBAC

### DIFF
--- a/kubernetes/apps/roundtable/bedivere/app/externalsecret.yaml
+++ b/kubernetes/apps/roundtable/bedivere/app/externalsecret.yaml
@@ -13,7 +13,11 @@ spec:
       engineVersion: v2
       data:
         ANTHROPIC_API_KEY: "{{ .OPENCLAW_ANTHROPIC_API_KEY }}"
+        HOMEASSISTANT_TOKEN: "{{ .MOLT_HOMEASSISTANT_TOKEN }}"
   dataFrom:
     - find:
         name:
           regexp: ^OPENCLAW.*
+    - find:
+        name:
+          regexp: ^MOLT_HOMEASSISTANT_TOKEN$

--- a/kubernetes/apps/roundtable/rbac/app/rbac.yaml
+++ b/kubernetes/apps/roundtable/rbac/app/rbac.yaml
@@ -32,3 +32,47 @@ roleRef:
   kind: Role
   name: molt-roundtable-access
   apiGroup: rbac.authorization.k8s.io
+---
+# Tristan — Cluster-wide read access for infrastructure monitoring
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRole
+metadata:
+  name: tristan-cluster-reader
+rules:
+  - apiGroups: [""]
+    resources: ["pods", "pods/log", "services", "configmaps", "events", "nodes", "namespaces", "persistentvolumeclaims"]
+    verbs: ["get", "list", "watch"]
+  - apiGroups: ["apps"]
+    resources: ["deployments", "replicasets", "statefulsets", "daemonsets"]
+    verbs: ["get", "list", "watch"]
+  - apiGroups: ["batch"]
+    resources: ["jobs", "cronjobs"]
+    verbs: ["get", "list", "watch"]
+  - apiGroups: ["kustomize.toolkit.fluxcd.io"]
+    resources: ["kustomizations"]
+    verbs: ["get", "list", "watch"]
+  - apiGroups: ["helm.toolkit.fluxcd.io"]
+    resources: ["helmreleases"]
+    verbs: ["get", "list", "watch"]
+  - apiGroups: ["source.toolkit.fluxcd.io"]
+    resources: ["gitrepositories", "helmrepositories", "ocirepositories", "helmcharts"]
+    verbs: ["get", "list", "watch"]
+  - apiGroups: ["networking.k8s.io"]
+    resources: ["ingresses"]
+    verbs: ["get", "list", "watch"]
+  - apiGroups: ["metrics.k8s.io"]
+    resources: ["nodes", "pods"]
+    verbs: ["get", "list"]
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRoleBinding
+metadata:
+  name: tristan-cluster-reader
+subjects:
+  - kind: ServiceAccount
+    name: default
+    namespace: roundtable
+roleRef:
+  kind: ClusterRole
+  name: tristan-cluster-reader
+  apiGroup: rbac.authorization.k8s.io


### PR DESCRIPTION
### Bedivere 🏠
- ExternalSecret updated to include `HOMEASSISTANT_TOKEN` (reuses `MOLT_HOMEASSISTANT_TOKEN` from Infisical — same token Tim uses)

### Tristan 🏗️  
- ClusterRole `tristan-cluster-reader` with read-only access to:
  - Core: pods, logs, services, configmaps, events, nodes, namespaces, PVCs
  - Workloads: deployments, replicasets, statefulsets, daemonsets
  - Batch: jobs, cronjobs
  - Flux: kustomizations, helmreleases, sources
  - Networking: ingresses
  - Metrics: node/pod metrics
- ClusterRoleBinding binds to `default` SA in `roundtable` namespace
- Note: All roundtable knights get read access. Only Tristan is expected to use it.