### PR TITLE
fix(roundtable): knight-agent 7ff5424 — symlink skill discovery

### DIFF
--- a/kubernetes/apps/roundtable/bedivere/app/helmrelease.yaml
+++ b/kubernetes/apps/roundtable/bedivere/app/helmrelease.yaml
@@ -97,7 +97,7 @@ spec:
           app:
             image:
               repository: ghcr.io/dapperdivers/knight-agent
-              tag: efc00b1
+              tag: 7ff5424
               pullPolicy: Always
             env:
               WORKSPACE_DIR: /workspace

--- a/kubernetes/apps/roundtable/galahad/app/helmrelease.yaml
+++ b/kubernetes/apps/roundtable/galahad/app/helmrelease.yaml
@@ -107,7 +107,7 @@ spec:
           app:
             image:
               repository: ghcr.io/dapperdivers/knight-agent
-              tag: efc00b1
+              tag: 7ff5424
               pullPolicy: Always
             env:
               # ── Runtime ──

--- a/kubernetes/apps/roundtable/kay/app/helmrelease.yaml
+++ b/kubernetes/apps/roundtable/kay/app/helmrelease.yaml
@@ -97,7 +97,7 @@ spec:
           app:
             image:
               repository: ghcr.io/dapperdivers/knight-agent
-              tag: efc00b1
+              tag: 7ff5424
               pullPolicy: Always
             env:
               WORKSPACE_DIR: /workspace

--- a/kubernetes/apps/roundtable/lancelot/app/helmrelease.yaml
+++ b/kubernetes/apps/roundtable/lancelot/app/helmrelease.yaml
@@ -97,7 +97,7 @@ spec:
           app:
             image:
               repository: ghcr.io/dapperdivers/knight-agent
-              tag: efc00b1
+              tag: 7ff5424
               pullPolicy: Always
             env:
               WORKSPACE_DIR: /workspace

--- a/kubernetes/apps/roundtable/percival/app/helmrelease.yaml
+++ b/kubernetes/apps/roundtable/percival/app/helmrelease.yaml
@@ -96,7 +96,7 @@ spec:
           app:
             image:
               repository: ghcr.io/dapperdivers/knight-agent
-              tag: efc00b1
+              tag: 7ff5424
               pullPolicy: Always
             env:
               WORKSPACE_DIR: /workspace

--- a/kubernetes/apps/roundtable/tristan/app/helmrelease.yaml
+++ b/kubernetes/apps/roundtable/tristan/app/helmrelease.yaml
@@ -97,7 +97,7 @@ spec:
           app:
             image:
               repository: ghcr.io/dapperdivers/knight-agent
-              tag: efc00b1
+              tag: 7ff5424
               pullPolicy: Always
             env:
               WORKSPACE_DIR: /workspace


### PR DESCRIPTION
Skill-linker creates symlinks → scanner must follow them. One-line fix in skill discovery.