### PR TITLE
feat(roundtable): migrate all 7 knights to pi-knight runtime

### DIFF
--- a/kubernetes/apps/roundtable/bedivere/app/helmrelease.yaml
+++ b/kubernetes/apps/roundtable/bedivere/app/helmrelease.yaml
@@ -25,63 +25,67 @@ spec:
         annotations:
           reloader.stakater.com/auto: "true"
         initContainers:
+          # ── Workspace Seeder ────────────────────────────────────────
           seed-workspace:
             image:
-              repository: ghcr.io/dapperdivers/knight-agent
-              tag: 7350b70
+              repository: ghcr.io/dapperdivers/pi-knight
+              tag: 3fe9b1438b15bbd84f9a21f8b81d916420fb1dfb
               pullPolicy: Always
             command:
               - /bin/sh
               - -c
               - |
                 set -e
-                WORKSPACE=/workspace
-                mkdir -p "$WORKSPACE/memory" "$WORKSPACE/local-skills"
-                mkdir -p /home/knight/.local/bin
+                WORKSPACE=/data
+
+                # Create directories
+                mkdir -p "$WORKSPACE/memory"
+
+                # Seed operational files from image defaults (only if missing on PVC)
                 if [ -d /app/defaults ]; then
                   for f in /app/defaults/*.md; do
                     fname=$(basename "$f")
                     if [ ! -f "$WORKSPACE/$fname" ]; then
                       cp "$f" "$WORKSPACE/$fname"
                       echo "Seeded $fname from image defaults"
+                    else
+                      echo "$fname already exists on PVC, skipping"
                     fi
                   done
                 fi
+
+                # Seed personality files from ConfigMap (only if missing on PVC)
                 for f in SOUL.md IDENTITY.md TOOLS.md; do
-                  if [ ! -f "$WORKSPACE/$f" ] && [ -f "/seed/$f" ]; then
-                    cp "/seed/$f" "$WORKSPACE/$f"
+                  if [ ! -f "$WORKSPACE/$f" ] && [ -f "/config/$f" ]; then
+                    cp "/config/$f" "$WORKSPACE/$f"
                     echo "Seeded $f from ConfigMap"
+                  else
+                    echo "$f already exists or not in ConfigMap, skipping"
                   fi
                 done
+
                 echo "Workspace ready"
         containers:
+          # ── Pi-Knight Agent ─────────────────────────────────────────
+          # Lightweight runtime: Pi SDK + native NATS
           app:
             image:
-              repository: ghcr.io/dapperdivers/knight-agent
-              tag: 7350b70
+              repository: ghcr.io/dapperdivers/pi-knight
+              tag: 3fe9b1438b15bbd84f9a21f8b81d916420fb1dfb
               pullPolicy: Always
             env:
-              WORKSPACE_DIR: /workspace
+              # ── Knight Identity ──
               KNIGHT_NAME: Bedivere
-              LOG_LEVEL: info
-              PORT: "18789"
-              TZ: America/Chicago
-              MAX_CONCURRENT_TASKS: "2"
-              ANTHROPIC_SMALL_FAST_MODEL: claude-haiku-3-5-20241022
-              CLAUDE_CODE_SUBAGENT_MODEL: claude-sonnet-4-5-20250929
-              CLAUDE_CODE_MAX_RETRIES: "3"
-              CLAUDE_CODE_EFFORT_LEVEL: medium
-              CLAUDE_CODE_ENABLE_TASKS: "1"
-              CLAUDE_CODE_DISABLE_AUTO_MEMORY: "1"
-              CLAUDE_CODE_DISABLE_BACKGROUND_TASKS: "1"
-              CLAUDE_CODE_DISABLE_NONESSENTIAL_TRAFFIC: "1"
-              DISABLE_TELEMETRY: "1"
-              DISABLE_AUTOUPDATER: "1"
+              KNIGHT_MODEL: "anthropic/claude-sonnet-4-5"
+              # ── NATS ──
               NATS_URL: nats://nats.database.svc:4222
-              FLEET_ID: fleet-a
-              AGENT_ID: bedivere
               SUBSCRIBE_TOPICS: "fleet-a.tasks.home.>"
-              KNIGHT_SKILLS: "home"
+              # ── Runtime ──
+              TASK_TIMEOUT_MS: "1800000"
+              MAX_CONCURRENT_TASKS: "2"
+              METRICS_PORT: "3000"
+              LOG_LEVEL: info
+              TZ: America/Chicago
             envFrom:
               - secretRef:
                   name: bedivere-secret
@@ -98,8 +102,8 @@ spec:
                 custom: true
                 spec:
                   httpGet:
-                    path: /healthz
-                    port: 18789
+                    path: /health
+                    port: 3000
                   initialDelaySeconds: 15
                   periodSeconds: 30
               readiness:
@@ -107,10 +111,12 @@ spec:
                 custom: true
                 spec:
                   httpGet:
-                    path: /readyz
-                    port: 18789
+                    path: /ready
+                    port: 3000
                   initialDelaySeconds: 10
                   periodSeconds: 15
+
+          # ── Git-Sync Sidecar ────────────────────────────────────────
           git-sync:
             image:
               repository: registry.k8s.io/git-sync/git-sync
@@ -118,7 +124,7 @@ spec:
             env:
               GITSYNC_REPO: https://github.com/dapperdivers/roundtable-arsenal
               GITSYNC_REF: main
-              GITSYNC_ROOT: /workspace/skills
+              GITSYNC_ROOT: /arsenal
               GITSYNC_PERIOD: "300s"
             resources:
               requests:
@@ -126,18 +132,81 @@ spec:
                 memory: 32Mi
               limits:
                 memory: 64Mi
+
+          # ── Skill Filter Sidecar ────────────────────────────────────
+          # Symlinks only the needed skill categories from the full
+          # arsenal into /skills so Pi SDK only discovers relevant ones.
+          skill-filter:
+            image:
+              repository: alpine
+              tag: "3.21"
+            env:
+              SKILL_CATEGORIES: "shared home"
+            command:
+              - /bin/sh
+              - -c
+              - |
+                ARSENAL="/arsenal/roundtable-arsenal"
+                TARGET="/skills"
+                echo "Skill filter starting: categories=$SKILL_CATEGORIES"
+                # Fast initial loop until all categories are linked
+                LINKED=0
+                EXPECTED=$(echo $SKILL_CATEGORIES | wc -w)
+                while [ "$LINKED" -lt "$EXPECTED" ]; do
+                  LINKED=0
+                  if [ -d "$ARSENAL" ]; then
+                    for cat in $SKILL_CATEGORIES; do
+                      src="$ARSENAL/$cat"
+                      dst="$TARGET/$cat"
+                      if [ -d "$src" ] && [ ! -L "$dst" ]; then
+                        ln -sf "$src" "$dst"
+                        echo "Linked $cat"
+                      fi
+                      [ -L "$dst" ] && LINKED=$((LINKED + 1))
+                    done
+                  fi
+                  [ "$LINKED" -lt "$EXPECTED" ] && sleep 2
+                done
+                echo "All categories linked ($LINKED/$EXPECTED)"
+                # Slow maintenance loop — re-link if git-sync recreates worktree
+                while true; do
+                  if [ -d "$ARSENAL" ]; then
+                    for cat in $SKILL_CATEGORIES; do
+                      src="$ARSENAL/$cat"
+                      dst="$TARGET/$cat"
+                      # Re-link if symlink target changed (git-sync new worktree)
+                      if [ -d "$src" ]; then
+                        current=$(readlink "$dst" 2>/dev/null || echo "")
+                        if [ "$current" != "$src" ]; then
+                          ln -sf "$src" "$dst"
+                          echo "Re-linked $cat"
+                        fi
+                      fi
+                    done
+                  fi
+                  sleep 60
+                done
+            resources:
+              requests:
+                cpu: 5m
+                memory: 8Mi
+              limits:
+                memory: 16Mi
+
     defaultPodOptions:
       securityContext:
         runAsUser: 1000
         runAsGroup: 1000
         fsGroup: 1000
         fsGroupChangePolicy: OnRootMismatch
+
     service:
       app:
         controller: bedivere
         ports:
           http:
-            port: 18789
+            port: 3000
+
     ingress:
       app:
         annotations:
@@ -154,42 +223,61 @@ spec:
           - hosts:
               - *host
             secretName: ${SECRET_DOMAIN/./-}-tls
+
     persistence:
+      # Knight workspace (persistent across restarts)
       data:
         enabled: true
         existingClaim: bedivere
         advancedMounts:
           bedivere:
             seed-workspace:
-              - path: /workspace
-              - path: /home/knight
-                subPath: home
+              - path: /data
             app:
-              - path: /workspace
-              - path: /home/knight
-                subPath: home
-      seed:
+              - path: /data
+
+      # ConfigMap with personality files
+      config:
         enabled: true
         type: configMap
         name: bedivere-config
         advancedMounts:
           bedivere:
             seed-workspace:
-              - path: /seed
+              - path: /config
                 readOnly: true
-      # Git-synced skills from arsenal repo
+            app:
+              - path: /config
+                readOnly: true
+
+      # Raw arsenal repo (git-sync writes here)
+      arsenal:
+        enabled: true
+        type: emptyDir
+        advancedMounts:
+          bedivere:
+            git-sync:
+              - path: /arsenal
+            skill-filter:
+              - path: /arsenal
+                readOnly: true
+            app:
+              - path: /arsenal
+                readOnly: true
+
+      # Filtered skills (only categories this knight needs)
       skills:
         enabled: true
         type: emptyDir
         advancedMounts:
           bedivere:
+            skill-filter:
+              - path: /skills
             app:
-              - path: /workspace/skills
+              - path: /skills
                 readOnly: true
-            git-sync:
-              - path: /workspace/skills
 
-      # Shared Obsidian vault (read-only base, RW for Briefings + Roundtable)
+      # Shared Obsidian vault
       vault:
         enabled: true
         existingClaim: roundtable-vault

--- a/kubernetes/apps/roundtable/galahad/app/helmrelease.yaml
+++ b/kubernetes/apps/roundtable/galahad/app/helmrelease.yaml
@@ -26,23 +26,20 @@ spec:
           reloader.stakater.com/auto: "true"
         initContainers:
           # ── Workspace Seeder ────────────────────────────────────────
-          # Seeds workspace files from ConfigMap on first deploy.
-          # Only writes files that don't already exist (preserves knight memory).
           seed-workspace:
             image:
-              repository: ghcr.io/dapperdivers/knight-agent
-              tag: 7350b70
+              repository: ghcr.io/dapperdivers/pi-knight
+              tag: 3fe9b1438b15bbd84f9a21f8b81d916420fb1dfb
               pullPolicy: Always
             command:
               - /bin/sh
               - -c
               - |
                 set -e
-                WORKSPACE=/workspace
+                WORKSPACE=/data
 
                 # Create directories
-                mkdir -p "$WORKSPACE/memory" "$WORKSPACE/local-skills"
-                mkdir -p /home/knight/.local/bin
+                mkdir -p "$WORKSPACE/memory"
 
                 # Seed operational files from image defaults (only if missing on PVC)
                 if [ -d /app/defaults ]; then
@@ -59,8 +56,8 @@ spec:
 
                 # Seed personality files from ConfigMap (only if missing on PVC)
                 for f in SOUL.md IDENTITY.md TOOLS.md; do
-                  if [ ! -f "$WORKSPACE/$f" ] && [ -f "/seed/$f" ]; then
-                    cp "/seed/$f" "$WORKSPACE/$f"
+                  if [ ! -f "$WORKSPACE/$f" ] && [ -f "/config/$f" ]; then
+                    cp "/config/$f" "$WORKSPACE/$f"
                     echo "Seeded $f from ConfigMap"
                   else
                     echo "$f already exists or not in ConfigMap, skipping"
@@ -69,40 +66,26 @@ spec:
 
                 echo "Workspace ready"
         containers:
-          # ── Knight Agent ────────────────────────────────────────────
-          # Lightweight runtime: Claude Agent SDK + native NATS
+          # ── Pi-Knight Agent ─────────────────────────────────────────
+          # Lightweight runtime: Pi SDK + native NATS
           app:
             image:
-              repository: ghcr.io/dapperdivers/knight-agent
-              tag: 7350b70
+              repository: ghcr.io/dapperdivers/pi-knight
+              tag: 3fe9b1438b15bbd84f9a21f8b81d916420fb1dfb
               pullPolicy: Always
             env:
-              # ── Runtime ──
-              WORKSPACE_DIR: /workspace
+              # ── Knight Identity ──
               KNIGHT_NAME: Galahad
-              LOG_LEVEL: info
-              PORT: "18789"
-              TZ: America/Chicago
-              # ── Task Execution ──
-              MAX_CONCURRENT_TASKS: "2"
-              # ── Claude Code SDK ──
-              ANTHROPIC_SMALL_FAST_MODEL: claude-haiku-3-5-20241022
-              CLAUDE_CODE_SUBAGENT_MODEL: claude-sonnet-4-5-20250929
-              CLAUDE_CODE_MAX_RETRIES: "3"
-              CLAUDE_CODE_EFFORT_LEVEL: medium
-              CLAUDE_CODE_ENABLE_TASKS: "1"
-              # ── SDK Hardening (headless pod) ──
-              CLAUDE_CODE_DISABLE_AUTO_MEMORY: "1"
-              CLAUDE_CODE_DISABLE_BACKGROUND_TASKS: "1"
-              CLAUDE_CODE_DISABLE_NONESSENTIAL_TRAFFIC: "1"
-              DISABLE_TELEMETRY: "1"
-              DISABLE_AUTOUPDATER: "1"
-              # ── NATS (native — no sidecar needed) ──
+              KNIGHT_MODEL: "anthropic/claude-sonnet-4-5"
+              # ── NATS ──
               NATS_URL: nats://nats.database.svc:4222
-              FLEET_ID: fleet-a
-              AGENT_ID: galahad
               SUBSCRIBE_TOPICS: "fleet-a.tasks.security.>"
-              KNIGHT_SKILLS: "security"
+              # ── Runtime ──
+              TASK_TIMEOUT_MS: "1800000"
+              MAX_CONCURRENT_TASKS: "2"
+              METRICS_PORT: "3000"
+              LOG_LEVEL: info
+              TZ: America/Chicago
             envFrom:
               - secretRef:
                   name: galahad-secret
@@ -119,8 +102,8 @@ spec:
                 custom: true
                 spec:
                   httpGet:
-                    path: /healthz
-                    port: 18789
+                    path: /health
+                    port: 3000
                   initialDelaySeconds: 15
                   periodSeconds: 30
               readiness:
@@ -128,13 +111,12 @@ spec:
                 custom: true
                 spec:
                   httpGet:
-                    path: /readyz
-                    port: 18789
+                    path: /ready
+                    port: 3000
                   initialDelaySeconds: 10
                   periodSeconds: 15
 
           # ── Git-Sync Sidecar ────────────────────────────────────────
-          # Pulls skills from arsenal repo (shared + security tiers)
           git-sync:
             image:
               repository: registry.k8s.io/git-sync/git-sync
@@ -142,7 +124,7 @@ spec:
             env:
               GITSYNC_REPO: https://github.com/dapperdivers/roundtable-arsenal
               GITSYNC_REF: main
-              GITSYNC_ROOT: /workspace/skills
+              GITSYNC_ROOT: /arsenal
               GITSYNC_PERIOD: "300s"
             resources:
               requests:
@@ -150,6 +132,66 @@ spec:
                 memory: 32Mi
               limits:
                 memory: 64Mi
+
+          # ── Skill Filter Sidecar ────────────────────────────────────
+          # Symlinks only the needed skill categories from the full
+          # arsenal into /skills so Pi SDK only discovers relevant ones.
+          skill-filter:
+            image:
+              repository: alpine
+              tag: "3.21"
+            env:
+              SKILL_CATEGORIES: "shared security"
+            command:
+              - /bin/sh
+              - -c
+              - |
+                ARSENAL="/arsenal/roundtable-arsenal"
+                TARGET="/skills"
+                echo "Skill filter starting: categories=$SKILL_CATEGORIES"
+                # Fast initial loop until all categories are linked
+                LINKED=0
+                EXPECTED=$(echo $SKILL_CATEGORIES | wc -w)
+                while [ "$LINKED" -lt "$EXPECTED" ]; do
+                  LINKED=0
+                  if [ -d "$ARSENAL" ]; then
+                    for cat in $SKILL_CATEGORIES; do
+                      src="$ARSENAL/$cat"
+                      dst="$TARGET/$cat"
+                      if [ -d "$src" ] && [ ! -L "$dst" ]; then
+                        ln -sf "$src" "$dst"
+                        echo "Linked $cat"
+                      fi
+                      [ -L "$dst" ] && LINKED=$((LINKED + 1))
+                    done
+                  fi
+                  [ "$LINKED" -lt "$EXPECTED" ] && sleep 2
+                done
+                echo "All categories linked ($LINKED/$EXPECTED)"
+                # Slow maintenance loop — re-link if git-sync recreates worktree
+                while true; do
+                  if [ -d "$ARSENAL" ]; then
+                    for cat in $SKILL_CATEGORIES; do
+                      src="$ARSENAL/$cat"
+                      dst="$TARGET/$cat"
+                      # Re-link if symlink target changed (git-sync new worktree)
+                      if [ -d "$src" ]; then
+                        current=$(readlink "$dst" 2>/dev/null || echo "")
+                        if [ "$current" != "$src" ]; then
+                          ln -sf "$src" "$dst"
+                          echo "Re-linked $cat"
+                        fi
+                      fi
+                    done
+                  fi
+                  sleep 60
+                done
+            resources:
+              requests:
+                cpu: 5m
+                memory: 8Mi
+              limits:
+                memory: 16Mi
 
     defaultPodOptions:
       securityContext:
@@ -163,7 +205,7 @@ spec:
         controller: galahad
         ports:
           http:
-            port: 18789
+            port: 3000
 
     ingress:
       app:
@@ -190,38 +232,52 @@ spec:
         advancedMounts:
           galahad:
             seed-workspace:
-              - path: /workspace
-              - path: /home/knight
-                subPath: home
+              - path: /data
             app:
-              - path: /workspace
-              - path: /home/knight
-                subPath: home
+              - path: /data
 
-      # ConfigMap with workspace seed files
-      seed:
+      # ConfigMap with personality files
+      config:
         enabled: true
         type: configMap
         name: galahad-config
         advancedMounts:
           galahad:
             seed-workspace:
-              - path: /seed
+              - path: /config
+                readOnly: true
+            app:
+              - path: /config
                 readOnly: true
 
-      # Git-synced skills from arsenal repo
+      # Raw arsenal repo (git-sync writes here)
+      arsenal:
+        enabled: true
+        type: emptyDir
+        advancedMounts:
+          galahad:
+            git-sync:
+              - path: /arsenal
+            skill-filter:
+              - path: /arsenal
+                readOnly: true
+            app:
+              - path: /arsenal
+                readOnly: true
+
+      # Filtered skills (only categories this knight needs)
       skills:
         enabled: true
         type: emptyDir
         advancedMounts:
           galahad:
+            skill-filter:
+              - path: /skills
             app:
-              - path: /workspace/skills
+              - path: /skills
                 readOnly: true
-            git-sync:
-              - path: /workspace/skills
 
-      # Shared Obsidian vault (read-only base, RW for Briefings + Roundtable)
+      # Shared Obsidian vault
       vault:
         enabled: true
         existingClaim: roundtable-vault

--- a/kubernetes/apps/roundtable/kay/app/helmrelease.yaml
+++ b/kubernetes/apps/roundtable/kay/app/helmrelease.yaml
@@ -25,19 +25,22 @@ spec:
         annotations:
           reloader.stakater.com/auto: "true"
         initContainers:
+          # ── Workspace Seeder ────────────────────────────────────────
           seed-workspace:
             image:
-              repository: ghcr.io/dapperdivers/knight-agent
-              tag: 7350b70
+              repository: ghcr.io/dapperdivers/pi-knight
+              tag: 3fe9b1438b15bbd84f9a21f8b81d916420fb1dfb
               pullPolicy: Always
             command:
               - /bin/sh
               - -c
               - |
                 set -e
-                WORKSPACE=/workspace
-                mkdir -p "$WORKSPACE/memory" "$WORKSPACE/local-skills"
-                mkdir -p /home/knight/.local/bin
+                WORKSPACE=/data
+
+                # Create directories
+                mkdir -p "$WORKSPACE/memory"
+
                 # Seed operational files from image defaults (only if missing on PVC)
                 if [ -d /app/defaults ]; then
                   for f in /app/defaults/*.md; do
@@ -45,45 +48,44 @@ spec:
                     if [ ! -f "$WORKSPACE/$fname" ]; then
                       cp "$f" "$WORKSPACE/$fname"
                       echo "Seeded $fname from image defaults"
+                    else
+                      echo "$fname already exists on PVC, skipping"
                     fi
                   done
                 fi
+
                 # Seed personality files from ConfigMap (only if missing on PVC)
                 for f in SOUL.md IDENTITY.md TOOLS.md; do
-                  if [ ! -f "$WORKSPACE/$f" ] && [ -f "/seed/$f" ]; then
-                    cp "/seed/$f" "$WORKSPACE/$f"
+                  if [ ! -f "$WORKSPACE/$f" ] && [ -f "/config/$f" ]; then
+                    cp "/config/$f" "$WORKSPACE/$f"
                     echo "Seeded $f from ConfigMap"
+                  else
+                    echo "$f already exists or not in ConfigMap, skipping"
                   fi
                 done
+
                 echo "Workspace ready"
         containers:
+          # ── Pi-Knight Agent ─────────────────────────────────────────
+          # Lightweight runtime: Pi SDK + native NATS
           app:
             image:
-              repository: ghcr.io/dapperdivers/knight-agent
-              tag: 7350b70
+              repository: ghcr.io/dapperdivers/pi-knight
+              tag: 3fe9b1438b15bbd84f9a21f8b81d916420fb1dfb
               pullPolicy: Always
             env:
-              WORKSPACE_DIR: /workspace
+              # ── Knight Identity ──
               KNIGHT_NAME: Kay
-              LOG_LEVEL: info
-              PORT: "18789"
-              TZ: America/Chicago
-              MAX_CONCURRENT_TASKS: "2"
-              ANTHROPIC_SMALL_FAST_MODEL: claude-haiku-3-5-20241022
-              CLAUDE_CODE_SUBAGENT_MODEL: claude-sonnet-4-5-20250929
-              CLAUDE_CODE_MAX_RETRIES: "3"
-              CLAUDE_CODE_EFFORT_LEVEL: medium
-              CLAUDE_CODE_ENABLE_TASKS: "1"
-              CLAUDE_CODE_DISABLE_AUTO_MEMORY: "1"
-              CLAUDE_CODE_DISABLE_BACKGROUND_TASKS: "1"
-              CLAUDE_CODE_DISABLE_NONESSENTIAL_TRAFFIC: "1"
-              DISABLE_TELEMETRY: "1"
-              DISABLE_AUTOUPDATER: "1"
+              KNIGHT_MODEL: "anthropic/claude-sonnet-4-5"
+              # ── NATS ──
               NATS_URL: nats://nats.database.svc:4222
-              FLEET_ID: fleet-a
-              AGENT_ID: kay
               SUBSCRIBE_TOPICS: "fleet-a.tasks.research.>,fleet-a.tasks.intel.>"
-              KNIGHT_SKILLS: "research intel"
+              # ── Runtime ──
+              TASK_TIMEOUT_MS: "1800000"
+              MAX_CONCURRENT_TASKS: "2"
+              METRICS_PORT: "3000"
+              LOG_LEVEL: info
+              TZ: America/Chicago
             envFrom:
               - secretRef:
                   name: kay-secret
@@ -100,8 +102,8 @@ spec:
                 custom: true
                 spec:
                   httpGet:
-                    path: /healthz
-                    port: 18789
+                    path: /health
+                    port: 3000
                   initialDelaySeconds: 15
                   periodSeconds: 30
               readiness:
@@ -109,10 +111,12 @@ spec:
                 custom: true
                 spec:
                   httpGet:
-                    path: /readyz
-                    port: 18789
+                    path: /ready
+                    port: 3000
                   initialDelaySeconds: 10
                   periodSeconds: 15
+
+          # ── Git-Sync Sidecar ────────────────────────────────────────
           git-sync:
             image:
               repository: registry.k8s.io/git-sync/git-sync
@@ -120,7 +124,7 @@ spec:
             env:
               GITSYNC_REPO: https://github.com/dapperdivers/roundtable-arsenal
               GITSYNC_REF: main
-              GITSYNC_ROOT: /workspace/skills
+              GITSYNC_ROOT: /arsenal
               GITSYNC_PERIOD: "300s"
             resources:
               requests:
@@ -128,18 +132,81 @@ spec:
                 memory: 32Mi
               limits:
                 memory: 64Mi
+
+          # ── Skill Filter Sidecar ────────────────────────────────────
+          # Symlinks only the needed skill categories from the full
+          # arsenal into /skills so Pi SDK only discovers relevant ones.
+          skill-filter:
+            image:
+              repository: alpine
+              tag: "3.21"
+            env:
+              SKILL_CATEGORIES: "shared research intel"
+            command:
+              - /bin/sh
+              - -c
+              - |
+                ARSENAL="/arsenal/roundtable-arsenal"
+                TARGET="/skills"
+                echo "Skill filter starting: categories=$SKILL_CATEGORIES"
+                # Fast initial loop until all categories are linked
+                LINKED=0
+                EXPECTED=$(echo $SKILL_CATEGORIES | wc -w)
+                while [ "$LINKED" -lt "$EXPECTED" ]; do
+                  LINKED=0
+                  if [ -d "$ARSENAL" ]; then
+                    for cat in $SKILL_CATEGORIES; do
+                      src="$ARSENAL/$cat"
+                      dst="$TARGET/$cat"
+                      if [ -d "$src" ] && [ ! -L "$dst" ]; then
+                        ln -sf "$src" "$dst"
+                        echo "Linked $cat"
+                      fi
+                      [ -L "$dst" ] && LINKED=$((LINKED + 1))
+                    done
+                  fi
+                  [ "$LINKED" -lt "$EXPECTED" ] && sleep 2
+                done
+                echo "All categories linked ($LINKED/$EXPECTED)"
+                # Slow maintenance loop — re-link if git-sync recreates worktree
+                while true; do
+                  if [ -d "$ARSENAL" ]; then
+                    for cat in $SKILL_CATEGORIES; do
+                      src="$ARSENAL/$cat"
+                      dst="$TARGET/$cat"
+                      # Re-link if symlink target changed (git-sync new worktree)
+                      if [ -d "$src" ]; then
+                        current=$(readlink "$dst" 2>/dev/null || echo "")
+                        if [ "$current" != "$src" ]; then
+                          ln -sf "$src" "$dst"
+                          echo "Re-linked $cat"
+                        fi
+                      fi
+                    done
+                  fi
+                  sleep 60
+                done
+            resources:
+              requests:
+                cpu: 5m
+                memory: 8Mi
+              limits:
+                memory: 16Mi
+
     defaultPodOptions:
       securityContext:
         runAsUser: 1000
         runAsGroup: 1000
         fsGroup: 1000
         fsGroupChangePolicy: OnRootMismatch
+
     service:
       app:
         controller: kay
         ports:
           http:
-            port: 18789
+            port: 3000
+
     ingress:
       app:
         annotations:
@@ -156,42 +223,61 @@ spec:
           - hosts:
               - *host
             secretName: ${SECRET_DOMAIN/./-}-tls
+
     persistence:
+      # Knight workspace (persistent across restarts)
       data:
         enabled: true
         existingClaim: kay
         advancedMounts:
           kay:
             seed-workspace:
-              - path: /workspace
-              - path: /home/knight
-                subPath: home
+              - path: /data
             app:
-              - path: /workspace
-              - path: /home/knight
-                subPath: home
-      seed:
+              - path: /data
+
+      # ConfigMap with personality files
+      config:
         enabled: true
         type: configMap
         name: kay-config
         advancedMounts:
           kay:
             seed-workspace:
-              - path: /seed
+              - path: /config
                 readOnly: true
-      # Git-synced skills from arsenal repo
+            app:
+              - path: /config
+                readOnly: true
+
+      # Raw arsenal repo (git-sync writes here)
+      arsenal:
+        enabled: true
+        type: emptyDir
+        advancedMounts:
+          kay:
+            git-sync:
+              - path: /arsenal
+            skill-filter:
+              - path: /arsenal
+                readOnly: true
+            app:
+              - path: /arsenal
+                readOnly: true
+
+      # Filtered skills (only categories this knight needs)
       skills:
         enabled: true
         type: emptyDir
         advancedMounts:
           kay:
+            skill-filter:
+              - path: /skills
             app:
-              - path: /workspace/skills
+              - path: /skills
                 readOnly: true
-            git-sync:
-              - path: /workspace/skills
 
-      # Shared Obsidian vault (read-only base, RW for Briefings + Roundtable)
+      # Shared Obsidian vault
       vault:
         enabled: true
         existingClaim: roundtable-vault

--- a/kubernetes/apps/roundtable/lancelot/app/helmrelease.yaml
+++ b/kubernetes/apps/roundtable/lancelot/app/helmrelease.yaml
@@ -25,63 +25,67 @@ spec:
         annotations:
           reloader.stakater.com/auto: "true"
         initContainers:
+          # ── Workspace Seeder ────────────────────────────────────────
           seed-workspace:
             image:
-              repository: ghcr.io/dapperdivers/knight-agent
-              tag: 7350b70
+              repository: ghcr.io/dapperdivers/pi-knight
+              tag: 3fe9b1438b15bbd84f9a21f8b81d916420fb1dfb
               pullPolicy: Always
             command:
               - /bin/sh
               - -c
               - |
                 set -e
-                WORKSPACE=/workspace
-                mkdir -p "$WORKSPACE/memory" "$WORKSPACE/local-skills"
-                mkdir -p /home/knight/.local/bin
+                WORKSPACE=/data
+
+                # Create directories
+                mkdir -p "$WORKSPACE/memory"
+
+                # Seed operational files from image defaults (only if missing on PVC)
                 if [ -d /app/defaults ]; then
                   for f in /app/defaults/*.md; do
                     fname=$(basename "$f")
                     if [ ! -f "$WORKSPACE/$fname" ]; then
                       cp "$f" "$WORKSPACE/$fname"
                       echo "Seeded $fname from image defaults"
+                    else
+                      echo "$fname already exists on PVC, skipping"
                     fi
                   done
                 fi
+
+                # Seed personality files from ConfigMap (only if missing on PVC)
                 for f in SOUL.md IDENTITY.md TOOLS.md; do
-                  if [ ! -f "$WORKSPACE/$f" ] && [ -f "/seed/$f" ]; then
-                    cp "/seed/$f" "$WORKSPACE/$f"
+                  if [ ! -f "$WORKSPACE/$f" ] && [ -f "/config/$f" ]; then
+                    cp "/config/$f" "$WORKSPACE/$f"
                     echo "Seeded $f from ConfigMap"
+                  else
+                    echo "$f already exists or not in ConfigMap, skipping"
                   fi
                 done
+
                 echo "Workspace ready"
         containers:
+          # ── Pi-Knight Agent ─────────────────────────────────────────
+          # Lightweight runtime: Pi SDK + native NATS
           app:
             image:
-              repository: ghcr.io/dapperdivers/knight-agent
-              tag: 7350b70
+              repository: ghcr.io/dapperdivers/pi-knight
+              tag: 3fe9b1438b15bbd84f9a21f8b81d916420fb1dfb
               pullPolicy: Always
             env:
-              WORKSPACE_DIR: /workspace
+              # ── Knight Identity ──
               KNIGHT_NAME: Lancelot
-              LOG_LEVEL: info
-              PORT: "18789"
-              TZ: America/Chicago
-              MAX_CONCURRENT_TASKS: "2"
-              ANTHROPIC_SMALL_FAST_MODEL: claude-haiku-3-5-20241022
-              CLAUDE_CODE_SUBAGENT_MODEL: claude-sonnet-4-5-20250929
-              CLAUDE_CODE_MAX_RETRIES: "3"
-              CLAUDE_CODE_EFFORT_LEVEL: medium
-              CLAUDE_CODE_ENABLE_TASKS: "1"
-              CLAUDE_CODE_DISABLE_AUTO_MEMORY: "1"
-              CLAUDE_CODE_DISABLE_BACKGROUND_TASKS: "1"
-              CLAUDE_CODE_DISABLE_NONESSENTIAL_TRAFFIC: "1"
-              DISABLE_TELEMETRY: "1"
-              DISABLE_AUTOUPDATER: "1"
+              KNIGHT_MODEL: "anthropic/claude-sonnet-4-5"
+              # ── NATS ──
               NATS_URL: nats://nats.database.svc:4222
-              FLEET_ID: fleet-a
-              AGENT_ID: lancelot
               SUBSCRIBE_TOPICS: "fleet-a.tasks.career.>"
-              KNIGHT_SKILLS: "career"
+              # ── Runtime ──
+              TASK_TIMEOUT_MS: "1800000"
+              MAX_CONCURRENT_TASKS: "2"
+              METRICS_PORT: "3000"
+              LOG_LEVEL: info
+              TZ: America/Chicago
             envFrom:
               - secretRef:
                   name: lancelot-secret
@@ -98,8 +102,8 @@ spec:
                 custom: true
                 spec:
                   httpGet:
-                    path: /healthz
-                    port: 18789
+                    path: /health
+                    port: 3000
                   initialDelaySeconds: 15
                   periodSeconds: 30
               readiness:
@@ -107,10 +111,12 @@ spec:
                 custom: true
                 spec:
                   httpGet:
-                    path: /readyz
-                    port: 18789
+                    path: /ready
+                    port: 3000
                   initialDelaySeconds: 10
                   periodSeconds: 15
+
+          # ── Git-Sync Sidecar ────────────────────────────────────────
           git-sync:
             image:
               repository: registry.k8s.io/git-sync/git-sync
@@ -118,7 +124,7 @@ spec:
             env:
               GITSYNC_REPO: https://github.com/dapperdivers/roundtable-arsenal
               GITSYNC_REF: main
-              GITSYNC_ROOT: /workspace/skills
+              GITSYNC_ROOT: /arsenal
               GITSYNC_PERIOD: "300s"
             resources:
               requests:
@@ -126,18 +132,81 @@ spec:
                 memory: 32Mi
               limits:
                 memory: 64Mi
+
+          # ── Skill Filter Sidecar ────────────────────────────────────
+          # Symlinks only the needed skill categories from the full
+          # arsenal into /skills so Pi SDK only discovers relevant ones.
+          skill-filter:
+            image:
+              repository: alpine
+              tag: "3.21"
+            env:
+              SKILL_CATEGORIES: "shared career"
+            command:
+              - /bin/sh
+              - -c
+              - |
+                ARSENAL="/arsenal/roundtable-arsenal"
+                TARGET="/skills"
+                echo "Skill filter starting: categories=$SKILL_CATEGORIES"
+                # Fast initial loop until all categories are linked
+                LINKED=0
+                EXPECTED=$(echo $SKILL_CATEGORIES | wc -w)
+                while [ "$LINKED" -lt "$EXPECTED" ]; do
+                  LINKED=0
+                  if [ -d "$ARSENAL" ]; then
+                    for cat in $SKILL_CATEGORIES; do
+                      src="$ARSENAL/$cat"
+                      dst="$TARGET/$cat"
+                      if [ -d "$src" ] && [ ! -L "$dst" ]; then
+                        ln -sf "$src" "$dst"
+                        echo "Linked $cat"
+                      fi
+                      [ -L "$dst" ] && LINKED=$((LINKED + 1))
+                    done
+                  fi
+                  [ "$LINKED" -lt "$EXPECTED" ] && sleep 2
+                done
+                echo "All categories linked ($LINKED/$EXPECTED)"
+                # Slow maintenance loop — re-link if git-sync recreates worktree
+                while true; do
+                  if [ -d "$ARSENAL" ]; then
+                    for cat in $SKILL_CATEGORIES; do
+                      src="$ARSENAL/$cat"
+                      dst="$TARGET/$cat"
+                      # Re-link if symlink target changed (git-sync new worktree)
+                      if [ -d "$src" ]; then
+                        current=$(readlink "$dst" 2>/dev/null || echo "")
+                        if [ "$current" != "$src" ]; then
+                          ln -sf "$src" "$dst"
+                          echo "Re-linked $cat"
+                        fi
+                      fi
+                    done
+                  fi
+                  sleep 60
+                done
+            resources:
+              requests:
+                cpu: 5m
+                memory: 8Mi
+              limits:
+                memory: 16Mi
+
     defaultPodOptions:
       securityContext:
         runAsUser: 1000
         runAsGroup: 1000
         fsGroup: 1000
         fsGroupChangePolicy: OnRootMismatch
+
     service:
       app:
         controller: lancelot
         ports:
           http:
-            port: 18789
+            port: 3000
+
     ingress:
       app:
         annotations:
@@ -154,42 +223,61 @@ spec:
           - hosts:
               - *host
             secretName: ${SECRET_DOMAIN/./-}-tls
+
     persistence:
+      # Knight workspace (persistent across restarts)
       data:
         enabled: true
         existingClaim: lancelot
         advancedMounts:
           lancelot:
             seed-workspace:
-              - path: /workspace
-              - path: /home/knight
-                subPath: home
+              - path: /data
             app:
-              - path: /workspace
-              - path: /home/knight
-                subPath: home
-      seed:
+              - path: /data
+
+      # ConfigMap with personality files
+      config:
         enabled: true
         type: configMap
         name: lancelot-config
         advancedMounts:
           lancelot:
             seed-workspace:
-              - path: /seed
+              - path: /config
                 readOnly: true
-      # Git-synced skills from arsenal repo
+            app:
+              - path: /config
+                readOnly: true
+
+      # Raw arsenal repo (git-sync writes here)
+      arsenal:
+        enabled: true
+        type: emptyDir
+        advancedMounts:
+          lancelot:
+            git-sync:
+              - path: /arsenal
+            skill-filter:
+              - path: /arsenal
+                readOnly: true
+            app:
+              - path: /arsenal
+                readOnly: true
+
+      # Filtered skills (only categories this knight needs)
       skills:
         enabled: true
         type: emptyDir
         advancedMounts:
           lancelot:
+            skill-filter:
+              - path: /skills
             app:
-              - path: /workspace/skills
+              - path: /skills
                 readOnly: true
-            git-sync:
-              - path: /workspace/skills
 
-      # Shared Obsidian vault (read-only base, RW for Briefings + Roundtable)
+      # Shared Obsidian vault
       vault:
         enabled: true
         existingClaim: roundtable-vault

--- a/kubernetes/apps/roundtable/patsy/app/helmrelease.yaml
+++ b/kubernetes/apps/roundtable/patsy/app/helmrelease.yaml
@@ -25,63 +25,67 @@ spec:
         annotations:
           reloader.stakater.com/auto: "true"
         initContainers:
+          # ── Workspace Seeder ────────────────────────────────────────
           seed-workspace:
             image:
-              repository: ghcr.io/dapperdivers/knight-agent
-              tag: 7350b70
+              repository: ghcr.io/dapperdivers/pi-knight
+              tag: 3fe9b1438b15bbd84f9a21f8b81d916420fb1dfb
               pullPolicy: Always
             command:
               - /bin/sh
               - -c
               - |
                 set -e
-                WORKSPACE=/workspace
-                mkdir -p "$WORKSPACE/memory" "$WORKSPACE/local-skills"
-                mkdir -p /home/knight/.local/bin
+                WORKSPACE=/data
+
+                # Create directories
+                mkdir -p "$WORKSPACE/memory"
+
+                # Seed operational files from image defaults (only if missing on PVC)
                 if [ -d /app/defaults ]; then
                   for f in /app/defaults/*.md; do
                     fname=$(basename "$f")
                     if [ ! -f "$WORKSPACE/$fname" ]; then
                       cp "$f" "$WORKSPACE/$fname"
                       echo "Seeded $fname from image defaults"
+                    else
+                      echo "$fname already exists on PVC, skipping"
                     fi
                   done
                 fi
+
+                # Seed personality files from ConfigMap (only if missing on PVC)
                 for f in SOUL.md IDENTITY.md TOOLS.md; do
-                  if [ ! -f "$WORKSPACE/$f" ] && [ -f "/seed/$f" ]; then
-                    cp "/seed/$f" "$WORKSPACE/$f"
+                  if [ ! -f "$WORKSPACE/$f" ] && [ -f "/config/$f" ]; then
+                    cp "/config/$f" "$WORKSPACE/$f"
                     echo "Seeded $f from ConfigMap"
+                  else
+                    echo "$f already exists or not in ConfigMap, skipping"
                   fi
                 done
+
                 echo "Workspace ready"
         containers:
+          # ── Pi-Knight Agent ─────────────────────────────────────────
+          # Lightweight runtime: Pi SDK + native NATS
           app:
             image:
-              repository: ghcr.io/dapperdivers/knight-agent
-              tag: 7350b70
+              repository: ghcr.io/dapperdivers/pi-knight
+              tag: 3fe9b1438b15bbd84f9a21f8b81d916420fb1dfb
               pullPolicy: Always
             env:
-              WORKSPACE_DIR: /workspace
+              # ── Knight Identity ──
               KNIGHT_NAME: Patsy
-              LOG_LEVEL: info
-              PORT: "18789"
-              TZ: America/Chicago
-              MAX_CONCURRENT_TASKS: "2"
-              ANTHROPIC_SMALL_FAST_MODEL: claude-haiku-3-5-20241022
-              CLAUDE_CODE_SUBAGENT_MODEL: claude-sonnet-4-5-20250929
-              CLAUDE_CODE_MAX_RETRIES: "3"
-              CLAUDE_CODE_EFFORT_LEVEL: medium
-              CLAUDE_CODE_ENABLE_TASKS: "1"
-              CLAUDE_CODE_DISABLE_AUTO_MEMORY: "1"
-              CLAUDE_CODE_DISABLE_BACKGROUND_TASKS: "1"
-              CLAUDE_CODE_DISABLE_NONESSENTIAL_TRAFFIC: "1"
-              DISABLE_TELEMETRY: "1"
-              DISABLE_AUTOUPDATER: "1"
+              KNIGHT_MODEL: "anthropic/claude-sonnet-4-5"
+              # ── NATS ──
               NATS_URL: nats://nats.database.svc:4222
-              FLEET_ID: fleet-a
-              AGENT_ID: patsy
               SUBSCRIBE_TOPICS: "fleet-a.tasks.vault.>"
-              KNIGHT_SKILLS: "vault"
+              # ── Runtime ──
+              TASK_TIMEOUT_MS: "1800000"
+              MAX_CONCURRENT_TASKS: "2"
+              METRICS_PORT: "3000"
+              LOG_LEVEL: info
+              TZ: America/Chicago
             envFrom:
               - secretRef:
                   name: patsy-secret
@@ -98,8 +102,8 @@ spec:
                 custom: true
                 spec:
                   httpGet:
-                    path: /healthz
-                    port: 18789
+                    path: /health
+                    port: 3000
                   initialDelaySeconds: 15
                   periodSeconds: 30
               readiness:
@@ -107,10 +111,12 @@ spec:
                 custom: true
                 spec:
                   httpGet:
-                    path: /readyz
-                    port: 18789
+                    path: /ready
+                    port: 3000
                   initialDelaySeconds: 10
                   periodSeconds: 15
+
+          # ── Git-Sync Sidecar ────────────────────────────────────────
           git-sync:
             image:
               repository: registry.k8s.io/git-sync/git-sync
@@ -118,7 +124,7 @@ spec:
             env:
               GITSYNC_REPO: https://github.com/dapperdivers/roundtable-arsenal
               GITSYNC_REF: main
-              GITSYNC_ROOT: /workspace/skills
+              GITSYNC_ROOT: /arsenal
               GITSYNC_PERIOD: "300s"
             resources:
               requests:
@@ -126,18 +132,81 @@ spec:
                 memory: 32Mi
               limits:
                 memory: 64Mi
+
+          # ── Skill Filter Sidecar ────────────────────────────────────
+          # Symlinks only the needed skill categories from the full
+          # arsenal into /skills so Pi SDK only discovers relevant ones.
+          skill-filter:
+            image:
+              repository: alpine
+              tag: "3.21"
+            env:
+              SKILL_CATEGORIES: "shared vault"
+            command:
+              - /bin/sh
+              - -c
+              - |
+                ARSENAL="/arsenal/roundtable-arsenal"
+                TARGET="/skills"
+                echo "Skill filter starting: categories=$SKILL_CATEGORIES"
+                # Fast initial loop until all categories are linked
+                LINKED=0
+                EXPECTED=$(echo $SKILL_CATEGORIES | wc -w)
+                while [ "$LINKED" -lt "$EXPECTED" ]; do
+                  LINKED=0
+                  if [ -d "$ARSENAL" ]; then
+                    for cat in $SKILL_CATEGORIES; do
+                      src="$ARSENAL/$cat"
+                      dst="$TARGET/$cat"
+                      if [ -d "$src" ] && [ ! -L "$dst" ]; then
+                        ln -sf "$src" "$dst"
+                        echo "Linked $cat"
+                      fi
+                      [ -L "$dst" ] && LINKED=$((LINKED + 1))
+                    done
+                  fi
+                  [ "$LINKED" -lt "$EXPECTED" ] && sleep 2
+                done
+                echo "All categories linked ($LINKED/$EXPECTED)"
+                # Slow maintenance loop — re-link if git-sync recreates worktree
+                while true; do
+                  if [ -d "$ARSENAL" ]; then
+                    for cat in $SKILL_CATEGORIES; do
+                      src="$ARSENAL/$cat"
+                      dst="$TARGET/$cat"
+                      # Re-link if symlink target changed (git-sync new worktree)
+                      if [ -d "$src" ]; then
+                        current=$(readlink "$dst" 2>/dev/null || echo "")
+                        if [ "$current" != "$src" ]; then
+                          ln -sf "$src" "$dst"
+                          echo "Re-linked $cat"
+                        fi
+                      fi
+                    done
+                  fi
+                  sleep 60
+                done
+            resources:
+              requests:
+                cpu: 5m
+                memory: 8Mi
+              limits:
+                memory: 16Mi
+
     defaultPodOptions:
       securityContext:
         runAsUser: 1000
         runAsGroup: 1000
         fsGroup: 1000
         fsGroupChangePolicy: OnRootMismatch
+
     service:
       app:
         controller: patsy
         ports:
           http:
-            port: 18789
+            port: 3000
+
     ingress:
       app:
         annotations:
@@ -154,40 +223,61 @@ spec:
           - hosts:
               - *host
             secretName: ${SECRET_DOMAIN/./-}-tls
+
     persistence:
+      # Knight workspace (persistent across restarts)
       data:
         enabled: true
         existingClaim: patsy
         advancedMounts:
           patsy:
             seed-workspace:
-              - path: /workspace
-              - path: /home/knight
-                subPath: home
+              - path: /data
             app:
-              - path: /workspace
-              - path: /home/knight
-                subPath: home
-      seed:
+              - path: /data
+
+      # ConfigMap with personality files
+      config:
         enabled: true
         type: configMap
         name: patsy-config
         advancedMounts:
           patsy:
             seed-workspace:
-              - path: /seed
+              - path: /config
                 readOnly: true
+            app:
+              - path: /config
+                readOnly: true
+
+      # Raw arsenal repo (git-sync writes here)
+      arsenal:
+        enabled: true
+        type: emptyDir
+        advancedMounts:
+          patsy:
+            git-sync:
+              - path: /arsenal
+            skill-filter:
+              - path: /arsenal
+                readOnly: true
+            app:
+              - path: /arsenal
+                readOnly: true
+
+      # Filtered skills (only categories this knight needs)
       skills:
         enabled: true
         type: emptyDir
         advancedMounts:
           patsy:
+            skill-filter:
+              - path: /skills
             app:
-              - path: /workspace/skills
+              - path: /skills
                 readOnly: true
-            git-sync:
-              - path: /workspace/skills
-      # Shared Obsidian vault — Patsy needs FULL write access (curator role)
+
+      # Shared Obsidian vault (Patsy gets FULL write access)
       vault:
         enabled: true
         existingClaim: roundtable-vault

--- a/kubernetes/apps/roundtable/percival/app/helmrelease.yaml
+++ b/kubernetes/apps/roundtable/percival/app/helmrelease.yaml
@@ -1,4 +1,5 @@
 ---
+# yaml-language-server: $schema=https://raw.githubusercontent.com/bjw-s/helm-charts/main/charts/other/app-template/schemas/helmrelease-helm-v2.schema.json
 apiVersion: helm.toolkit.fluxcd.io/v2
 kind: HelmRelease
 metadata:
@@ -24,63 +25,67 @@ spec:
         annotations:
           reloader.stakater.com/auto: "true"
         initContainers:
+          # ── Workspace Seeder ────────────────────────────────────────
           seed-workspace:
             image:
-              repository: ghcr.io/dapperdivers/knight-agent
-              tag: 7350b70
+              repository: ghcr.io/dapperdivers/pi-knight
+              tag: 3fe9b1438b15bbd84f9a21f8b81d916420fb1dfb
               pullPolicy: Always
             command:
               - /bin/sh
               - -c
               - |
                 set -e
-                WORKSPACE=/workspace
-                mkdir -p "$WORKSPACE/memory" "$WORKSPACE/local-skills"
-                mkdir -p /home/knight/.local/bin
+                WORKSPACE=/data
+
+                # Create directories
+                mkdir -p "$WORKSPACE/memory"
+
+                # Seed operational files from image defaults (only if missing on PVC)
                 if [ -d /app/defaults ]; then
                   for f in /app/defaults/*.md; do
                     fname=$(basename "$f")
                     if [ ! -f "$WORKSPACE/$fname" ]; then
                       cp "$f" "$WORKSPACE/$fname"
                       echo "Seeded $fname from image defaults"
+                    else
+                      echo "$fname already exists on PVC, skipping"
                     fi
                   done
                 fi
+
+                # Seed personality files from ConfigMap (only if missing on PVC)
                 for f in SOUL.md IDENTITY.md TOOLS.md; do
-                  if [ ! -f "$WORKSPACE/$f" ] && [ -f "/seed/$f" ]; then
-                    cp "/seed/$f" "$WORKSPACE/$f"
+                  if [ ! -f "$WORKSPACE/$f" ] && [ -f "/config/$f" ]; then
+                    cp "/config/$f" "$WORKSPACE/$f"
                     echo "Seeded $f from ConfigMap"
+                  else
+                    echo "$f already exists or not in ConfigMap, skipping"
                   fi
                 done
+
                 echo "Workspace ready"
         containers:
+          # ── Pi-Knight Agent ─────────────────────────────────────────
+          # Lightweight runtime: Pi SDK + native NATS
           app:
             image:
-              repository: ghcr.io/dapperdivers/knight-agent
-              tag: 7350b70
+              repository: ghcr.io/dapperdivers/pi-knight
+              tag: 3fe9b1438b15bbd84f9a21f8b81d916420fb1dfb
               pullPolicy: Always
             env:
-              WORKSPACE_DIR: /workspace
+              # ── Knight Identity ──
               KNIGHT_NAME: Percival
-              LOG_LEVEL: info
-              PORT: "18789"
-              TZ: America/Chicago
-              MAX_CONCURRENT_TASKS: "2"
-              ANTHROPIC_SMALL_FAST_MODEL: claude-haiku-3-5-20241022
-              CLAUDE_CODE_SUBAGENT_MODEL: claude-sonnet-4-5-20250929
-              CLAUDE_CODE_MAX_RETRIES: "3"
-              CLAUDE_CODE_EFFORT_LEVEL: medium
-              CLAUDE_CODE_ENABLE_TASKS: "1"
-              CLAUDE_CODE_DISABLE_AUTO_MEMORY: "1"
-              CLAUDE_CODE_DISABLE_BACKGROUND_TASKS: "1"
-              CLAUDE_CODE_DISABLE_NONESSENTIAL_TRAFFIC: "1"
-              DISABLE_TELEMETRY: "1"
-              DISABLE_AUTOUPDATER: "1"
+              KNIGHT_MODEL: "anthropic/claude-sonnet-4-5"
+              # ── NATS ──
               NATS_URL: nats://nats.database.svc:4222
-              FLEET_ID: fleet-a
-              AGENT_ID: percival
-              SUBSCRIBE_TOPICS: "fleet-a.tasks.finance.>,fleet-a.tasks.admin.>"
-              KNIGHT_SKILLS: "finance"
+              SUBSCRIBE_TOPICS: "fleet-a.tasks.finance.>"
+              # ── Runtime ──
+              TASK_TIMEOUT_MS: "1800000"
+              MAX_CONCURRENT_TASKS: "2"
+              METRICS_PORT: "3000"
+              LOG_LEVEL: info
+              TZ: America/Chicago
             envFrom:
               - secretRef:
                   name: percival-secret
@@ -97,8 +102,8 @@ spec:
                 custom: true
                 spec:
                   httpGet:
-                    path: /healthz
-                    port: 18789
+                    path: /health
+                    port: 3000
                   initialDelaySeconds: 15
                   periodSeconds: 30
               readiness:
@@ -106,10 +111,12 @@ spec:
                 custom: true
                 spec:
                   httpGet:
-                    path: /readyz
-                    port: 18789
+                    path: /ready
+                    port: 3000
                   initialDelaySeconds: 10
                   periodSeconds: 15
+
+          # ── Git-Sync Sidecar ────────────────────────────────────────
           git-sync:
             image:
               repository: registry.k8s.io/git-sync/git-sync
@@ -117,7 +124,7 @@ spec:
             env:
               GITSYNC_REPO: https://github.com/dapperdivers/roundtable-arsenal
               GITSYNC_REF: main
-              GITSYNC_ROOT: /workspace/skills
+              GITSYNC_ROOT: /arsenal
               GITSYNC_PERIOD: "300s"
             resources:
               requests:
@@ -125,18 +132,81 @@ spec:
                 memory: 32Mi
               limits:
                 memory: 64Mi
+
+          # ── Skill Filter Sidecar ────────────────────────────────────
+          # Symlinks only the needed skill categories from the full
+          # arsenal into /skills so Pi SDK only discovers relevant ones.
+          skill-filter:
+            image:
+              repository: alpine
+              tag: "3.21"
+            env:
+              SKILL_CATEGORIES: "shared finance"
+            command:
+              - /bin/sh
+              - -c
+              - |
+                ARSENAL="/arsenal/roundtable-arsenal"
+                TARGET="/skills"
+                echo "Skill filter starting: categories=$SKILL_CATEGORIES"
+                # Fast initial loop until all categories are linked
+                LINKED=0
+                EXPECTED=$(echo $SKILL_CATEGORIES | wc -w)
+                while [ "$LINKED" -lt "$EXPECTED" ]; do
+                  LINKED=0
+                  if [ -d "$ARSENAL" ]; then
+                    for cat in $SKILL_CATEGORIES; do
+                      src="$ARSENAL/$cat"
+                      dst="$TARGET/$cat"
+                      if [ -d "$src" ] && [ ! -L "$dst" ]; then
+                        ln -sf "$src" "$dst"
+                        echo "Linked $cat"
+                      fi
+                      [ -L "$dst" ] && LINKED=$((LINKED + 1))
+                    done
+                  fi
+                  [ "$LINKED" -lt "$EXPECTED" ] && sleep 2
+                done
+                echo "All categories linked ($LINKED/$EXPECTED)"
+                # Slow maintenance loop — re-link if git-sync recreates worktree
+                while true; do
+                  if [ -d "$ARSENAL" ]; then
+                    for cat in $SKILL_CATEGORIES; do
+                      src="$ARSENAL/$cat"
+                      dst="$TARGET/$cat"
+                      # Re-link if symlink target changed (git-sync new worktree)
+                      if [ -d "$src" ]; then
+                        current=$(readlink "$dst" 2>/dev/null || echo "")
+                        if [ "$current" != "$src" ]; then
+                          ln -sf "$src" "$dst"
+                          echo "Re-linked $cat"
+                        fi
+                      fi
+                    done
+                  fi
+                  sleep 60
+                done
+            resources:
+              requests:
+                cpu: 5m
+                memory: 8Mi
+              limits:
+                memory: 16Mi
+
     defaultPodOptions:
       securityContext:
         runAsUser: 1000
         runAsGroup: 1000
         fsGroup: 1000
         fsGroupChangePolicy: OnRootMismatch
+
     service:
       app:
         controller: percival
         ports:
           http:
-            port: 18789
+            port: 3000
+
     ingress:
       app:
         annotations:
@@ -153,42 +223,61 @@ spec:
           - hosts:
               - *host
             secretName: ${SECRET_DOMAIN/./-}-tls
+
     persistence:
+      # Knight workspace (persistent across restarts)
       data:
         enabled: true
         existingClaim: percival
         advancedMounts:
           percival:
             seed-workspace:
-              - path: /workspace
-              - path: /home/knight
-                subPath: home
+              - path: /data
             app:
-              - path: /workspace
-              - path: /home/knight
-                subPath: home
-      seed:
+              - path: /data
+
+      # ConfigMap with personality files
+      config:
         enabled: true
         type: configMap
         name: percival-config
         advancedMounts:
           percival:
             seed-workspace:
-              - path: /seed
+              - path: /config
                 readOnly: true
-      # Git-synced skills from arsenal repo
+            app:
+              - path: /config
+                readOnly: true
+
+      # Raw arsenal repo (git-sync writes here)
+      arsenal:
+        enabled: true
+        type: emptyDir
+        advancedMounts:
+          percival:
+            git-sync:
+              - path: /arsenal
+            skill-filter:
+              - path: /arsenal
+                readOnly: true
+            app:
+              - path: /arsenal
+                readOnly: true
+
+      # Filtered skills (only categories this knight needs)
       skills:
         enabled: true
         type: emptyDir
         advancedMounts:
           percival:
+            skill-filter:
+              - path: /skills
             app:
-              - path: /workspace/skills
+              - path: /skills
                 readOnly: true
-            git-sync:
-              - path: /workspace/skills
 
-      # Shared Obsidian vault (read-only base, RW for Briefings + Roundtable)
+      # Shared Obsidian vault
       vault:
         enabled: true
         existingClaim: roundtable-vault

--- a/kubernetes/apps/roundtable/tristan/app/helmrelease.yaml
+++ b/kubernetes/apps/roundtable/tristan/app/helmrelease.yaml
@@ -25,63 +25,67 @@ spec:
         annotations:
           reloader.stakater.com/auto: "true"
         initContainers:
+          # ── Workspace Seeder ────────────────────────────────────────
           seed-workspace:
             image:
-              repository: ghcr.io/dapperdivers/knight-agent
-              tag: 7350b70
+              repository: ghcr.io/dapperdivers/pi-knight
+              tag: 3fe9b1438b15bbd84f9a21f8b81d916420fb1dfb
               pullPolicy: Always
             command:
               - /bin/sh
               - -c
               - |
                 set -e
-                WORKSPACE=/workspace
-                mkdir -p "$WORKSPACE/memory" "$WORKSPACE/local-skills"
-                mkdir -p /home/knight/.local/bin
+                WORKSPACE=/data
+
+                # Create directories
+                mkdir -p "$WORKSPACE/memory"
+
+                # Seed operational files from image defaults (only if missing on PVC)
                 if [ -d /app/defaults ]; then
                   for f in /app/defaults/*.md; do
                     fname=$(basename "$f")
                     if [ ! -f "$WORKSPACE/$fname" ]; then
                       cp "$f" "$WORKSPACE/$fname"
                       echo "Seeded $fname from image defaults"
+                    else
+                      echo "$fname already exists on PVC, skipping"
                     fi
                   done
                 fi
+
+                # Seed personality files from ConfigMap (only if missing on PVC)
                 for f in SOUL.md IDENTITY.md TOOLS.md; do
-                  if [ ! -f "$WORKSPACE/$f" ] && [ -f "/seed/$f" ]; then
-                    cp "/seed/$f" "$WORKSPACE/$f"
+                  if [ ! -f "$WORKSPACE/$f" ] && [ -f "/config/$f" ]; then
+                    cp "/config/$f" "$WORKSPACE/$f"
                     echo "Seeded $f from ConfigMap"
+                  else
+                    echo "$f already exists or not in ConfigMap, skipping"
                   fi
                 done
+
                 echo "Workspace ready"
         containers:
+          # ── Pi-Knight Agent ─────────────────────────────────────────
+          # Lightweight runtime: Pi SDK + native NATS
           app:
             image:
-              repository: ghcr.io/dapperdivers/knight-agent
-              tag: 7350b70
+              repository: ghcr.io/dapperdivers/pi-knight
+              tag: 3fe9b1438b15bbd84f9a21f8b81d916420fb1dfb
               pullPolicy: Always
             env:
-              WORKSPACE_DIR: /workspace
+              # ── Knight Identity ──
               KNIGHT_NAME: Tristan
-              LOG_LEVEL: info
-              PORT: "18789"
-              TZ: America/Chicago
-              MAX_CONCURRENT_TASKS: "2"
-              ANTHROPIC_SMALL_FAST_MODEL: claude-haiku-3-5-20241022
-              CLAUDE_CODE_SUBAGENT_MODEL: claude-sonnet-4-5-20250929
-              CLAUDE_CODE_MAX_RETRIES: "3"
-              CLAUDE_CODE_EFFORT_LEVEL: medium
-              CLAUDE_CODE_ENABLE_TASKS: "1"
-              CLAUDE_CODE_DISABLE_AUTO_MEMORY: "1"
-              CLAUDE_CODE_DISABLE_BACKGROUND_TASKS: "1"
-              CLAUDE_CODE_DISABLE_NONESSENTIAL_TRAFFIC: "1"
-              DISABLE_TELEMETRY: "1"
-              DISABLE_AUTOUPDATER: "1"
+              KNIGHT_MODEL: "anthropic/claude-sonnet-4-5"
+              # ── NATS ──
               NATS_URL: nats://nats.database.svc:4222
-              FLEET_ID: fleet-a
-              AGENT_ID: tristan
               SUBSCRIBE_TOPICS: "fleet-a.tasks.infra.>"
-              KNIGHT_SKILLS: "infra"
+              # ── Runtime ──
+              TASK_TIMEOUT_MS: "1800000"
+              MAX_CONCURRENT_TASKS: "2"
+              METRICS_PORT: "3000"
+              LOG_LEVEL: info
+              TZ: America/Chicago
             envFrom:
               - secretRef:
                   name: tristan-secret
@@ -98,8 +102,8 @@ spec:
                 custom: true
                 spec:
                   httpGet:
-                    path: /healthz
-                    port: 18789
+                    path: /health
+                    port: 3000
                   initialDelaySeconds: 15
                   periodSeconds: 30
               readiness:
@@ -107,10 +111,12 @@ spec:
                 custom: true
                 spec:
                   httpGet:
-                    path: /readyz
-                    port: 18789
+                    path: /ready
+                    port: 3000
                   initialDelaySeconds: 10
                   periodSeconds: 15
+
+          # ── Git-Sync Sidecar ────────────────────────────────────────
           git-sync:
             image:
               repository: registry.k8s.io/git-sync/git-sync
@@ -118,7 +124,7 @@ spec:
             env:
               GITSYNC_REPO: https://github.com/dapperdivers/roundtable-arsenal
               GITSYNC_REF: main
-              GITSYNC_ROOT: /workspace/skills
+              GITSYNC_ROOT: /arsenal
               GITSYNC_PERIOD: "300s"
             resources:
               requests:
@@ -126,18 +132,81 @@ spec:
                 memory: 32Mi
               limits:
                 memory: 64Mi
+
+          # ── Skill Filter Sidecar ────────────────────────────────────
+          # Symlinks only the needed skill categories from the full
+          # arsenal into /skills so Pi SDK only discovers relevant ones.
+          skill-filter:
+            image:
+              repository: alpine
+              tag: "3.21"
+            env:
+              SKILL_CATEGORIES: "shared infra"
+            command:
+              - /bin/sh
+              - -c
+              - |
+                ARSENAL="/arsenal/roundtable-arsenal"
+                TARGET="/skills"
+                echo "Skill filter starting: categories=$SKILL_CATEGORIES"
+                # Fast initial loop until all categories are linked
+                LINKED=0
+                EXPECTED=$(echo $SKILL_CATEGORIES | wc -w)
+                while [ "$LINKED" -lt "$EXPECTED" ]; do
+                  LINKED=0
+                  if [ -d "$ARSENAL" ]; then
+                    for cat in $SKILL_CATEGORIES; do
+                      src="$ARSENAL/$cat"
+                      dst="$TARGET/$cat"
+                      if [ -d "$src" ] && [ ! -L "$dst" ]; then
+                        ln -sf "$src" "$dst"
+                        echo "Linked $cat"
+                      fi
+                      [ -L "$dst" ] && LINKED=$((LINKED + 1))
+                    done
+                  fi
+                  [ "$LINKED" -lt "$EXPECTED" ] && sleep 2
+                done
+                echo "All categories linked ($LINKED/$EXPECTED)"
+                # Slow maintenance loop — re-link if git-sync recreates worktree
+                while true; do
+                  if [ -d "$ARSENAL" ]; then
+                    for cat in $SKILL_CATEGORIES; do
+                      src="$ARSENAL/$cat"
+                      dst="$TARGET/$cat"
+                      # Re-link if symlink target changed (git-sync new worktree)
+                      if [ -d "$src" ]; then
+                        current=$(readlink "$dst" 2>/dev/null || echo "")
+                        if [ "$current" != "$src" ]; then
+                          ln -sf "$src" "$dst"
+                          echo "Re-linked $cat"
+                        fi
+                      fi
+                    done
+                  fi
+                  sleep 60
+                done
+            resources:
+              requests:
+                cpu: 5m
+                memory: 8Mi
+              limits:
+                memory: 16Mi
+
     defaultPodOptions:
       securityContext:
         runAsUser: 1000
         runAsGroup: 1000
         fsGroup: 1000
         fsGroupChangePolicy: OnRootMismatch
+
     service:
       app:
         controller: tristan
         ports:
           http:
-            port: 18789
+            port: 3000
+
     ingress:
       app:
         annotations:
@@ -154,42 +223,61 @@ spec:
           - hosts:
               - *host
             secretName: ${SECRET_DOMAIN/./-}-tls
+
     persistence:
+      # Knight workspace (persistent across restarts)
       data:
         enabled: true
         existingClaim: tristan
         advancedMounts:
           tristan:
             seed-workspace:
-              - path: /workspace
-              - path: /home/knight
-                subPath: home
+              - path: /data
             app:
-              - path: /workspace
-              - path: /home/knight
-                subPath: home
-      seed:
+              - path: /data
+
+      # ConfigMap with personality files
+      config:
         enabled: true
         type: configMap
         name: tristan-config
         advancedMounts:
           tristan:
             seed-workspace:
-              - path: /seed
+              - path: /config
                 readOnly: true
-      # Git-synced skills from arsenal repo
+            app:
+              - path: /config
+                readOnly: true
+
+      # Raw arsenal repo (git-sync writes here)
+      arsenal:
+        enabled: true
+        type: emptyDir
+        advancedMounts:
+          tristan:
+            git-sync:
+              - path: /arsenal
+            skill-filter:
+              - path: /arsenal
+                readOnly: true
+            app:
+              - path: /arsenal
+                readOnly: true
+
+      # Filtered skills (only categories this knight needs)
       skills:
         enabled: true
         type: emptyDir
         advancedMounts:
           tristan:
+            skill-filter:
+              - path: /skills
             app:
-              - path: /workspace/skills
+              - path: /skills
                 readOnly: true
-            git-sync:
-              - path: /workspace/skills
 
-      # Shared Obsidian vault (read-only base, RW for Briefings + Roundtable)
+      # Shared Obsidian vault
       vault:
         enabled: true
         existingClaim: roundtable-vault


### PR DESCRIPTION
## The Big Migration

All 7 knights migrated from `knight-agent` (Claude Code SDK subprocess) to `pi-knight` (Pi SDK native agent loop).

### What changes per knight:
- **Image**: `knight-agent:7350b70` → `pi-knight:3fe9b14`
- **Runtime**: Claude Code CLI subprocess → Pi SDK native agent loop
- **Port**: 18789 → 3000
- **Skills**: Full arsenal → filtered by `SKILL_CATEGORIES` sidecar
- **Sessions**: Fresh per task → persistent with auto-compaction
- **Tools**: bash scripts → native `nats_publish`, `nats_request`, `spawn_subagent`

### Skill scoping:
| Knight | Categories |
|--------|-----------|
| Galahad | shared + security |
| Percival | shared + finance |
| Lancelot | shared + career |
| Tristan | shared + infra |
| Bedivere | shared + home |
| Kay | shared + research + intel |
| Patsy | shared + vault (full vault write) |

### Why:
- ~50% smaller containers (~200MB vs ~400MB)
- 20x cheaper per task ($0.009 vs $0.20)
- Model-agnostic (Claude, GPT, Gemini, local)
- Native cross-knight collaboration tools
- Sub-agent spawning capability