### PR TITLE
fix(roundtable): Update knight-agent to 56c9702 — recursive skill discovery

### DIFF
--- a/kubernetes/apps/roundtable/bedivere/app/helmrelease.yaml
+++ b/kubernetes/apps/roundtable/bedivere/app/helmrelease.yaml
@@ -50,7 +50,7 @@ spec:
           app:
             image:
               repository: ghcr.io/dapperdivers/knight-agent
-              tag: fb5f071
+              tag: 56c9702
               pullPolicy: Always
             env:
               WORKSPACE_DIR: /workspace

--- a/kubernetes/apps/roundtable/galahad/app/helmrelease.yaml
+++ b/kubernetes/apps/roundtable/galahad/app/helmrelease.yaml
@@ -60,7 +60,7 @@ spec:
           app:
             image:
               repository: ghcr.io/dapperdivers/knight-agent
-              tag: fb5f071
+              tag: 56c9702
               pullPolicy: Always
             env:
               # ── Runtime ──

--- a/kubernetes/apps/roundtable/kay/app/helmrelease.yaml
+++ b/kubernetes/apps/roundtable/kay/app/helmrelease.yaml
@@ -50,7 +50,7 @@ spec:
           app:
             image:
               repository: ghcr.io/dapperdivers/knight-agent
-              tag: fb5f071
+              tag: 56c9702
               pullPolicy: Always
             env:
               WORKSPACE_DIR: /workspace

--- a/kubernetes/apps/roundtable/lancelot/app/helmrelease.yaml
+++ b/kubernetes/apps/roundtable/lancelot/app/helmrelease.yaml
@@ -50,7 +50,7 @@ spec:
           app:
             image:
               repository: ghcr.io/dapperdivers/knight-agent
-              tag: fb5f071
+              tag: 56c9702
               pullPolicy: Always
             env:
               WORKSPACE_DIR: /workspace

--- a/kubernetes/apps/roundtable/percival/app/helmrelease.yaml
+++ b/kubernetes/apps/roundtable/percival/app/helmrelease.yaml
@@ -49,7 +49,7 @@ spec:
           app:
             image:
               repository: ghcr.io/dapperdivers/knight-agent
-              tag: fb5f071
+              tag: 56c9702
               pullPolicy: Always
             env:
               WORKSPACE_DIR: /workspace

--- a/kubernetes/apps/roundtable/tristan/app/helmrelease.yaml
+++ b/kubernetes/apps/roundtable/tristan/app/helmrelease.yaml
@@ -50,7 +50,7 @@ spec:
           app:
             image:
               repository: ghcr.io/dapperdivers/knight-agent
-              tag: fb5f071
+              tag: 56c9702
               pullPolicy: Always
             env:
               WORKSPACE_DIR: /workspace


### PR DESCRIPTION
Updates all 6 knights to image `56c9702` which fixes skill discovery for git-sync nested paths. Previously `skillsAvailable: 0` because skills were at depth 3 but scanner only checked depth 1.