### PR TITLE
fix(observability): kube-state-metrics CPU throttle — 208 restarts

### DIFF
--- a/kubernetes/apps/observability/kube-prometheus-stack/app/helmrelease.yaml
+++ b/kubernetes/apps/observability/kube-prometheus-stack/app/helmrelease.yaml
@@ -132,9 +132,6 @@ spec:
         requests:
           cpu: 25m
           memory: 128Mi
-        limits:
-          cpu: 100m
-          memory: 512Mi
       prometheus:
         monitor:
           enabled: true


### PR DESCRIPTION
**208 restarts in 11 days.**

Root cause: 100m CPU limit causes throttling on a 240-pod cluster watching 29 resource types. API server calls timeout under throttle, liveness probe fails (`Failed to contact API server for /livez: got 0`), pod killed.

**Fix:** Remove CPU and memory limits, keep requests for scheduling.

**Impact:** Stable metrics collection → reliable Grafana dashboards and alerting.