### PR TITLE
fix(opencti): opensearch readyChecker hostname mismatch

### DIFF
--- a/kubernetes/apps/security/opencti/app/helmrelease.yaml
+++ b/kubernetes/apps/security/opencti/app/helmrelease.yaml
@@ -114,6 +114,7 @@ spec:
     # ===================
     opensearch:
       enabled: true
+      fullnameOverride: opensearch-cluster-master
       replicas: 1
       sysctlInit:
         enabled: false


### PR DESCRIPTION
The v0.4.0 upgrade is failing because the readyChecker init container looks for `opencti-opensearch-cluster-master` (release-name prefixed) but the actual OpenSearch service is `opensearch-cluster-master`.

Chart template: `opensearch.fullnameOverride | default (printf "%s-opensearch-cluster-master" .Release.Name)`

**Fix:** Set `opensearch.fullnameOverride: opensearch-cluster-master` to match the existing service name. This only affects the readyChecker hostname resolution — does NOT rename the statefulset or PVC.