### PR TITLE
fix(wazuh): downgrade chart 1.0.18 → 1.0.17 (broken template)

### DIFF
--- a/kubernetes/apps/security/wazuh/app/helmrelease.yaml
+++ b/kubernetes/apps/security/wazuh/app/helmrelease.yaml
@@ -9,7 +9,7 @@ spec:
   chart:
     spec:
       chart: wazuh
-      version: 1.0.18
+      version: 1.0.17
       sourceRef:
         kind: HelmRepository
         name: wazuh
@@ -23,10 +23,6 @@ spec:
       strategy: rollback
       retries: 3
   values:
-    global:
-      dualStack:
-        enabled: false
-
     # Use existing cert-manager, don't deploy new one
     cert-manager:
       enabled: false


### PR DESCRIPTION
Chart 1.0.18 has a broken `_helpers.tpl` — `.Values.global.dualStack.enabled` is referenced inside a `tpl` context where global scope is lost. Even `helm template` with default values fails. 1.0.17 renders cleanly. Pin until upstream fixes.

Also removes the `global.dualStack` workaround from #2384 since 1.0.17 doesn't need it.