### PR TITLE
feat(gawain): skill-filter sidecar for per-knight skill scoping

### DIFF
--- a/kubernetes/apps/roundtable/gawain/app/helmrelease.yaml
+++ b/kubernetes/apps/roundtable/gawain/app/helmrelease.yaml
@@ -124,7 +124,7 @@ spec:
             env:
               GITSYNC_REPO: https://github.com/dapperdivers/roundtable-arsenal
               GITSYNC_REF: main
-              GITSYNC_ROOT: /skills
+              GITSYNC_ROOT: /arsenal
               GITSYNC_PERIOD: "300s"
             resources:
               requests:
@@ -132,6 +132,42 @@ spec:
                 memory: 32Mi
               limits:
                 memory: 64Mi
+
+          # ── Skill Filter Sidecar ────────────────────────────────────
+          # Symlinks only the needed skill categories from the full
+          # arsenal into /skills so Pi SDK only discovers relevant ones.
+          skill-filter:
+            image:
+              repository: alpine
+              tag: "3.21"
+            env:
+              SKILL_CATEGORIES: "shared security"
+            command:
+              - /bin/sh
+              - -c
+              - |
+                ARSENAL="/arsenal/roundtable-arsenal"
+                TARGET="/skills"
+                echo "Skill filter starting: categories=$SKILL_CATEGORIES"
+                while true; do
+                  if [ -d "$ARSENAL" ]; then
+                    for cat in $SKILL_CATEGORIES; do
+                      src="$ARSENAL/$cat"
+                      dst="$TARGET/$cat"
+                      if [ -d "$src" ] && [ ! -L "$dst" ]; then
+                        ln -sf "$src" "$dst"
+                        echo "Linked $cat"
+                      fi
+                    done
+                  fi
+                  sleep 30
+                done
+            resources:
+              requests:
+                cpu: 5m
+                memory: 8Mi
+              limits:
+                memory: 16Mi
 
     defaultPodOptions:
       securityContext:
@@ -190,17 +226,29 @@ spec:
               - path: /config
                 readOnly: true
 
-      # Git-synced skills from arsenal repo
+      # Raw arsenal repo (git-sync writes here)
+      arsenal:
+        enabled: true
+        type: emptyDir
+        advancedMounts:
+          gawain:
+            git-sync:
+              - path: /arsenal
+            skill-filter:
+              - path: /arsenal
+                readOnly: true
+
+      # Filtered skills (only categories this knight needs)
       skills:
         enabled: true
         type: emptyDir
         advancedMounts:
           gawain:
+            skill-filter:
+              - path: /skills
             app:
               - path: /skills
                 readOnly: true
-            git-sync:
-              - path: /skills
 
       # Shared Obsidian vault
       vault:


### PR DESCRIPTION
## Problem
Gawain loaded all 31 skills from the arsenal — should only see shared + security.

## Solution
Add a lightweight skill-filter sidecar (alpine, 8Mi RAM) that:
1. Watches `/arsenal` (where git-sync writes the full repo)
2. Symlinks only `SKILL_CATEGORIES` into `/skills` (where Pi SDK discovers)

Architecture:
```
git-sync → /arsenal (full repo)
skill-filter → reads /arsenal, symlinks selected categories → /skills
pi-knight → reads /skills (only sees shared + security)
```

## Per-Knight Config
Just change the env var:
- Gawain: `SKILL_CATEGORIES: "shared security"`
- Percival: `SKILL_CATEGORIES: "shared finance"`
- Kay: `SKILL_CATEGORIES: "shared research intel"`

Pattern is reusable across all knights.