### PR TITLE
fix(opencti): AlienVault OTX connector OOM — bump to 2Gi

### DIFF
--- a/kubernetes/apps/security/opencti/app/helmrelease.yaml
+++ b/kubernetes/apps/security/opencti/app/helmrelease.yaml
@@ -362,6 +362,6 @@ spec:
         resources:
           requests:
             cpu: 100m
-            memory: 256Mi
-          limits:
             memory: 512Mi
+          limits:
+            memory: 2Gi


### PR DESCRIPTION
**1,100+ OOMKills in 6 days.**

Root cause: Large OTX pulses (up to 29,932 indicators per pulse) cause memory spikes during STIX bundle building that exceed the 512Mi limit.

The connector works fine on normal pulses but OOMs on large ones, restarts, hits the same large pulse, OOMs again — infinite loop.

**Fix:** 512Mi → 2Gi limit, 256Mi → 512Mi request.

After this merges, Galahad will need to re-enable the AlienVault connector in OpenCTI (he deleted the entity during a platform audit).