### PR TITLE
fix(molt): increase PVC capacity to 10Gi

### DIFF
--- a/kubernetes/apps/ai/openclaw/ks.yaml
+++ b/kubernetes/apps/ai/openclaw/ks.yaml
@@ -34,4 +34,4 @@ spec:
       APP: molt
       GATUS_SUBDOMAIN: molt
       GATUS_DOMAIN: ${SECRET_DOMAIN}
-      VOLSYNC_CAPACITY: 5Gi
+      VOLSYNC_CAPACITY: 10Gi


### PR DESCRIPTION
## Summary
- Increases the molt volsync PVC capacity from 5Gi to 10Gi
- The molt deployment was hitting `ENOSPC: no space left on device` errors with the volume at 100% utilization
- Root cause: accumulated tools (~1.4G in `.local/`), Go workspace (~1.1G), app data, caches, and VS Code server filled the 5Gi volume
- This caused cron scheduler and Discord handler failures

## Changes
- `kubernetes/apps/ai/openclaw/ks.yaml`: `VOLSYNC_CAPACITY: 5Gi` -> `10Gi`

## Immediate mitigations applied
- Cleared `.cache/` and `.npm/` directories (~774MB freed)
- Live-patched the PVC to 10Gi via `kubectl patch` (ceph-rbd supports online expansion)

## Test plan
- [x] Verified ceph-rbd storageclass has `allowVolumeExpansion: true`
- [x] Confirmed Ceph cluster has 220 TiB available capacity
- [ ] Flux reconciles and the volsync ReplicationDestination reflects the new capacity

🤖 Generated with [Claude Code](https://claude.com/claude-code)