### PR TITLE
fix(gawain): mount arsenal in app for symlink resolution

### DIFF
--- a/kubernetes/apps/roundtable/gawain/app/helmrelease.yaml
+++ b/kubernetes/apps/roundtable/gawain/app/helmrelease.yaml
@@ -261,6 +261,9 @@ spec:
             skill-filter:
               - path: /arsenal
                 readOnly: true
+            app:
+              - path: /arsenal
+                readOnly: true
 
       # Filtered skills (only categories this knight needs)
       skills:


### PR DESCRIPTION
Skill symlinks in /skills point to /arsenal/... but app container didn't have /arsenal mounted → dangling symlinks → 0 skills discovered.