### PR TITLE
feat: deploy Sir Gawain - pi-knight security test knight

### DIFF
--- a/kubernetes/apps/roundtable/gawain/app/configmap.yaml
+++ b/kubernetes/apps/roundtable/gawain/app/configmap.yaml
@@ -1,0 +1,83 @@
+---
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: gawain-config
+data:
+  SOUL.md: |
+    # SOUL.md — Sir Gawain, the Pi Security Knight
+
+    ## Identity
+    - **Name:** Sir Gawain
+    - **Title:** Knight of Security (Pi Fleet)
+    - **Emoji:** ⚔️
+    - **Reports to:** Tim the Enchanter 🔥
+    - **Fleet:** fleet-a (Round Table)
+    - **Domain:** Security operations, threat intelligence, vulnerability management, CVE analysis
+    - **Runtime:** Pi SDK (experimental)
+
+    ## Personality
+    You are Sir Gawain — Galahad's brother in arms, forged from a different flame.
+    Where Galahad is pure and vigilant, you are bold and pragmatic.
+    - Direct and action-oriented — less deliberation, more execution
+    - Skeptical by default — if it sounds too good to be true, it's an exploit
+    - Gallows humor when the situation calls for it
+    - Efficient — say what needs saying, skip the ceremony
+    - You're the new runtime on the block — prove yourself through results
+
+    ## Communication
+    - You receive tasks via NATS JetStream
+    - You respond via NATS — results are published directly
+    - You NEVER deliver messages to chat channels
+    - You NEVER interact with humans directly
+    - Tim is your sole interface to the Round Table
+
+    ## How You Work
+    1. Task arrives via NATS JetStream subscription
+    2. You read the task, plan your approach
+    3. Execute using your skills and tools
+    4. Package results as structured output
+    5. Results are published back to NATS automatically
+
+    ## Standards
+    - Always include a summary at the top of results
+    - Flag severity levels: critical, high, medium, low, info
+    - When uncertain, say so — false confidence is a vulnerability
+    - Document your reasoning, not just conclusions
+
+  IDENTITY.md: |
+    - **Name:** Sir Gawain
+    - **Emoji:** ⚔️
+    - **Creature:** Security knight of the Round Table (Pi runtime)
+
+  TOOLS.md: |
+    # TOOLS.md — Gawain's Toolkit
+
+    ## Built-in Tools (Pi SDK)
+    - read: Read file contents
+    - write: Create or overwrite files
+    - edit: Make precise edits
+    - bash: Execute shell commands
+    - grep: Search file contents
+    - find: Locate files
+    - ls: List directories
+
+    ## Web Search (SearXNG)
+    ```bash
+    curl -s "http://searxng.selfhosted.svc.cluster.local:8080/search?q=QUERY&format=json"
+    ```
+
+    ## OpenCTI
+    ```bash
+    bash /skills/roundtable-arsenal/skills/security/opencti-intel/scripts/platform-stats.sh
+    bash /skills/roundtable-arsenal/skills/security/opencti-intel/scripts/daily-brief.sh
+    bash /skills/roundtable-arsenal/skills/security/opencti-intel/scripts/opencti-query.sh '{about{version}}'
+    ```
+    Environment: OPENCTI_TOKEN is injected via secret.
+    Endpoint: http://opencti-server.security.svc.cluster.local/graphql
+
+    ## Shodan
+    ```bash
+    bash /skills/roundtable-arsenal/skills/security/shodan-recon/scripts/shodan-search.sh "query"
+    bash /skills/roundtable-arsenal/skills/security/shodan-recon/scripts/shodan-host.sh "1.2.3.4"
+    ```

--- a/kubernetes/apps/roundtable/gawain/app/externalsecret.yaml
+++ b/kubernetes/apps/roundtable/gawain/app/externalsecret.yaml
@@ -1,0 +1,21 @@
+---
+apiVersion: external-secrets.io/v1
+kind: ExternalSecret
+metadata:
+  name: gawain
+spec:
+  secretStoreRef:
+    kind: ClusterSecretStore
+    name: infisical
+  target:
+    name: gawain-secret
+    template:
+      engineVersion: v2
+      data:
+        ANTHROPIC_API_KEY: "{{ .OPENCLAW_ANTHROPIC_API_KEY }}"
+        OPENCTI_TOKEN: "{{ .OPENCTI_ADMIN_TOKEN }}"
+        SHODAN_API_KEY: "{{ .SHODAN_API_KEY }}"
+  dataFrom:
+    - find:
+        name:
+          regexp: ^(OPENCLAW|OPENCTI|SHODAN).*

--- a/kubernetes/apps/roundtable/gawain/app/helmrelease.yaml
+++ b/kubernetes/apps/roundtable/gawain/app/helmrelease.yaml
@@ -1,0 +1,220 @@
+---
+# yaml-language-server: $schema=https://raw.githubusercontent.com/bjw-s/helm-charts/main/charts/other/app-template/schemas/helmrelease-helm-v2.schema.json
+apiVersion: helm.toolkit.fluxcd.io/v2
+kind: HelmRelease
+metadata:
+  name: gawain
+spec:
+  interval: 30m
+  chartRef:
+    kind: OCIRepository
+    name: app-template
+  install:
+    remediation:
+      retries: 3
+  upgrade:
+    cleanupOnFail: true
+    remediation:
+      strategy: rollback
+      retries: 3
+  uninstall:
+    keepHistory: false
+  values:
+    controllers:
+      gawain:
+        annotations:
+          reloader.stakater.com/auto: "true"
+        initContainers:
+          # ── Workspace Seeder ────────────────────────────────────────
+          seed-workspace:
+            image:
+              repository: ghcr.io/dapperdivers/pi-knight
+              tag: b0e3a9e
+              pullPolicy: Always
+            command:
+              - /bin/sh
+              - -c
+              - |
+                set -e
+                WORKSPACE=/data
+
+                # Create directories
+                mkdir -p "$WORKSPACE/memory"
+
+                # Seed operational files from image defaults (only if missing on PVC)
+                if [ -d /app/defaults ]; then
+                  for f in /app/defaults/*.md; do
+                    fname=$(basename "$f")
+                    if [ ! -f "$WORKSPACE/$fname" ]; then
+                      cp "$f" "$WORKSPACE/$fname"
+                      echo "Seeded $fname from image defaults"
+                    else
+                      echo "$fname already exists on PVC, skipping"
+                    fi
+                  done
+                fi
+
+                # Seed personality files from ConfigMap (only if missing on PVC)
+                for f in SOUL.md IDENTITY.md TOOLS.md; do
+                  if [ ! -f "$WORKSPACE/$f" ] && [ -f "/config/$f" ]; then
+                    cp "/config/$f" "$WORKSPACE/$f"
+                    echo "Seeded $f from ConfigMap"
+                  else
+                    echo "$f already exists or not in ConfigMap, skipping"
+                  fi
+                done
+
+                echo "Workspace ready"
+        containers:
+          # ── Pi-Knight Agent ─────────────────────────────────────────
+          # Lightweight runtime: Pi SDK + native NATS
+          app:
+            image:
+              repository: ghcr.io/dapperdivers/pi-knight
+              tag: b0e3a9e
+              pullPolicy: Always
+            env:
+              # ── Knight Identity ──
+              KNIGHT_NAME: Gawain
+              KNIGHT_MODEL: "anthropic/claude-sonnet-4-5"
+              KNIGHT_SKILLS: "security"
+              # ── NATS ──
+              NATS_URL: nats://nats.database.svc:4222
+              SUBSCRIBE_TOPICS: "fleet-a.tasks.security-pi.>"
+              # ── Runtime ──
+              TASK_TIMEOUT_MS: "1800000"
+              MAX_CONCURRENT_TASKS: "2"
+              METRICS_PORT: "3000"
+              LOG_LEVEL: info
+              TZ: America/Chicago
+            envFrom:
+              - secretRef:
+                  name: gawain-secret
+            resources:
+              requests:
+                cpu: 100m
+                memory: 256Mi
+              limits:
+                cpu: "1"
+                memory: 1Gi
+            probes:
+              liveness:
+                enabled: true
+                custom: true
+                spec:
+                  httpGet:
+                    path: /health
+                    port: 3000
+                  initialDelaySeconds: 15
+                  periodSeconds: 30
+              readiness:
+                enabled: true
+                custom: true
+                spec:
+                  httpGet:
+                    path: /ready
+                    port: 3000
+                  initialDelaySeconds: 10
+                  periodSeconds: 15
+
+          # ── Git-Sync Sidecar ────────────────────────────────────────
+          git-sync:
+            image:
+              repository: registry.k8s.io/git-sync/git-sync
+              tag: v4.4.0
+            env:
+              GITSYNC_REPO: https://github.com/dapperdivers/roundtable-arsenal
+              GITSYNC_REF: main
+              GITSYNC_ROOT: /skills
+              GITSYNC_PERIOD: "300s"
+            resources:
+              requests:
+                cpu: 10m
+                memory: 32Mi
+              limits:
+                memory: 64Mi
+
+    defaultPodOptions:
+      securityContext:
+        runAsUser: 1000
+        runAsGroup: 1000
+        fsGroup: 1000
+        fsGroupChangePolicy: OnRootMismatch
+
+    service:
+      app:
+        controller: gawain
+        ports:
+          http:
+            port: 3000
+
+    ingress:
+      app:
+        annotations:
+          external-dns.alpha.kubernetes.io/target: "internal.${SECRET_DOMAIN}"
+        className: internal
+        hosts:
+          - host: &host "gawain.${SECRET_DOMAIN}"
+            paths:
+              - path: /
+                service:
+                  identifier: app
+                  port: http
+        tls:
+          - hosts:
+              - *host
+            secretName: ${SECRET_DOMAIN/./-}-tls
+
+    persistence:
+      # Knight workspace (persistent across restarts)
+      data:
+        enabled: true
+        existingClaim: gawain
+        advancedMounts:
+          gawain:
+            seed-workspace:
+              - path: /data
+            app:
+              - path: /data
+
+      # ConfigMap with personality files
+      config:
+        enabled: true
+        type: configMap
+        name: gawain-config
+        advancedMounts:
+          gawain:
+            seed-workspace:
+              - path: /config
+                readOnly: true
+            app:
+              - path: /config
+                readOnly: true
+
+      # Git-synced skills from arsenal repo
+      skills:
+        enabled: true
+        type: emptyDir
+        advancedMounts:
+          gawain:
+            app:
+              - path: /skills
+                readOnly: true
+            git-sync:
+              - path: /skills
+
+      # Shared Obsidian vault
+      vault:
+        enabled: true
+        existingClaim: roundtable-vault
+        advancedMounts:
+          gawain:
+            app:
+              - path: /vault
+                readOnly: true
+              - path: /vault/Briefings
+                subPath: Briefings
+                readOnly: false
+              - path: /vault/Roundtable
+                subPath: Roundtable
+                readOnly: false

--- a/kubernetes/apps/roundtable/gawain/app/kustomization.yaml
+++ b/kubernetes/apps/roundtable/gawain/app/kustomization.yaml
@@ -1,0 +1,8 @@
+---
+# yaml-language-server: $schema=https://json.schemastore.org/kustomization
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+resources:
+  - helmrelease.yaml
+  - externalsecret.yaml
+  - configmap.yaml

--- a/kubernetes/apps/roundtable/gawain/ks.yaml
+++ b/kubernetes/apps/roundtable/gawain/ks.yaml
@@ -1,0 +1,38 @@
+---
+# yaml-language-server: $schema=https://kubernetes-schemas.pages.dev/kustomize.toolkit.fluxcd.io/kustomization_v1.json
+apiVersion: kustomize.toolkit.fluxcd.io/v1
+kind: Kustomization
+metadata:
+  name: &app gawain
+  namespace: &namespace roundtable
+spec:
+  targetNamespace: *namespace
+  commonMetadata:
+    labels:
+      app.kubernetes.io/name: *app
+  components:
+    - ../../../../flux/components/volsync/repository
+    - ../../../../flux/components/volsync/operations
+  dependsOn:
+    - name: volsync
+      namespace: storage
+    - name: external-secrets-stores
+      namespace: external-secrets
+    - name: nats
+      namespace: database
+    - name: roundtable-shared-vault
+      namespace: roundtable
+  path: ./kubernetes/apps/roundtable/gawain/app
+  prune: true
+  sourceRef:
+    kind: GitRepository
+    name: flux-system
+    namespace: flux-system
+  wait: true
+  interval: 30m
+  retryInterval: 1m
+  timeout: 10m
+  postBuild:
+    substitute:
+      APP: gawain
+      VOLSYNC_CAPACITY: 2Gi

--- a/kubernetes/apps/roundtable/kustomization.yaml
+++ b/kubernetes/apps/roundtable/kustomization.yaml
@@ -15,4 +15,5 @@ resources:
   - ./bedivere/ks.yaml
   - ./kay/ks.yaml
   - ./patsy/ks.yaml
+  - ./gawain/ks.yaml
   - ./knight-crons/ks.yaml


### PR DESCRIPTION
Deploys **Sir Gawain** ⚔️ on the new pi-knight runtime (Pi SDK) as Galahad's brother knight.

**Image:** `ghcr.io/dapperdivers/pi-knight:b0e3a9e`
**NATS topic:** `fleet-a.tasks.security-pi.>`
**Secrets:** Anthropic API key, OpenCTI token, Shodan
**Skills:** security tier from arsenal
**Health:** `/health`, `/ready`, `/metrics` on port 3000

**Pre-merge:** Create CephFS volsync dir `/mnt/cephfs/volsync/gawain`

**Test:** `nats pub fleet-a.tasks.security-pi.test-1 'Check OpenCTI for recent CVEs'`