### PR TITLE
fix(external-dns): reduce sync interval — 342 restart update loop

### DIFF
--- a/kubernetes/apps/network/external/external-dns/helmrelease.yaml
+++ b/kubernetes/apps/network/external/external-dns/helmrelease.yaml
@@ -41,6 +41,7 @@ spec:
       - --events
       - --ignore-ingress-tls-spec
       - --ingress-class=external
+      - --interval=5m
     policy: sync
     sources: ["crd", "ingress"]
     txtPrefix: k8s.


### PR DESCRIPTION
**342 restarts in 45 days.**

Root cause: `--cloudflare-proxied` + bare domain CNAMEs (`derekmackley.com`, `turtleassmedia.com`) creates perpetual UPDATE loop. Cloudflare proxied records use 'auto' TTL but external-dns writes TTL=1, sees a diff on readback, updates again — every 60 seconds. Eventually Cloudflare rate-limits/truncates response → `unexpected EOF` → crash.

**Fix:** Add `--interval=5m` to reduce sync frequency from 1m to 5m. This cuts Cloudflare API calls by 80% and makes the EOF crash much less frequent.

**Note:** The UPDATE loop is a known behavior with proxied Cloudflare records. The chart is already at 1.20.0 (latest). A full fix would require upstream changes to how external-dns compares TTL on proxied records. The interval increase is the recommended mitigation.