### PR TITLE
feat(roundtable): Native skill discovery — kill the skill-linker

### DIFF
--- a/kubernetes/apps/roundtable/bedivere/app/helmrelease.yaml
+++ b/kubernetes/apps/roundtable/bedivere/app/helmrelease.yaml
@@ -46,58 +46,11 @@ spec:
                   fi
                 done
                 echo "Workspace ready"
-          # ── Skill Linker ─────────────────────────────────────────
-          # Links relevant skills from arsenal repo into flat /workspace/skills/
-          skill-linker:
-            image:
-              repository: alpine/git
-              tag: "2.47.2"
-            command:
-              - /bin/sh
-              - -c
-              - |
-                set -e
-                REPO_DIR="/skills-repo/roundtable-arsenal"
-                TARGET="/workspace/skills"
-
-                # Bootstrap: clone if git-sync hasn't populated yet
-                if [ ! -d "$REPO_DIR" ]; then
-                  echo "Bootstrapping arsenal repo..."
-                  git clone --depth 1 --branch main \
-                    https://github.com/dapperdivers/roundtable-arsenal.git \
-                    "$REPO_DIR"
-                fi
-
-                # Create flat skill directory
-                find "$TARGET" -mindepth 1 -delete 2>/dev/null || true
-                mkdir -p "$TARGET"
-
-                # Link shared skills (all knights)
-                for skill in "$REPO_DIR"/shared/*/; do
-                  [ -d "$skill" ] || continue
-                  name=$(basename "$skill")
-                  ln -sfn "$skill" "$TARGET/$name"
-                  echo "Linked shared/$name"
-                done
-
-                # Link domain skills
-                for category in $KNIGHT_SKILLS; do
-                  for skill in "$REPO_DIR"/$category/*/; do
-                    [ -d "$skill" ] || continue
-                    name=$(basename "$skill")
-                    ln -sfn "$skill" "$TARGET/$name"
-                    echo "Linked $category/$name"
-                  done
-                done
-
-                echo "Skills linked: $(ls "$TARGET" | wc -l) total"
-            env:
-              KNIGHT_SKILLS: "home"
         containers:
           app:
             image:
               repository: ghcr.io/dapperdivers/knight-agent
-              tag: 7ff5424
+              tag: 06d4a19
               pullPolicy: Always
             env:
               WORKSPACE_DIR: /workspace
@@ -121,6 +74,7 @@ spec:
               FLEET_ID: fleet-a
               AGENT_ID: bedivere
               SUBSCRIBE_TOPICS: "fleet-a.tasks.home.>"
+              KNIGHT_SKILLS: "home"
             envFrom:
               - secretRef:
                   name: bedivere-secret
@@ -157,7 +111,7 @@ spec:
             env:
               GITSYNC_REPO: https://github.com/dapperdivers/roundtable-arsenal
               GITSYNC_REF: main
-              GITSYNC_ROOT: /skills-repo
+              GITSYNC_ROOT: /workspace/skills
               GITSYNC_PERIOD: "300s"
             resources:
               requests:
@@ -203,8 +157,6 @@ spec:
               - path: /workspace
               - path: /home/knight
                 subPath: home
-            skill-linker:
-              - path: /workspace
             app:
               - path: /workspace
               - path: /home/knight
@@ -218,28 +170,14 @@ spec:
             seed-workspace:
               - path: /seed
                 readOnly: true
-      # Raw arsenal repo (git-sync populates, skill-linker reads)
-      skills-repo:
-        enabled: true
-        type: emptyDir
-        advancedMounts:
-          bedivere:
-            skill-linker:
-              - path: /skills-repo
-            app:
-              - path: /skills-repo
-                readOnly: true
-            git-sync:
-              - path: /skills-repo
-
-      # Flat skill symlinks (skill-linker creates, app reads)
+      # Git-synced skills from arsenal repo
       skills:
         enabled: true
         type: emptyDir
         advancedMounts:
           bedivere:
-            skill-linker:
-              - path: /workspace/skills
             app:
               - path: /workspace/skills
                 readOnly: true
+            git-sync:
+              - path: /workspace/skills

--- a/kubernetes/apps/roundtable/galahad/app/helmrelease.yaml
+++ b/kubernetes/apps/roundtable/galahad/app/helmrelease.yaml
@@ -54,60 +54,13 @@ spec:
                 done
 
                 echo "Workspace ready"
-          # ── Skill Linker ─────────────────────────────────────────
-          # Links relevant skills from arsenal repo into flat /workspace/skills/
-          skill-linker:
-            image:
-              repository: alpine/git
-              tag: "2.47.2"
-            command:
-              - /bin/sh
-              - -c
-              - |
-                set -e
-                REPO_DIR="/skills-repo/roundtable-arsenal"
-                TARGET="/workspace/skills"
-
-                # Bootstrap: clone if git-sync hasn't populated yet
-                if [ ! -d "$REPO_DIR" ]; then
-                  echo "Bootstrapping arsenal repo..."
-                  git clone --depth 1 --branch main \
-                    https://github.com/dapperdivers/roundtable-arsenal.git \
-                    "$REPO_DIR"
-                fi
-
-                # Create flat skill directory
-                find "$TARGET" -mindepth 1 -delete 2>/dev/null || true
-                mkdir -p "$TARGET"
-
-                # Link shared skills (all knights)
-                for skill in "$REPO_DIR"/shared/*/; do
-                  [ -d "$skill" ] || continue
-                  name=$(basename "$skill")
-                  ln -sfn "$skill" "$TARGET/$name"
-                  echo "Linked shared/$name"
-                done
-
-                # Link domain skills
-                for category in $KNIGHT_SKILLS; do
-                  for skill in "$REPO_DIR"/$category/*/; do
-                    [ -d "$skill" ] || continue
-                    name=$(basename "$skill")
-                    ln -sfn "$skill" "$TARGET/$name"
-                    echo "Linked $category/$name"
-                  done
-                done
-
-                echo "Skills linked: $(ls "$TARGET" | wc -l) total"
-            env:
-              KNIGHT_SKILLS: "security"
         containers:
           # ── Knight Agent ────────────────────────────────────────────
           # Lightweight runtime: Claude Agent SDK + native NATS
           app:
             image:
               repository: ghcr.io/dapperdivers/knight-agent
-              tag: 7ff5424
+              tag: 06d4a19
               pullPolicy: Always
             env:
               # ── Runtime ──
@@ -136,6 +89,7 @@ spec:
               FLEET_ID: fleet-a
               AGENT_ID: galahad
               SUBSCRIBE_TOPICS: "fleet-a.tasks.security.>"
+              KNIGHT_SKILLS: "security"
             envFrom:
               - secretRef:
                   name: galahad-secret
@@ -175,7 +129,7 @@ spec:
             env:
               GITSYNC_REPO: https://github.com/dapperdivers/roundtable-arsenal
               GITSYNC_REF: main
-              GITSYNC_ROOT: /skills-repo
+              GITSYNC_ROOT: /workspace/skills
               GITSYNC_PERIOD: "300s"
             resources:
               requests:
@@ -226,8 +180,6 @@ spec:
               - path: /workspace
               - path: /home/knight
                 subPath: home
-            skill-linker:
-              - path: /workspace
             app:
               - path: /workspace
               - path: /home/knight
@@ -244,28 +196,14 @@ spec:
               - path: /seed
                 readOnly: true
 
-      # Raw arsenal repo (git-sync populates, skill-linker reads)
-      skills-repo:
-        enabled: true
-        type: emptyDir
-        advancedMounts:
-          galahad:
-            skill-linker:
-              - path: /skills-repo
-            app:
-              - path: /skills-repo
-                readOnly: true
-            git-sync:
-              - path: /skills-repo
-
-      # Flat skill symlinks (skill-linker creates, app reads)
+      # Git-synced skills from arsenal repo
       skills:
         enabled: true
         type: emptyDir
         advancedMounts:
           galahad:
-            skill-linker:
-              - path: /workspace/skills
             app:
               - path: /workspace/skills
                 readOnly: true
+            git-sync:
+              - path: /workspace/skills

--- a/kubernetes/apps/roundtable/kay/app/helmrelease.yaml
+++ b/kubernetes/apps/roundtable/kay/app/helmrelease.yaml
@@ -46,58 +46,11 @@ spec:
                   fi
                 done
                 echo "Workspace ready"
-          # ── Skill Linker ─────────────────────────────────────────
-          # Links relevant skills from arsenal repo into flat /workspace/skills/
-          skill-linker:
-            image:
-              repository: alpine/git
-              tag: "2.47.2"
-            command:
-              - /bin/sh
-              - -c
-              - |
-                set -e
-                REPO_DIR="/skills-repo/roundtable-arsenal"
-                TARGET="/workspace/skills"
-
-                # Bootstrap: clone if git-sync hasn't populated yet
-                if [ ! -d "$REPO_DIR" ]; then
-                  echo "Bootstrapping arsenal repo..."
-                  git clone --depth 1 --branch main \
-                    https://github.com/dapperdivers/roundtable-arsenal.git \
-                    "$REPO_DIR"
-                fi
-
-                # Create flat skill directory
-                find "$TARGET" -mindepth 1 -delete 2>/dev/null || true
-                mkdir -p "$TARGET"
-
-                # Link shared skills (all knights)
-                for skill in "$REPO_DIR"/shared/*/; do
-                  [ -d "$skill" ] || continue
-                  name=$(basename "$skill")
-                  ln -sfn "$skill" "$TARGET/$name"
-                  echo "Linked shared/$name"
-                done
-
-                # Link domain skills
-                for category in $KNIGHT_SKILLS; do
-                  for skill in "$REPO_DIR"/$category/*/; do
-                    [ -d "$skill" ] || continue
-                    name=$(basename "$skill")
-                    ln -sfn "$skill" "$TARGET/$name"
-                    echo "Linked $category/$name"
-                  done
-                done
-
-                echo "Skills linked: $(ls "$TARGET" | wc -l) total"
-            env:
-              KNIGHT_SKILLS: "research intel"
         containers:
           app:
             image:
               repository: ghcr.io/dapperdivers/knight-agent
-              tag: 7ff5424
+              tag: 06d4a19
               pullPolicy: Always
             env:
               WORKSPACE_DIR: /workspace
@@ -121,6 +74,7 @@ spec:
               FLEET_ID: fleet-a
               AGENT_ID: kay
               SUBSCRIBE_TOPICS: "fleet-a.tasks.research.>,fleet-a.tasks.intel.>"
+              KNIGHT_SKILLS: "research intel"
             envFrom:
               - secretRef:
                   name: kay-secret
@@ -157,7 +111,7 @@ spec:
             env:
               GITSYNC_REPO: https://github.com/dapperdivers/roundtable-arsenal
               GITSYNC_REF: main
-              GITSYNC_ROOT: /skills-repo
+              GITSYNC_ROOT: /workspace/skills
               GITSYNC_PERIOD: "300s"
             resources:
               requests:
@@ -203,8 +157,6 @@ spec:
               - path: /workspace
               - path: /home/knight
                 subPath: home
-            skill-linker:
-              - path: /workspace
             app:
               - path: /workspace
               - path: /home/knight
@@ -218,28 +170,14 @@ spec:
             seed-workspace:
               - path: /seed
                 readOnly: true
-      # Raw arsenal repo (git-sync populates, skill-linker reads)
-      skills-repo:
-        enabled: true
-        type: emptyDir
-        advancedMounts:
-          kay:
-            skill-linker:
-              - path: /skills-repo
-            app:
-              - path: /skills-repo
-                readOnly: true
-            git-sync:
-              - path: /skills-repo
-
-      # Flat skill symlinks (skill-linker creates, app reads)
+      # Git-synced skills from arsenal repo
       skills:
         enabled: true
         type: emptyDir
         advancedMounts:
           kay:
-            skill-linker:
-              - path: /workspace/skills
             app:
               - path: /workspace/skills
                 readOnly: true
+            git-sync:
+              - path: /workspace/skills

--- a/kubernetes/apps/roundtable/lancelot/app/helmrelease.yaml
+++ b/kubernetes/apps/roundtable/lancelot/app/helmrelease.yaml
@@ -46,58 +46,11 @@ spec:
                   fi
                 done
                 echo "Workspace ready"
-          # ── Skill Linker ─────────────────────────────────────────
-          # Links relevant skills from arsenal repo into flat /workspace/skills/
-          skill-linker:
-            image:
-              repository: alpine/git
-              tag: "2.47.2"
-            command:
-              - /bin/sh
-              - -c
-              - |
-                set -e
-                REPO_DIR="/skills-repo/roundtable-arsenal"
-                TARGET="/workspace/skills"
-
-                # Bootstrap: clone if git-sync hasn't populated yet
-                if [ ! -d "$REPO_DIR" ]; then
-                  echo "Bootstrapping arsenal repo..."
-                  git clone --depth 1 --branch main \
-                    https://github.com/dapperdivers/roundtable-arsenal.git \
-                    "$REPO_DIR"
-                fi
-
-                # Create flat skill directory
-                find "$TARGET" -mindepth 1 -delete 2>/dev/null || true
-                mkdir -p "$TARGET"
-
-                # Link shared skills (all knights)
-                for skill in "$REPO_DIR"/shared/*/; do
-                  [ -d "$skill" ] || continue
-                  name=$(basename "$skill")
-                  ln -sfn "$skill" "$TARGET/$name"
-                  echo "Linked shared/$name"
-                done
-
-                # Link domain skills
-                for category in $KNIGHT_SKILLS; do
-                  for skill in "$REPO_DIR"/$category/*/; do
-                    [ -d "$skill" ] || continue
-                    name=$(basename "$skill")
-                    ln -sfn "$skill" "$TARGET/$name"
-                    echo "Linked $category/$name"
-                  done
-                done
-
-                echo "Skills linked: $(ls "$TARGET" | wc -l) total"
-            env:
-              KNIGHT_SKILLS: "career"
         containers:
           app:
             image:
               repository: ghcr.io/dapperdivers/knight-agent
-              tag: 7ff5424
+              tag: 06d4a19
               pullPolicy: Always
             env:
               WORKSPACE_DIR: /workspace
@@ -121,6 +74,7 @@ spec:
               FLEET_ID: fleet-a
               AGENT_ID: lancelot
               SUBSCRIBE_TOPICS: "fleet-a.tasks.career.>"
+              KNIGHT_SKILLS: "career"
             envFrom:
               - secretRef:
                   name: lancelot-secret
@@ -157,7 +111,7 @@ spec:
             env:
               GITSYNC_REPO: https://github.com/dapperdivers/roundtable-arsenal
               GITSYNC_REF: main
-              GITSYNC_ROOT: /skills-repo
+              GITSYNC_ROOT: /workspace/skills
               GITSYNC_PERIOD: "300s"
             resources:
               requests:
@@ -203,8 +157,6 @@ spec:
               - path: /workspace
               - path: /home/knight
                 subPath: home
-            skill-linker:
-              - path: /workspace
             app:
               - path: /workspace
               - path: /home/knight
@@ -218,28 +170,14 @@ spec:
             seed-workspace:
               - path: /seed
                 readOnly: true
-      # Raw arsenal repo (git-sync populates, skill-linker reads)
-      skills-repo:
-        enabled: true
-        type: emptyDir
-        advancedMounts:
-          lancelot:
-            skill-linker:
-              - path: /skills-repo
-            app:
-              - path: /skills-repo
-                readOnly: true
-            git-sync:
-              - path: /skills-repo
-
-      # Flat skill symlinks (skill-linker creates, app reads)
+      # Git-synced skills from arsenal repo
       skills:
         enabled: true
         type: emptyDir
         advancedMounts:
           lancelot:
-            skill-linker:
-              - path: /workspace/skills
             app:
               - path: /workspace/skills
                 readOnly: true
+            git-sync:
+              - path: /workspace/skills

--- a/kubernetes/apps/roundtable/percival/app/helmrelease.yaml
+++ b/kubernetes/apps/roundtable/percival/app/helmrelease.yaml
@@ -45,58 +45,11 @@ spec:
                   fi
                 done
                 echo "Workspace ready"
-          # ── Skill Linker ─────────────────────────────────────────
-          # Links relevant skills from arsenal repo into flat /workspace/skills/
-          skill-linker:
-            image:
-              repository: alpine/git
-              tag: "2.47.2"
-            command:
-              - /bin/sh
-              - -c
-              - |
-                set -e
-                REPO_DIR="/skills-repo/roundtable-arsenal"
-                TARGET="/workspace/skills"
-
-                # Bootstrap: clone if git-sync hasn't populated yet
-                if [ ! -d "$REPO_DIR" ]; then
-                  echo "Bootstrapping arsenal repo..."
-                  git clone --depth 1 --branch main \
-                    https://github.com/dapperdivers/roundtable-arsenal.git \
-                    "$REPO_DIR"
-                fi
-
-                # Create flat skill directory
-                find "$TARGET" -mindepth 1 -delete 2>/dev/null || true
-                mkdir -p "$TARGET"
-
-                # Link shared skills (all knights)
-                for skill in "$REPO_DIR"/shared/*/; do
-                  [ -d "$skill" ] || continue
-                  name=$(basename "$skill")
-                  ln -sfn "$skill" "$TARGET/$name"
-                  echo "Linked shared/$name"
-                done
-
-                # Link domain skills
-                for category in $KNIGHT_SKILLS; do
-                  for skill in "$REPO_DIR"/$category/*/; do
-                    [ -d "$skill" ] || continue
-                    name=$(basename "$skill")
-                    ln -sfn "$skill" "$TARGET/$name"
-                    echo "Linked $category/$name"
-                  done
-                done
-
-                echo "Skills linked: $(ls "$TARGET" | wc -l) total"
-            env:
-              KNIGHT_SKILLS: "finance"
         containers:
           app:
             image:
               repository: ghcr.io/dapperdivers/knight-agent
-              tag: 7ff5424
+              tag: 06d4a19
               pullPolicy: Always
             env:
               WORKSPACE_DIR: /workspace
@@ -120,6 +73,7 @@ spec:
               FLEET_ID: fleet-a
               AGENT_ID: percival
               SUBSCRIBE_TOPICS: "fleet-a.tasks.finance.>,fleet-a.tasks.admin.>"
+              KNIGHT_SKILLS: "finance"
             envFrom:
               - secretRef:
                   name: percival-secret
@@ -156,7 +110,7 @@ spec:
             env:
               GITSYNC_REPO: https://github.com/dapperdivers/roundtable-arsenal
               GITSYNC_REF: main
-              GITSYNC_ROOT: /skills-repo
+              GITSYNC_ROOT: /workspace/skills
               GITSYNC_PERIOD: "300s"
             resources:
               requests:
@@ -202,8 +156,6 @@ spec:
               - path: /workspace
               - path: /home/knight
                 subPath: home
-            skill-linker:
-              - path: /workspace
             app:
               - path: /workspace
               - path: /home/knight
@@ -217,28 +169,14 @@ spec:
             seed-workspace:
               - path: /seed
                 readOnly: true
-      # Raw arsenal repo (git-sync populates, skill-linker reads)
-      skills-repo:
-        enabled: true
-        type: emptyDir
-        advancedMounts:
-          percival:
-            skill-linker:
-              - path: /skills-repo
-            app:
-              - path: /skills-repo
-                readOnly: true
-            git-sync:
-              - path: /skills-repo
-
-      # Flat skill symlinks (skill-linker creates, app reads)
+      # Git-synced skills from arsenal repo
       skills:
         enabled: true
         type: emptyDir
         advancedMounts:
           percival:
-            skill-linker:
-              - path: /workspace/skills
             app:
               - path: /workspace/skills
                 readOnly: true
+            git-sync:
+              - path: /workspace/skills

--- a/kubernetes/apps/roundtable/tristan/app/helmrelease.yaml
+++ b/kubernetes/apps/roundtable/tristan/app/helmrelease.yaml
@@ -46,58 +46,11 @@ spec:
                   fi
                 done
                 echo "Workspace ready"
-          # ── Skill Linker ─────────────────────────────────────────
-          # Links relevant skills from arsenal repo into flat /workspace/skills/
-          skill-linker:
-            image:
-              repository: alpine/git
-              tag: "2.47.2"
-            command:
-              - /bin/sh
-              - -c
-              - |
-                set -e
-                REPO_DIR="/skills-repo/roundtable-arsenal"
-                TARGET="/workspace/skills"
-
-                # Bootstrap: clone if git-sync hasn't populated yet
-                if [ ! -d "$REPO_DIR" ]; then
-                  echo "Bootstrapping arsenal repo..."
-                  git clone --depth 1 --branch main \
-                    https://github.com/dapperdivers/roundtable-arsenal.git \
-                    "$REPO_DIR"
-                fi
-
-                # Create flat skill directory
-                find "$TARGET" -mindepth 1 -delete 2>/dev/null || true
-                mkdir -p "$TARGET"
-
-                # Link shared skills (all knights)
-                for skill in "$REPO_DIR"/shared/*/; do
-                  [ -d "$skill" ] || continue
-                  name=$(basename "$skill")
-                  ln -sfn "$skill" "$TARGET/$name"
-                  echo "Linked shared/$name"
-                done
-
-                # Link domain skills
-                for category in $KNIGHT_SKILLS; do
-                  for skill in "$REPO_DIR"/$category/*/; do
-                    [ -d "$skill" ] || continue
-                    name=$(basename "$skill")
-                    ln -sfn "$skill" "$TARGET/$name"
-                    echo "Linked $category/$name"
-                  done
-                done
-
-                echo "Skills linked: $(ls "$TARGET" | wc -l) total"
-            env:
-              KNIGHT_SKILLS: "infra"
         containers:
           app:
             image:
               repository: ghcr.io/dapperdivers/knight-agent
-              tag: 7ff5424
+              tag: 06d4a19
               pullPolicy: Always
             env:
               WORKSPACE_DIR: /workspace
@@ -121,6 +74,7 @@ spec:
               FLEET_ID: fleet-a
               AGENT_ID: tristan
               SUBSCRIBE_TOPICS: "fleet-a.tasks.infra.>"
+              KNIGHT_SKILLS: "infra"
             envFrom:
               - secretRef:
                   name: tristan-secret
@@ -157,7 +111,7 @@ spec:
             env:
               GITSYNC_REPO: https://github.com/dapperdivers/roundtable-arsenal
               GITSYNC_REF: main
-              GITSYNC_ROOT: /skills-repo
+              GITSYNC_ROOT: /workspace/skills
               GITSYNC_PERIOD: "300s"
             resources:
               requests:
@@ -203,8 +157,6 @@ spec:
               - path: /workspace
               - path: /home/knight
                 subPath: home
-            skill-linker:
-              - path: /workspace
             app:
               - path: /workspace
               - path: /home/knight
@@ -218,28 +170,14 @@ spec:
             seed-workspace:
               - path: /seed
                 readOnly: true
-      # Raw arsenal repo (git-sync populates, skill-linker reads)
-      skills-repo:
-        enabled: true
-        type: emptyDir
-        advancedMounts:
-          tristan:
-            skill-linker:
-              - path: /skills-repo
-            app:
-              - path: /skills-repo
-                readOnly: true
-            git-sync:
-              - path: /skills-repo
-
-      # Flat skill symlinks (skill-linker creates, app reads)
+      # Git-synced skills from arsenal repo
       skills:
         enabled: true
         type: emptyDir
         advancedMounts:
           tristan:
-            skill-linker:
-              - path: /workspace/skills
             app:
               - path: /workspace/skills
                 readOnly: true
+            git-sync:
+              - path: /workspace/skills


### PR DESCRIPTION
### What
Removes the `skill-linker` initContainer, `alpine/git` image, and dual emptyDirs from all 6 knights.

### Why
The skill-linker was fighting git-sync (mount point conflicts, symlink overwrites, crashloops). The right fix is making the agent smart, not the deployment clever.

### How
- **knight-agent `06d4a19`**: Recursive skill walker that handles git-sync worktrees, follows symlinks, skips dotfiles
- **`KNIGHT_SKILLS` env var**: Space-separated category filter per knight. `shared` always included.

### Result
- **-408 lines** deleted from manifests
- **1 fewer container** per pod (no alpine/git initContainer)
- **1 fewer emptyDir** per pod
- Each knight just mounts the arsenal and the agent finds the right skills

### Skill mapping
| Knight | KNIGHT_SKILLS | Gets |
|--------|--------------|------|
| 🛡️ Galahad | `security` | shared + security |
| 📋 Percival | `finance` | shared + finance |
| ⚔️ Lancelot | `career` | shared + career |
| 🏗️ Tristan | `infra` | shared + infra |
| 🏠 Bedivere | `home` | shared + home |
| 📡 Kay | `research intel` | shared + research + intel |