### PR TITLE
fix(roundtable): bump knight memory requests to 512Mi

### DIFF
--- a/kubernetes/apps/roundtable/chelonian/app/roundtable.yaml
+++ b/kubernetes/apps/roundtable/chelonian/app/roundtable.yaml
@@ -21,6 +21,9 @@ spec:
     image: ""
     taskTimeout: 300
     concurrency: 2
+    resources:
+      memory: "512Mi"
+      cpu: "200m"
   policies:
     costBudgetUSD: "25"
     costResetSchedule: "0 0 1 * *"

--- a/kubernetes/apps/roundtable/knights/app/roundtable.yaml
+++ b/kubernetes/apps/roundtable/knights/app/roundtable.yaml
@@ -21,6 +21,9 @@ spec:
     image: ""
     taskTimeout: 600
     concurrency: 2
+    resources:
+      memory: "512Mi"
+      cpu: "200m"
   policies:
     costBudgetUSD: "0"
     maxConcurrentTasks: 0


### PR DESCRIPTION
## Problem
All 15 knights request 256Mi but consistently use 230-454Mi in practice:

| Knight | Actual MiB | % Over Request |
|--------|-----------|----------------|
| tristan | 454 | 177% |
| tor | 373 | 146% |
| gawain | 341 | 133% |
| kay | 341 | 133% |
| galahad | 295 | 115% |
| bedivere | 286 | 112% |
| bors | 276 | 108% |

This means kube-scheduler underestimates actual usage, and under memory pressure these burstable pods are first to be evicted.

## Fix
Bump `defaults.resources.memory` to `512Mi` on both RoundTable CRs:
- **personal** (10 knights)
- **chelonian** (5 knights)

No limits set — knights remain burstable. CPU unchanged at 200m.