### PR TITLE
feat(roundtable): Skill-linker — per-knight skill injection from arsenal

### DIFF
--- a/kubernetes/apps/roundtable/bedivere/app/helmrelease.yaml
+++ b/kubernetes/apps/roundtable/bedivere/app/helmrelease.yaml
@@ -46,11 +46,58 @@ spec:
                   fi
                 done
                 echo "Workspace ready"
+          # ── Skill Linker ─────────────────────────────────────────
+          # Links relevant skills from arsenal repo into flat /workspace/skills/
+          skill-linker:
+            image:
+              repository: alpine/git
+              tag: "2.47.2"
+            command:
+              - /bin/sh
+              - -c
+              - |
+                set -e
+                REPO_DIR="/skills-repo/roundtable-arsenal"
+                TARGET="/workspace/skills"
+
+                # Bootstrap: clone if git-sync hasn't populated yet
+                if [ ! -d "$REPO_DIR" ]; then
+                  echo "Bootstrapping arsenal repo..."
+                  git clone --depth 1 --branch main \
+                    https://github.com/dapperdivers/roundtable-arsenal.git \
+                    "$REPO_DIR"
+                fi
+
+                # Create flat skill directory
+                rm -rf "$TARGET"
+                mkdir -p "$TARGET"
+
+                # Link shared skills (all knights)
+                for skill in "$REPO_DIR"/shared/*/; do
+                  [ -d "$skill" ] || continue
+                  name=$(basename "$skill")
+                  ln -sfn "$skill" "$TARGET/$name"
+                  echo "Linked shared/$name"
+                done
+
+                # Link domain skills
+                for category in $KNIGHT_SKILLS; do
+                  for skill in "$REPO_DIR"/$category/*/; do
+                    [ -d "$skill" ] || continue
+                    name=$(basename "$skill")
+                    ln -sfn "$skill" "$TARGET/$name"
+                    echo "Linked $category/$name"
+                  done
+                done
+
+                echo "Skills linked: $(ls "$TARGET" | wc -l) total"
+            env:
+              KNIGHT_SKILLS: "home"
         containers:
           app:
             image:
               repository: ghcr.io/dapperdivers/knight-agent
-              tag: 56c9702
+              tag: efc00b1
               pullPolicy: Always
             env:
               WORKSPACE_DIR: /workspace
@@ -110,7 +157,7 @@ spec:
             env:
               GITSYNC_REPO: https://github.com/dapperdivers/roundtable-arsenal
               GITSYNC_REF: main
-              GITSYNC_ROOT: /skills
+              GITSYNC_ROOT: /skills-repo
               GITSYNC_PERIOD: "300s"
             resources:
               requests:
@@ -156,6 +203,8 @@ spec:
               - path: /workspace
               - path: /home/knight
                 subPath: home
+            skill-linker:
+              - path: /workspace
             app:
               - path: /workspace
               - path: /home/knight
@@ -174,8 +223,11 @@ spec:
         type: emptyDir
         advancedMounts:
           bedivere:
+            skill-linker:
+              - path: /skills-repo
             app:
               - path: /workspace/skills
+              - path: /skills-repo
                 readOnly: true
             git-sync:
-              - path: /skills
+              - path: /skills-repo

--- a/kubernetes/apps/roundtable/galahad/app/helmrelease.yaml
+++ b/kubernetes/apps/roundtable/galahad/app/helmrelease.yaml
@@ -54,13 +54,60 @@ spec:
                 done
 
                 echo "Workspace ready"
+          # ── Skill Linker ─────────────────────────────────────────
+          # Links relevant skills from arsenal repo into flat /workspace/skills/
+          skill-linker:
+            image:
+              repository: alpine/git
+              tag: "2.47.2"
+            command:
+              - /bin/sh
+              - -c
+              - |
+                set -e
+                REPO_DIR="/skills-repo/roundtable-arsenal"
+                TARGET="/workspace/skills"
+
+                # Bootstrap: clone if git-sync hasn't populated yet
+                if [ ! -d "$REPO_DIR" ]; then
+                  echo "Bootstrapping arsenal repo..."
+                  git clone --depth 1 --branch main \
+                    https://github.com/dapperdivers/roundtable-arsenal.git \
+                    "$REPO_DIR"
+                fi
+
+                # Create flat skill directory
+                rm -rf "$TARGET"
+                mkdir -p "$TARGET"
+
+                # Link shared skills (all knights)
+                for skill in "$REPO_DIR"/shared/*/; do
+                  [ -d "$skill" ] || continue
+                  name=$(basename "$skill")
+                  ln -sfn "$skill" "$TARGET/$name"
+                  echo "Linked shared/$name"
+                done
+
+                # Link domain skills
+                for category in $KNIGHT_SKILLS; do
+                  for skill in "$REPO_DIR"/$category/*/; do
+                    [ -d "$skill" ] || continue
+                    name=$(basename "$skill")
+                    ln -sfn "$skill" "$TARGET/$name"
+                    echo "Linked $category/$name"
+                  done
+                done
+
+                echo "Skills linked: $(ls "$TARGET" | wc -l) total"
+            env:
+              KNIGHT_SKILLS: "security"
         containers:
           # ── Knight Agent ────────────────────────────────────────────
           # Lightweight runtime: Claude Agent SDK + native NATS
           app:
             image:
               repository: ghcr.io/dapperdivers/knight-agent
-              tag: 56c9702
+              tag: efc00b1
               pullPolicy: Always
             env:
               # ── Runtime ──
@@ -128,7 +175,7 @@ spec:
             env:
               GITSYNC_REPO: https://github.com/dapperdivers/roundtable-arsenal
               GITSYNC_REF: main
-              GITSYNC_ROOT: /skills
+              GITSYNC_ROOT: /skills-repo
               GITSYNC_PERIOD: "300s"
             resources:
               requests:
@@ -179,6 +226,8 @@ spec:
               - path: /workspace
               - path: /home/knight
                 subPath: home
+            skill-linker:
+              - path: /workspace
             app:
               - path: /workspace
               - path: /home/knight
@@ -201,8 +250,11 @@ spec:
         type: emptyDir
         advancedMounts:
           galahad:
+            skill-linker:
+              - path: /skills-repo
             app:
               - path: /workspace/skills
+              - path: /skills-repo
                 readOnly: true
             git-sync:
-              - path: /skills
+              - path: /skills-repo

--- a/kubernetes/apps/roundtable/kay/app/helmrelease.yaml
+++ b/kubernetes/apps/roundtable/kay/app/helmrelease.yaml
@@ -46,11 +46,58 @@ spec:
                   fi
                 done
                 echo "Workspace ready"
+          # ── Skill Linker ─────────────────────────────────────────
+          # Links relevant skills from arsenal repo into flat /workspace/skills/
+          skill-linker:
+            image:
+              repository: alpine/git
+              tag: "2.47.2"
+            command:
+              - /bin/sh
+              - -c
+              - |
+                set -e
+                REPO_DIR="/skills-repo/roundtable-arsenal"
+                TARGET="/workspace/skills"
+
+                # Bootstrap: clone if git-sync hasn't populated yet
+                if [ ! -d "$REPO_DIR" ]; then
+                  echo "Bootstrapping arsenal repo..."
+                  git clone --depth 1 --branch main \
+                    https://github.com/dapperdivers/roundtable-arsenal.git \
+                    "$REPO_DIR"
+                fi
+
+                # Create flat skill directory
+                rm -rf "$TARGET"
+                mkdir -p "$TARGET"
+
+                # Link shared skills (all knights)
+                for skill in "$REPO_DIR"/shared/*/; do
+                  [ -d "$skill" ] || continue
+                  name=$(basename "$skill")
+                  ln -sfn "$skill" "$TARGET/$name"
+                  echo "Linked shared/$name"
+                done
+
+                # Link domain skills
+                for category in $KNIGHT_SKILLS; do
+                  for skill in "$REPO_DIR"/$category/*/; do
+                    [ -d "$skill" ] || continue
+                    name=$(basename "$skill")
+                    ln -sfn "$skill" "$TARGET/$name"
+                    echo "Linked $category/$name"
+                  done
+                done
+
+                echo "Skills linked: $(ls "$TARGET" | wc -l) total"
+            env:
+              KNIGHT_SKILLS: "research intel"
         containers:
           app:
             image:
               repository: ghcr.io/dapperdivers/knight-agent
-              tag: 56c9702
+              tag: efc00b1
               pullPolicy: Always
             env:
               WORKSPACE_DIR: /workspace
@@ -110,7 +157,7 @@ spec:
             env:
               GITSYNC_REPO: https://github.com/dapperdivers/roundtable-arsenal
               GITSYNC_REF: main
-              GITSYNC_ROOT: /skills
+              GITSYNC_ROOT: /skills-repo
               GITSYNC_PERIOD: "300s"
             resources:
               requests:
@@ -156,6 +203,8 @@ spec:
               - path: /workspace
               - path: /home/knight
                 subPath: home
+            skill-linker:
+              - path: /workspace
             app:
               - path: /workspace
               - path: /home/knight
@@ -174,8 +223,11 @@ spec:
         type: emptyDir
         advancedMounts:
           kay:
+            skill-linker:
+              - path: /skills-repo
             app:
               - path: /workspace/skills
+              - path: /skills-repo
                 readOnly: true
             git-sync:
-              - path: /skills
+              - path: /skills-repo

--- a/kubernetes/apps/roundtable/lancelot/app/helmrelease.yaml
+++ b/kubernetes/apps/roundtable/lancelot/app/helmrelease.yaml
@@ -46,11 +46,58 @@ spec:
                   fi
                 done
                 echo "Workspace ready"
+          # ── Skill Linker ─────────────────────────────────────────
+          # Links relevant skills from arsenal repo into flat /workspace/skills/
+          skill-linker:
+            image:
+              repository: alpine/git
+              tag: "2.47.2"
+            command:
+              - /bin/sh
+              - -c
+              - |
+                set -e
+                REPO_DIR="/skills-repo/roundtable-arsenal"
+                TARGET="/workspace/skills"
+
+                # Bootstrap: clone if git-sync hasn't populated yet
+                if [ ! -d "$REPO_DIR" ]; then
+                  echo "Bootstrapping arsenal repo..."
+                  git clone --depth 1 --branch main \
+                    https://github.com/dapperdivers/roundtable-arsenal.git \
+                    "$REPO_DIR"
+                fi
+
+                # Create flat skill directory
+                rm -rf "$TARGET"
+                mkdir -p "$TARGET"
+
+                # Link shared skills (all knights)
+                for skill in "$REPO_DIR"/shared/*/; do
+                  [ -d "$skill" ] || continue
+                  name=$(basename "$skill")
+                  ln -sfn "$skill" "$TARGET/$name"
+                  echo "Linked shared/$name"
+                done
+
+                # Link domain skills
+                for category in $KNIGHT_SKILLS; do
+                  for skill in "$REPO_DIR"/$category/*/; do
+                    [ -d "$skill" ] || continue
+                    name=$(basename "$skill")
+                    ln -sfn "$skill" "$TARGET/$name"
+                    echo "Linked $category/$name"
+                  done
+                done
+
+                echo "Skills linked: $(ls "$TARGET" | wc -l) total"
+            env:
+              KNIGHT_SKILLS: "career"
         containers:
           app:
             image:
               repository: ghcr.io/dapperdivers/knight-agent
-              tag: 56c9702
+              tag: efc00b1
               pullPolicy: Always
             env:
               WORKSPACE_DIR: /workspace
@@ -110,7 +157,7 @@ spec:
             env:
               GITSYNC_REPO: https://github.com/dapperdivers/roundtable-arsenal
               GITSYNC_REF: main
-              GITSYNC_ROOT: /skills
+              GITSYNC_ROOT: /skills-repo
               GITSYNC_PERIOD: "300s"
             resources:
               requests:
@@ -156,6 +203,8 @@ spec:
               - path: /workspace
               - path: /home/knight
                 subPath: home
+            skill-linker:
+              - path: /workspace
             app:
               - path: /workspace
               - path: /home/knight
@@ -174,8 +223,11 @@ spec:
         type: emptyDir
         advancedMounts:
           lancelot:
+            skill-linker:
+              - path: /skills-repo
             app:
               - path: /workspace/skills
+              - path: /skills-repo
                 readOnly: true
             git-sync:
-              - path: /skills
+              - path: /skills-repo

--- a/kubernetes/apps/roundtable/percival/app/helmrelease.yaml
+++ b/kubernetes/apps/roundtable/percival/app/helmrelease.yaml
@@ -45,11 +45,58 @@ spec:
                   fi
                 done
                 echo "Workspace ready"
+          # ── Skill Linker ─────────────────────────────────────────
+          # Links relevant skills from arsenal repo into flat /workspace/skills/
+          skill-linker:
+            image:
+              repository: alpine/git
+              tag: "2.47.2"
+            command:
+              - /bin/sh
+              - -c
+              - |
+                set -e
+                REPO_DIR="/skills-repo/roundtable-arsenal"
+                TARGET="/workspace/skills"
+
+                # Bootstrap: clone if git-sync hasn't populated yet
+                if [ ! -d "$REPO_DIR" ]; then
+                  echo "Bootstrapping arsenal repo..."
+                  git clone --depth 1 --branch main \
+                    https://github.com/dapperdivers/roundtable-arsenal.git \
+                    "$REPO_DIR"
+                fi
+
+                # Create flat skill directory
+                rm -rf "$TARGET"
+                mkdir -p "$TARGET"
+
+                # Link shared skills (all knights)
+                for skill in "$REPO_DIR"/shared/*/; do
+                  [ -d "$skill" ] || continue
+                  name=$(basename "$skill")
+                  ln -sfn "$skill" "$TARGET/$name"
+                  echo "Linked shared/$name"
+                done
+
+                # Link domain skills
+                for category in $KNIGHT_SKILLS; do
+                  for skill in "$REPO_DIR"/$category/*/; do
+                    [ -d "$skill" ] || continue
+                    name=$(basename "$skill")
+                    ln -sfn "$skill" "$TARGET/$name"
+                    echo "Linked $category/$name"
+                  done
+                done
+
+                echo "Skills linked: $(ls "$TARGET" | wc -l) total"
+            env:
+              KNIGHT_SKILLS: "finance"
         containers:
           app:
             image:
               repository: ghcr.io/dapperdivers/knight-agent
-              tag: 56c9702
+              tag: efc00b1
               pullPolicy: Always
             env:
               WORKSPACE_DIR: /workspace
@@ -109,7 +156,7 @@ spec:
             env:
               GITSYNC_REPO: https://github.com/dapperdivers/roundtable-arsenal
               GITSYNC_REF: main
-              GITSYNC_ROOT: /skills
+              GITSYNC_ROOT: /skills-repo
               GITSYNC_PERIOD: "300s"
             resources:
               requests:
@@ -155,6 +202,8 @@ spec:
               - path: /workspace
               - path: /home/knight
                 subPath: home
+            skill-linker:
+              - path: /workspace
             app:
               - path: /workspace
               - path: /home/knight
@@ -173,8 +222,11 @@ spec:
         type: emptyDir
         advancedMounts:
           percival:
+            skill-linker:
+              - path: /skills-repo
             app:
               - path: /workspace/skills
+              - path: /skills-repo
                 readOnly: true
             git-sync:
-              - path: /skills
+              - path: /skills-repo

--- a/kubernetes/apps/roundtable/tristan/app/helmrelease.yaml
+++ b/kubernetes/apps/roundtable/tristan/app/helmrelease.yaml
@@ -46,11 +46,58 @@ spec:
                   fi
                 done
                 echo "Workspace ready"
+          # ── Skill Linker ─────────────────────────────────────────
+          # Links relevant skills from arsenal repo into flat /workspace/skills/
+          skill-linker:
+            image:
+              repository: alpine/git
+              tag: "2.47.2"
+            command:
+              - /bin/sh
+              - -c
+              - |
+                set -e
+                REPO_DIR="/skills-repo/roundtable-arsenal"
+                TARGET="/workspace/skills"
+
+                # Bootstrap: clone if git-sync hasn't populated yet
+                if [ ! -d "$REPO_DIR" ]; then
+                  echo "Bootstrapping arsenal repo..."
+                  git clone --depth 1 --branch main \
+                    https://github.com/dapperdivers/roundtable-arsenal.git \
+                    "$REPO_DIR"
+                fi
+
+                # Create flat skill directory
+                rm -rf "$TARGET"
+                mkdir -p "$TARGET"
+
+                # Link shared skills (all knights)
+                for skill in "$REPO_DIR"/shared/*/; do
+                  [ -d "$skill" ] || continue
+                  name=$(basename "$skill")
+                  ln -sfn "$skill" "$TARGET/$name"
+                  echo "Linked shared/$name"
+                done
+
+                # Link domain skills
+                for category in $KNIGHT_SKILLS; do
+                  for skill in "$REPO_DIR"/$category/*/; do
+                    [ -d "$skill" ] || continue
+                    name=$(basename "$skill")
+                    ln -sfn "$skill" "$TARGET/$name"
+                    echo "Linked $category/$name"
+                  done
+                done
+
+                echo "Skills linked: $(ls "$TARGET" | wc -l) total"
+            env:
+              KNIGHT_SKILLS: "infra"
         containers:
           app:
             image:
               repository: ghcr.io/dapperdivers/knight-agent
-              tag: 56c9702
+              tag: efc00b1
               pullPolicy: Always
             env:
               WORKSPACE_DIR: /workspace
@@ -110,7 +157,7 @@ spec:
             env:
               GITSYNC_REPO: https://github.com/dapperdivers/roundtable-arsenal
               GITSYNC_REF: main
-              GITSYNC_ROOT: /skills
+              GITSYNC_ROOT: /skills-repo
               GITSYNC_PERIOD: "300s"
             resources:
               requests:
@@ -156,6 +203,8 @@ spec:
               - path: /workspace
               - path: /home/knight
                 subPath: home
+            skill-linker:
+              - path: /workspace
             app:
               - path: /workspace
               - path: /home/knight
@@ -174,8 +223,11 @@ spec:
         type: emptyDir
         advancedMounts:
           tristan:
+            skill-linker:
+              - path: /skills-repo
             app:
               - path: /workspace/skills
+              - path: /skills-repo
                 readOnly: true
             git-sync:
-              - path: /skills
+              - path: /skills-repo


### PR DESCRIPTION
### What
Each knight gets a `skill-linker` initContainer that symlinks the right skills from the arsenal into a flat `/workspace/skills/` directory.

### Why
- Arsenal repo has nested category structure (`shared/`, `security/`, etc.)
- Git-sync creates a worktree symlink one level deeper
- Knight-agent's flat skill scanner couldn't find anything (`skillsAvailable: 0`)
- Rather than making the scanner recursive, we inject the right skills at deployment time

### How
1. `skill-linker` initContainer bootstraps repo via `git clone` (before git-sync starts)
2. Symlinks `shared/*` skills for all knights
3. Symlinks domain-specific skills based on `KNIGHT_SKILLS` env var
4. Git-sync sidecar keeps the repo updated after boot

### Per-knight skills
| Knight | KNIGHT_SKILLS | Gets |
|--------|--------------|------|
| 🛡️ Galahad | `security` | shared + security (7 + 4 skills) |
| 📋 Percival | `finance` | shared + finance (7 + 2 skills) |
| ⚔️ Lancelot | `career` | shared + career (7 + 2 skills) |
| 🏗️ Tristan | `infra` | shared + infra (7 + 1 skills) |
| 🏠 Bedivere | `home` | shared + home (7 + 1 skills) |
| 📡 Kay | `research intel` | shared + research + intel (7 + 1 + 3 skills) |

Also updates image to `efc00b1` (reverted to flat scanner).