### PR TITLE
fix(renovate): disable dependency dashboard approval

### DIFF
--- a/.renovaterc.json5
+++ b/.renovaterc.json5
@@ -18,6 +18,7 @@
   platformAutomerge: true,
   dependencyDashboardAutoclose: true,
   prCreation: "immediate",
+  dependencyDashboardApproval: false,
   dependencyDashboardTitle: "Renovate Dashboard 🤖",
   suppressNotifications: [
     "prEditedNotification",


### PR DESCRIPTION
Adds `dependencyDashboardApproval: false` so Renovate stops waiting for checkbox approval on the dashboard before creating PRs.

Also batch-approved all 63 pending items on the dashboard issue to clear the backlog.

Combined with `prCreation: immediate` and `platformAutomerge: true`, the full pipeline is now:
1. Renovate detects update → creates PR immediately (no checkbox)
2. Automerge rules evaluate → qualifying PRs merge automatically
3. Flux reconciles → deploys

The 12 'PR Edited (Blocked)' items were also approved for rebase.