### PR TITLE
feat(roundtable): pi-knight 24dd567 — auto-reconcile NATS consumers

### DIFF
--- a/kubernetes/apps/roundtable/bedivere/app/helmrelease.yaml
+++ b/kubernetes/apps/roundtable/bedivere/app/helmrelease.yaml
@@ -29,7 +29,7 @@ spec:
           seed-workspace:
             image:
               repository: ghcr.io/dapperdivers/pi-knight
-              tag: b71ed6111ee7503336247f3900ea779c41105023
+              tag: 24dd567c7748320225c612016647df8517e63468
               pullPolicy: Always
             command:
               - /bin/sh
@@ -71,7 +71,7 @@ spec:
           app:
             image:
               repository: ghcr.io/dapperdivers/pi-knight
-              tag: b71ed6111ee7503336247f3900ea779c41105023
+              tag: 24dd567c7748320225c612016647df8517e63468
               pullPolicy: Always
             env:
               # ── Knight Identity ──

--- a/kubernetes/apps/roundtable/galahad/app/helmrelease.yaml
+++ b/kubernetes/apps/roundtable/galahad/app/helmrelease.yaml
@@ -29,7 +29,7 @@ spec:
           seed-workspace:
             image:
               repository: ghcr.io/dapperdivers/pi-knight
-              tag: b71ed6111ee7503336247f3900ea779c41105023
+              tag: 24dd567c7748320225c612016647df8517e63468
               pullPolicy: Always
             command:
               - /bin/sh
@@ -71,7 +71,7 @@ spec:
           app:
             image:
               repository: ghcr.io/dapperdivers/pi-knight
-              tag: b71ed6111ee7503336247f3900ea779c41105023
+              tag: 24dd567c7748320225c612016647df8517e63468
               pullPolicy: Always
             env:
               # ── Knight Identity ──

--- a/kubernetes/apps/roundtable/gawain/app/helmrelease.yaml
+++ b/kubernetes/apps/roundtable/gawain/app/helmrelease.yaml
@@ -29,7 +29,7 @@ spec:
           seed-workspace:
             image:
               repository: ghcr.io/dapperdivers/pi-knight
-              tag: b71ed6111ee7503336247f3900ea779c41105023
+              tag: 24dd567c7748320225c612016647df8517e63468
               pullPolicy: Always
             command:
               - /bin/sh
@@ -71,7 +71,7 @@ spec:
           app:
             image:
               repository: ghcr.io/dapperdivers/pi-knight
-              tag: b71ed6111ee7503336247f3900ea779c41105023
+              tag: 24dd567c7748320225c612016647df8517e63468
               pullPolicy: Always
             env:
               # ── Knight Identity ──

--- a/kubernetes/apps/roundtable/kay/app/helmrelease.yaml
+++ b/kubernetes/apps/roundtable/kay/app/helmrelease.yaml
@@ -29,7 +29,7 @@ spec:
           seed-workspace:
             image:
               repository: ghcr.io/dapperdivers/pi-knight
-              tag: b71ed6111ee7503336247f3900ea779c41105023
+              tag: 24dd567c7748320225c612016647df8517e63468
               pullPolicy: Always
             command:
               - /bin/sh
@@ -71,7 +71,7 @@ spec:
           app:
             image:
               repository: ghcr.io/dapperdivers/pi-knight
-              tag: b71ed6111ee7503336247f3900ea779c41105023
+              tag: 24dd567c7748320225c612016647df8517e63468
               pullPolicy: Always
             env:
               # ── Knight Identity ──

--- a/kubernetes/apps/roundtable/lancelot/app/helmrelease.yaml
+++ b/kubernetes/apps/roundtable/lancelot/app/helmrelease.yaml
@@ -29,7 +29,7 @@ spec:
           seed-workspace:
             image:
               repository: ghcr.io/dapperdivers/pi-knight
-              tag: b71ed6111ee7503336247f3900ea779c41105023
+              tag: 24dd567c7748320225c612016647df8517e63468
               pullPolicy: Always
             command:
               - /bin/sh
@@ -71,7 +71,7 @@ spec:
           app:
             image:
               repository: ghcr.io/dapperdivers/pi-knight
-              tag: b71ed6111ee7503336247f3900ea779c41105023
+              tag: 24dd567c7748320225c612016647df8517e63468
               pullPolicy: Always
             env:
               # ── Knight Identity ──

--- a/kubernetes/apps/roundtable/patsy/app/helmrelease.yaml
+++ b/kubernetes/apps/roundtable/patsy/app/helmrelease.yaml
@@ -29,7 +29,7 @@ spec:
           seed-workspace:
             image:
               repository: ghcr.io/dapperdivers/pi-knight
-              tag: b71ed6111ee7503336247f3900ea779c41105023
+              tag: 24dd567c7748320225c612016647df8517e63468
               pullPolicy: Always
             command:
               - /bin/sh
@@ -71,7 +71,7 @@ spec:
           app:
             image:
               repository: ghcr.io/dapperdivers/pi-knight
-              tag: b71ed6111ee7503336247f3900ea779c41105023
+              tag: 24dd567c7748320225c612016647df8517e63468
               pullPolicy: Always
             env:
               # ── Knight Identity ──

--- a/kubernetes/apps/roundtable/percival/app/helmrelease.yaml
+++ b/kubernetes/apps/roundtable/percival/app/helmrelease.yaml
@@ -29,7 +29,7 @@ spec:
           seed-workspace:
             image:
               repository: ghcr.io/dapperdivers/pi-knight
-              tag: b71ed6111ee7503336247f3900ea779c41105023
+              tag: 24dd567c7748320225c612016647df8517e63468
               pullPolicy: Always
             command:
               - /bin/sh
@@ -71,7 +71,7 @@ spec:
           app:
             image:
               repository: ghcr.io/dapperdivers/pi-knight
-              tag: b71ed6111ee7503336247f3900ea779c41105023
+              tag: 24dd567c7748320225c612016647df8517e63468
               pullPolicy: Always
             env:
               # ── Knight Identity ──

--- a/kubernetes/apps/roundtable/tristan/app/helmrelease.yaml
+++ b/kubernetes/apps/roundtable/tristan/app/helmrelease.yaml
@@ -29,7 +29,7 @@ spec:
           seed-workspace:
             image:
               repository: ghcr.io/dapperdivers/pi-knight
-              tag: b71ed6111ee7503336247f3900ea779c41105023
+              tag: 24dd567c7748320225c612016647df8517e63468
               pullPolicy: Always
             command:
               - /bin/sh
@@ -71,7 +71,7 @@ spec:
           app:
             image:
               repository: ghcr.io/dapperdivers/pi-knight
-              tag: b71ed6111ee7503336247f3900ea779c41105023
+              tag: 24dd567c7748320225c612016647df8517e63468
               pullPolicy: Always
             env:
               # ── Knight Identity ──


### PR DESCRIPTION
## What
On startup, knights now check if their durable consumer's filter subjects match `SUBSCRIBE_TOPICS`. If mismatched, the consumer is automatically deleted and recreated. Normal restarts reuse the existing consumer — queued messages preserved.

## Why
Changing a knight's topic subscription (like Gawain's repurpose today) required manual `nats consumer rm`. Now it self-heals.

## Changes
All 8 roundtable agents pinned to `pi-knight:24dd567`.