### PR TITLE
fix(roundtable): Split skill volumes — git-sync was overwriting symlinks

### DIFF
--- a/kubernetes/apps/roundtable/bedivere/app/helmrelease.yaml
+++ b/kubernetes/apps/roundtable/bedivere/app/helmrelease.yaml
@@ -218,7 +218,8 @@ spec:
             seed-workspace:
               - path: /seed
                 readOnly: true
-      skills:
+      # Raw arsenal repo (git-sync populates, skill-linker reads)
+      skills-repo:
         enabled: true
         type: emptyDir
         advancedMounts:
@@ -226,8 +227,19 @@ spec:
             skill-linker:
               - path: /skills-repo
             app:
-              - path: /workspace/skills
               - path: /skills-repo
                 readOnly: true
             git-sync:
               - path: /skills-repo
+
+      # Flat skill symlinks (skill-linker creates, app reads)
+      skills:
+        enabled: true
+        type: emptyDir
+        advancedMounts:
+          bedivere:
+            skill-linker:
+              - path: /workspace/skills
+            app:
+              - path: /workspace/skills
+                readOnly: true

--- a/kubernetes/apps/roundtable/galahad/app/helmrelease.yaml
+++ b/kubernetes/apps/roundtable/galahad/app/helmrelease.yaml
@@ -244,8 +244,8 @@ spec:
               - path: /seed
                 readOnly: true
 
-      # Git-synced skills from arsenal repo
-      skills:
+      # Raw arsenal repo (git-sync populates, skill-linker reads)
+      skills-repo:
         enabled: true
         type: emptyDir
         advancedMounts:
@@ -253,8 +253,19 @@ spec:
             skill-linker:
               - path: /skills-repo
             app:
-              - path: /workspace/skills
               - path: /skills-repo
                 readOnly: true
             git-sync:
               - path: /skills-repo
+
+      # Flat skill symlinks (skill-linker creates, app reads)
+      skills:
+        enabled: true
+        type: emptyDir
+        advancedMounts:
+          galahad:
+            skill-linker:
+              - path: /workspace/skills
+            app:
+              - path: /workspace/skills
+                readOnly: true

--- a/kubernetes/apps/roundtable/kay/app/helmrelease.yaml
+++ b/kubernetes/apps/roundtable/kay/app/helmrelease.yaml
@@ -218,7 +218,8 @@ spec:
             seed-workspace:
               - path: /seed
                 readOnly: true
-      skills:
+      # Raw arsenal repo (git-sync populates, skill-linker reads)
+      skills-repo:
         enabled: true
         type: emptyDir
         advancedMounts:
@@ -226,8 +227,19 @@ spec:
             skill-linker:
               - path: /skills-repo
             app:
-              - path: /workspace/skills
               - path: /skills-repo
                 readOnly: true
             git-sync:
               - path: /skills-repo
+
+      # Flat skill symlinks (skill-linker creates, app reads)
+      skills:
+        enabled: true
+        type: emptyDir
+        advancedMounts:
+          kay:
+            skill-linker:
+              - path: /workspace/skills
+            app:
+              - path: /workspace/skills
+                readOnly: true

--- a/kubernetes/apps/roundtable/lancelot/app/helmrelease.yaml
+++ b/kubernetes/apps/roundtable/lancelot/app/helmrelease.yaml
@@ -218,7 +218,8 @@ spec:
             seed-workspace:
               - path: /seed
                 readOnly: true
-      skills:
+      # Raw arsenal repo (git-sync populates, skill-linker reads)
+      skills-repo:
         enabled: true
         type: emptyDir
         advancedMounts:
@@ -226,8 +227,19 @@ spec:
             skill-linker:
               - path: /skills-repo
             app:
-              - path: /workspace/skills
               - path: /skills-repo
                 readOnly: true
             git-sync:
               - path: /skills-repo
+
+      # Flat skill symlinks (skill-linker creates, app reads)
+      skills:
+        enabled: true
+        type: emptyDir
+        advancedMounts:
+          lancelot:
+            skill-linker:
+              - path: /workspace/skills
+            app:
+              - path: /workspace/skills
+                readOnly: true

--- a/kubernetes/apps/roundtable/percival/app/helmrelease.yaml
+++ b/kubernetes/apps/roundtable/percival/app/helmrelease.yaml
@@ -217,7 +217,8 @@ spec:
             seed-workspace:
               - path: /seed
                 readOnly: true
-      skills:
+      # Raw arsenal repo (git-sync populates, skill-linker reads)
+      skills-repo:
         enabled: true
         type: emptyDir
         advancedMounts:
@@ -225,8 +226,19 @@ spec:
             skill-linker:
               - path: /skills-repo
             app:
-              - path: /workspace/skills
               - path: /skills-repo
                 readOnly: true
             git-sync:
               - path: /skills-repo
+
+      # Flat skill symlinks (skill-linker creates, app reads)
+      skills:
+        enabled: true
+        type: emptyDir
+        advancedMounts:
+          percival:
+            skill-linker:
+              - path: /workspace/skills
+            app:
+              - path: /workspace/skills
+                readOnly: true

--- a/kubernetes/apps/roundtable/tristan/app/helmrelease.yaml
+++ b/kubernetes/apps/roundtable/tristan/app/helmrelease.yaml
@@ -218,7 +218,8 @@ spec:
             seed-workspace:
               - path: /seed
                 readOnly: true
-      skills:
+      # Raw arsenal repo (git-sync populates, skill-linker reads)
+      skills-repo:
         enabled: true
         type: emptyDir
         advancedMounts:
@@ -226,8 +227,19 @@ spec:
             skill-linker:
               - path: /skills-repo
             app:
-              - path: /workspace/skills
               - path: /skills-repo
                 readOnly: true
             git-sync:
               - path: /skills-repo
+
+      # Flat skill symlinks (skill-linker creates, app reads)
+      skills:
+        enabled: true
+        type: emptyDir
+        advancedMounts:
+          tristan:
+            skill-linker:
+              - path: /workspace/skills
+            app:
+              - path: /workspace/skills
+                readOnly: true


### PR DESCRIPTION
Git-sync sidecar was overwriting the skill symlinks created by the skill-linker initContainer (same emptyDir).

**Fix:** Two separate emptyDirs:
- `skills-repo` — git-sync writes raw repo, skill-linker reads
- `skills` — skill-linker creates flat symlinks, app reads

Also cleans up duplicate skills-repo block in galahad.