### PR TITLE
feat(galahad): add Shodan API key

### DIFF
--- a/kubernetes/apps/roundtable/galahad/app/externalsecret.yaml
+++ b/kubernetes/apps/roundtable/galahad/app/externalsecret.yaml
@@ -14,7 +14,8 @@ spec:
       data:
         ANTHROPIC_API_KEY: "{{ .OPENCLAW_ANTHROPIC_API_KEY }}"
         OPENCTI_TOKEN: "{{ .OPENCTI_ADMIN_TOKEN }}"
+        SHODAN_API_KEY: "{{ .SHODAN_API_KEY }}"
   dataFrom:
     - find:
         name:
-          regexp: ^(OPENCLAW|OPENCTI).*
+          regexp: ^(OPENCLAW|OPENCTI|SHODAN).*


### PR DESCRIPTION
Adds SHODAN_API_KEY to Galahad's ExternalSecret for internet-facing asset reconnaissance.

- Added explicit template mapping for SHODAN_API_KEY
- Widened dataFrom regex to include SHODAN prefix
- Key already added to Infisical by Derek