### PR TITLE
fix(external-dns): remove duplicate --interval flag

### DIFF
--- a/kubernetes/apps/network/external/external-dns/helmrelease.yaml
+++ b/kubernetes/apps/network/external/external-dns/helmrelease.yaml
@@ -35,6 +35,7 @@ spec:
           secretKeyRef:
             name: external-dns-secret
             key: api-token
+    interval: 5m
     extraArgs:
       - --cloudflare-dns-records-per-page=1000
       - --cloudflare-proxied
@@ -43,7 +44,6 @@ spec:
       - --events
       - --ignore-ingress-tls-spec
       - --ingress-class=external
-      - --interval=5m
     policy: sync
     sources: ["crd", "ingress"]
     txtPrefix: k8s.


### PR DESCRIPTION
Chart 1.20.0 added `interval` as a top-level value. Having `--interval=5m` in `extraArgs` duplicates the flag → fatal crash.

Move to chart value, remove from extraArgs.