### PR TITLE
feat(gawain): pi-knight native NATS tools + persistent sessions

### DIFF
--- a/kubernetes/apps/roundtable/gawain/app/helmrelease.yaml
+++ b/kubernetes/apps/roundtable/gawain/app/helmrelease.yaml
@@ -29,7 +29,7 @@ spec:
           seed-workspace:
             image:
               repository: ghcr.io/dapperdivers/pi-knight
-              tag: fdf6f2fd63d6db23889415628d5f05a6c49906ed
+              tag: ccc48634a31a46f3e0ebc19e9a2e66dd6e94e3b2
               pullPolicy: Always
             command:
               - /bin/sh
@@ -71,13 +71,12 @@ spec:
           app:
             image:
               repository: ghcr.io/dapperdivers/pi-knight
-              tag: fdf6f2fd63d6db23889415628d5f05a6c49906ed
+              tag: ccc48634a31a46f3e0ebc19e9a2e66dd6e94e3b2
               pullPolicy: Always
             env:
               # ── Knight Identity ──
               KNIGHT_NAME: Gawain
               KNIGHT_MODEL: "anthropic/claude-sonnet-4-5"
-              KNIGHT_SKILLS: "security"
               # ── NATS ──
               NATS_URL: nats://nats.database.svc:4222
               SUBSCRIBE_TOPICS: "fleet-a.tasks.security-pi.>"


### PR DESCRIPTION
## Changes
- Image bump: `fdf6f2f` → `ccc4863`
- **Native NATS tools**: `nats_publish` and `nats_request` registered as Pi SDK custom tools — no more bash scripts
- **Persistent sessions**: AgentSession reused across tasks with auto-compaction
- **KNIGHT_THINKING**: env var wired to Pi SDK thinking level
- **Abort signal**: properly connected to session.abort()
- **Remove KNIGHT_SKILLS**: managed at gitsync/helm layer, not in runtime

## Testing
Merge and dispatch a test task to Gawain via NATS to verify:
1. Task execution works on new image
2. nats_request tool is available in tool list
3. Session persists across multiple tasks