### PR TITLE
fix(opencti): bump helm timeout 15m → 30m — unstall v0.4.0 upgrade

### DIFF
--- a/kubernetes/apps/security/opencti/app/helmrelease.yaml
+++ b/kubernetes/apps/security/opencti/app/helmrelease.yaml
@@ -16,7 +16,7 @@ spec:
         namespace: flux-system
       interval: 15m
   maxHistory: 2
-  timeout: 15m
+  timeout: 30m
   install:
     crds: CreateReplace
     remediation:


### PR DESCRIPTION
**OpenCTI stuck on chart v0.3.2 — upgrade to v0.4.0 keeps timing out.**

The HelmRelease is Stalled after 4 failed upgrade attempts, all with `context deadline exceeded` at the 15m mark. Flux rolled back to v0.3.2 each time.

Root cause: OpenCTI has 14+ pods with readyChecker init containers that wait for sequential dependency startup (OpenSearch → RabbitMQ → MinIO → Server → Workers → Connectors). This chain takes >15m.

**Fix:** Bump timeout from 15m to 30m. The spec change will also un-stall the HelmRelease, causing Flux to retry the v0.4.0 upgrade with the new timeout.

Everything is currently running fine on v0.3.2 — this just gets us to the v0.4.0 chart we already built and tested.