### PR TITLE
fix(renovate): enable immediate PR creation for auto-merge

### DIFF
--- a/.renovaterc.json5
+++ b/.renovaterc.json5
@@ -16,6 +16,8 @@
     ":timezone(America/New_York)",
   ],
   platformAutomerge: true,
+  dependencyDashboardAutoclose: true,
+  prCreation: "immediate",
   dependencyDashboardTitle: "Renovate Dashboard 🤖",
   suppressNotifications: [
     "prEditedNotification",


### PR DESCRIPTION
## The Checkbox Problem

Renovate was creating entries in the Dependency Dashboard's 'Pending Status Checks' section, requiring manual checkbox clicks before PRs were created. This defeats the purpose of automerge.

### Fix
- `prCreation: "immediate"` — PRs are created as soon as Renovate detects an update, no dashboard approval needed
- `dependencyDashboardAutoclose: true` — auto-close dashboard when no open items

Combined with existing `platformAutomerge: true` and the automerge rules in `autoMerge.json5`, qualifying updates (minor/patch for trusted packages) will flow through fully autonomously:

1. Renovate detects update → creates PR immediately
2. GitHub auto-merge kicks in → squash merges
3. Flux reconciles → deploys

No checkboxes. No humans. Automagically. ✨