### PR TITLE
fix(galahad): standardize task_id pattern to match other knights

### DIFF
--- a/kubernetes/apps/roundtable/knight-crons/app/cronjob.yaml
+++ b/kubernetes/apps/roundtable/knight-crons/app/cronjob.yaml
@@ -47,8 +47,8 @@ spec:
                   esac
                   nats pub \
                     --server=nats://nats.database.svc:4222 \
-                    "fleet-a.tasks.security.$${MODE}-$${TODAY}-galahad" \
-                    "{\"task_id\":\"$${MODE}-$${TODAY}-galahad\",\"domain\":\"security\",\"description\":\"$${DESC} Today is $${TODAY}.\",\"run_id\":\"daily-$${TODAY}\",\"metadata\":{\"type\":\"scheduled\",\"schedule\":\"$${MODE}\"}}"
+                    "fleet-a.tasks.security.daily-$${TODAY}-galahad" \
+                    "{\"task_id\":\"daily-$${TODAY}-galahad\",\"domain\":\"security\",\"description\":\"$${DESC} Today is $${TODAY}.\",\"run_id\":\"daily-$${TODAY}\",\"metadata\":{\"type\":\"scheduled\",\"schedule\":\"$${MODE}\"}}"
 ---
 apiVersion: batch/v1
 kind: CronJob


### PR DESCRIPTION
Galahad used `${MODE}-${DATE}-galahad` while all other knights use `daily-${DATE}-${knight}`. The day-of-week mode is already in `metadata.schedule`, so the task_id doesn't need it. One-line change.