### PR TITLE
feat(roundtable): immediate NATS ack + 30min default timeout (7350b70)

### DIFF
--- a/kubernetes/apps/roundtable/bedivere/app/helmrelease.yaml
+++ b/kubernetes/apps/roundtable/bedivere/app/helmrelease.yaml
@@ -28,7 +28,7 @@ spec:
           seed-workspace:
             image:
               repository: ghcr.io/dapperdivers/knight-agent
-              tag: bd79a30
+              tag: 7350b70
               pullPolicy: Always
             command:
               - /bin/sh
@@ -58,7 +58,7 @@ spec:
           app:
             image:
               repository: ghcr.io/dapperdivers/knight-agent
-              tag: bd79a30
+              tag: 7350b70
               pullPolicy: Always
             env:
               WORKSPACE_DIR: /workspace
@@ -66,7 +66,6 @@ spec:
               LOG_LEVEL: info
               PORT: "18789"
               TZ: America/Chicago
-              TASK_TIMEOUT_MS: "180000"
               MAX_CONCURRENT_TASKS: "2"
               ANTHROPIC_SMALL_FAST_MODEL: claude-haiku-3-5-20241022
               CLAUDE_CODE_SUBAGENT_MODEL: claude-sonnet-4-5-20250929

--- a/kubernetes/apps/roundtable/galahad/app/helmrelease.yaml
+++ b/kubernetes/apps/roundtable/galahad/app/helmrelease.yaml
@@ -31,7 +31,7 @@ spec:
           seed-workspace:
             image:
               repository: ghcr.io/dapperdivers/knight-agent
-              tag: bd79a30
+              tag: 7350b70
               pullPolicy: Always
             command:
               - /bin/sh
@@ -74,7 +74,7 @@ spec:
           app:
             image:
               repository: ghcr.io/dapperdivers/knight-agent
-              tag: bd79a30
+              tag: 7350b70
               pullPolicy: Always
             env:
               # ── Runtime ──
@@ -84,7 +84,6 @@ spec:
               PORT: "18789"
               TZ: America/Chicago
               # ── Task Execution ──
-              TASK_TIMEOUT_MS: "300000"
               MAX_CONCURRENT_TASKS: "2"
               # ── Claude Code SDK ──
               ANTHROPIC_SMALL_FAST_MODEL: claude-haiku-3-5-20241022

--- a/kubernetes/apps/roundtable/kay/app/helmrelease.yaml
+++ b/kubernetes/apps/roundtable/kay/app/helmrelease.yaml
@@ -28,7 +28,7 @@ spec:
           seed-workspace:
             image:
               repository: ghcr.io/dapperdivers/knight-agent
-              tag: bd79a30
+              tag: 7350b70
               pullPolicy: Always
             command:
               - /bin/sh
@@ -60,7 +60,7 @@ spec:
           app:
             image:
               repository: ghcr.io/dapperdivers/knight-agent
-              tag: bd79a30
+              tag: 7350b70
               pullPolicy: Always
             env:
               WORKSPACE_DIR: /workspace
@@ -68,7 +68,6 @@ spec:
               LOG_LEVEL: info
               PORT: "18789"
               TZ: America/Chicago
-              TASK_TIMEOUT_MS: "300000"
               MAX_CONCURRENT_TASKS: "2"
               ANTHROPIC_SMALL_FAST_MODEL: claude-haiku-3-5-20241022
               CLAUDE_CODE_SUBAGENT_MODEL: claude-sonnet-4-5-20250929

--- a/kubernetes/apps/roundtable/lancelot/app/helmrelease.yaml
+++ b/kubernetes/apps/roundtable/lancelot/app/helmrelease.yaml
@@ -28,7 +28,7 @@ spec:
           seed-workspace:
             image:
               repository: ghcr.io/dapperdivers/knight-agent
-              tag: bd79a30
+              tag: 7350b70
               pullPolicy: Always
             command:
               - /bin/sh
@@ -58,7 +58,7 @@ spec:
           app:
             image:
               repository: ghcr.io/dapperdivers/knight-agent
-              tag: bd79a30
+              tag: 7350b70
               pullPolicy: Always
             env:
               WORKSPACE_DIR: /workspace
@@ -66,7 +66,6 @@ spec:
               LOG_LEVEL: info
               PORT: "18789"
               TZ: America/Chicago
-              TASK_TIMEOUT_MS: "240000"
               MAX_CONCURRENT_TASKS: "2"
               ANTHROPIC_SMALL_FAST_MODEL: claude-haiku-3-5-20241022
               CLAUDE_CODE_SUBAGENT_MODEL: claude-sonnet-4-5-20250929

--- a/kubernetes/apps/roundtable/percival/app/helmrelease.yaml
+++ b/kubernetes/apps/roundtable/percival/app/helmrelease.yaml
@@ -27,7 +27,7 @@ spec:
           seed-workspace:
             image:
               repository: ghcr.io/dapperdivers/knight-agent
-              tag: bd79a30
+              tag: 7350b70
               pullPolicy: Always
             command:
               - /bin/sh
@@ -57,7 +57,7 @@ spec:
           app:
             image:
               repository: ghcr.io/dapperdivers/knight-agent
-              tag: bd79a30
+              tag: 7350b70
               pullPolicy: Always
             env:
               WORKSPACE_DIR: /workspace
@@ -65,7 +65,6 @@ spec:
               LOG_LEVEL: info
               PORT: "18789"
               TZ: America/Chicago
-              TASK_TIMEOUT_MS: "180000"
               MAX_CONCURRENT_TASKS: "2"
               ANTHROPIC_SMALL_FAST_MODEL: claude-haiku-3-5-20241022
               CLAUDE_CODE_SUBAGENT_MODEL: claude-sonnet-4-5-20250929

--- a/kubernetes/apps/roundtable/tristan/app/helmrelease.yaml
+++ b/kubernetes/apps/roundtable/tristan/app/helmrelease.yaml
@@ -28,7 +28,7 @@ spec:
           seed-workspace:
             image:
               repository: ghcr.io/dapperdivers/knight-agent
-              tag: bd79a30
+              tag: 7350b70
               pullPolicy: Always
             command:
               - /bin/sh
@@ -58,7 +58,7 @@ spec:
           app:
             image:
               repository: ghcr.io/dapperdivers/knight-agent
-              tag: bd79a30
+              tag: 7350b70
               pullPolicy: Always
             env:
               WORKSPACE_DIR: /workspace
@@ -66,7 +66,6 @@ spec:
               LOG_LEVEL: info
               PORT: "18789"
               TZ: America/Chicago
-              TASK_TIMEOUT_MS: "180000"
               MAX_CONCURRENT_TASKS: "2"
               ANTHROPIC_SMALL_FAST_MODEL: claude-haiku-3-5-20241022
               CLAUDE_CODE_SUBAGENT_MODEL: claude-sonnet-4-5-20250929


### PR DESCRIPTION
## Changes
- Update all 6 knights to `knight-agent:7350b70`
- Remove per-knight `TASK_TIMEOUT_MS` overrides (default is now 30min in image)

## knight-agent changes (7350b70)
- **Immediate NATS ack**: Messages acked on receipt, not after processing
- **30-min default timeout**: Up from 120s
- **max_deliver=1**: No redelivery with immediate ack

## Why
NATS redelivered tasks after 120s ack timeout, causing duplicate execution. All 6 knights timed out on vault exploration tasks.