### PR TITLE
fix(roundtable): skill-linker rm on mount point

### DIFF
--- a/kubernetes/apps/roundtable/bedivere/app/helmrelease.yaml
+++ b/kubernetes/apps/roundtable/bedivere/app/helmrelease.yaml
@@ -69,7 +69,7 @@ spec:
                 fi
 
                 # Create flat skill directory
-                rm -rf "$TARGET"
+                find "$TARGET" -mindepth 1 -delete 2>/dev/null || true
                 mkdir -p "$TARGET"
 
                 # Link shared skills (all knights)

--- a/kubernetes/apps/roundtable/galahad/app/helmrelease.yaml
+++ b/kubernetes/apps/roundtable/galahad/app/helmrelease.yaml
@@ -77,7 +77,7 @@ spec:
                 fi
 
                 # Create flat skill directory
-                rm -rf "$TARGET"
+                find "$TARGET" -mindepth 1 -delete 2>/dev/null || true
                 mkdir -p "$TARGET"
 
                 # Link shared skills (all knights)

--- a/kubernetes/apps/roundtable/kay/app/helmrelease.yaml
+++ b/kubernetes/apps/roundtable/kay/app/helmrelease.yaml
@@ -69,7 +69,7 @@ spec:
                 fi
 
                 # Create flat skill directory
-                rm -rf "$TARGET"
+                find "$TARGET" -mindepth 1 -delete 2>/dev/null || true
                 mkdir -p "$TARGET"
 
                 # Link shared skills (all knights)

--- a/kubernetes/apps/roundtable/lancelot/app/helmrelease.yaml
+++ b/kubernetes/apps/roundtable/lancelot/app/helmrelease.yaml
@@ -69,7 +69,7 @@ spec:
                 fi
 
                 # Create flat skill directory
-                rm -rf "$TARGET"
+                find "$TARGET" -mindepth 1 -delete 2>/dev/null || true
                 mkdir -p "$TARGET"
 
                 # Link shared skills (all knights)

--- a/kubernetes/apps/roundtable/percival/app/helmrelease.yaml
+++ b/kubernetes/apps/roundtable/percival/app/helmrelease.yaml
@@ -68,7 +68,7 @@ spec:
                 fi
 
                 # Create flat skill directory
-                rm -rf "$TARGET"
+                find "$TARGET" -mindepth 1 -delete 2>/dev/null || true
                 mkdir -p "$TARGET"
 
                 # Link shared skills (all knights)

--- a/kubernetes/apps/roundtable/tristan/app/helmrelease.yaml
+++ b/kubernetes/apps/roundtable/tristan/app/helmrelease.yaml
@@ -69,7 +69,7 @@ spec:
                 fi
 
                 # Create flat skill directory
-                rm -rf "$TARGET"
+                find "$TARGET" -mindepth 1 -delete 2>/dev/null || true
                 mkdir -p "$TARGET"
 
                 # Link shared skills (all knights)


### PR DESCRIPTION
/workspace/skills is an emptyDir mount point — can't rm -rf it. Clear contents with find instead.