### PR TITLE
feat(roundtable): Night Watch — overnight self-fixing sweep (phase 0+1)

### DIFF
--- a/kubernetes/apps/roundtable/chains/app/kustomization.yaml
+++ b/kubernetes/apps/roundtable/chains/app/kustomization.yaml
@@ -5,3 +5,4 @@ kind: Kustomization
 resources:
   - morning-briefing.yaml
   - fleet-self-improvement.yaml
+  - night-watch.yaml

--- a/kubernetes/apps/roundtable/chains/app/night-watch.yaml
+++ b/kubernetes/apps/roundtable/chains/app/night-watch.yaml
@@ -9,14 +9,17 @@ metadata:
   name: night-watch
   namespace: roundtable
 spec:
-  roundTableRef: personal
+  # roundtable-dev table: the platform's own dev team handles platform health.
+  # NOTE chains cannot span tables (step subjects use this table's prefix),
+  # so every knightRef here must live on roundtable-dev.
+  roundTableRef: roundtable-dev
   description: "Nightly telemetry sweep — triage platform errors, keep the ledger, dispatch fix Missions"
   schedule: "0 7 * * *"  # ~2-3 AM ET
   timeout: 10800
   retryPolicy:
     maxRetries: 1
     backoffSeconds: 120
-  outputKnight: gawain
+  outputKnight: watchman
   steps:
     - name: verify_yesterday
       knightRef: watchman
@@ -86,9 +89,11 @@ spec:
       timeout: 3600
 
     - name: report
-      knightRef: gawain
+      knightRef: watchman
       # No outputPath on purpose — the controller would overwrite the file
-      # Gawain writes with this step's raw .Output (see morning-briefing).
+      # the knight writes with this step's raw .Output (see morning-briefing).
+      # Watchman writes its own report: gawain lives on the personal table and
+      # chains can't dispatch across tables.
       dependsOn:
         - triage
       task: |

--- a/kubernetes/apps/roundtable/chains/app/night-watch.yaml
+++ b/kubernetes/apps/roundtable/chains/app/night-watch.yaml
@@ -1,0 +1,120 @@
+---
+# Night Watch — overnight self-fixing sweep for the Round Table platform.
+# Phase 1: DIAGNOSIS mode (triage + ledger only, no fix Missions).
+# Kill switch: set spec.suspended: true (or `kubectl patch chain night-watch
+# -n roundtable --type merge -p '{"spec":{"suspended":true}}'`).
+apiVersion: ai.roundtable.io/v1alpha1
+kind: Chain
+metadata:
+  name: night-watch
+  namespace: roundtable
+spec:
+  roundTableRef: personal
+  description: "Nightly telemetry sweep — triage platform errors, keep the ledger, dispatch fix Missions"
+  schedule: "0 7 * * *"  # ~2-3 AM ET
+  timeout: 10800
+  retryPolicy:
+    maxRetries: 1
+    backoffSeconds: 120
+  outputKnight: gawain
+  steps:
+    - name: verify_yesterday
+      knightRef: watchman
+      continueOnFailure: true
+      task: |
+        NIGHT WATCH — VERIFICATION PASS.
+        Read the watch/telemetry-queries and watch/night-watch-triage skills first.
+
+        Read /vault/NightWatch/ledger.md (create it with the schema from the
+        triage skill if it does not exist). For every row with status
+        "dispatched", "fix-pr-open", or "merged":
+          1. Check the Mission result if one exists:
+             kubectl get missions -n roundtable -l night-watch/fingerprint=<fp> -o yaml
+             and check PR state via: gh pr list --repo <repo> --search "<fp>" --state all
+             Update status accordingly (fix-pr-open / merged).
+          2. For "merged" rows: query Prometheus and Victoria Logs for that
+             fingerprint's signature over the last 24h. Gone → status "verified".
+             Still occurring → status "recurred" (flag it prominently).
+
+        Update the ledger rows in place. Return a concise summary of every
+        status transition you made (or "No rows to verify.").
+      timeout: 1800
+
+    - name: collect
+      knightRef: watchman
+      continueOnFailure: false
+      task: |
+        NIGHT WATCH — COLLECTION PASS.
+        Read the watch/telemetry-queries skill and follow it exactly.
+
+        Sweep the last 24h of telemetry for the roundtable namespace:
+        firing alerts, knight task failures, pod restarts/OOMs, NATS
+        disconnects, error-level logs from knights, the operator, and the
+        dashboard. Aggregate FIRST, then sample raw lines only for the top
+        offenders. Also record the fleet's 24h LLM spend.
+
+        Output: a compact markdown list of at most 50 distinct error
+        signatures, each with: workload, normalized signature, count,
+        and 1-3 sample log lines. Include the spend figure at the top.
+        If the namespace was quiet, say exactly that.
+      timeout: 1800
+
+    - name: triage
+      knightRef: watchman
+      dependsOn:
+        - verify_yesterday
+        - collect
+      task: |
+        NIGHT WATCH — TRIAGE PASS. Mode: DIAGNOSIS (no Missions, ledger only).
+        Read the watch/night-watch-triage skill and follow it exactly.
+
+        Yesterday's verification:
+        {{ .Steps.verify_yesterday.Output }}
+
+        Tonight's collection:
+        {{ .Steps.collect.Output }}
+
+        Fingerprint every signature, dedup against the ledger and existing
+        Missions, rank, and update /vault/NightWatch/ledger.md. Apply the
+        cost-cap check. Because this is DIAGNOSIS mode, do NOT create any
+        Mission CRs — instead, for each incident you WOULD have dispatched
+        (max 3), write the complete would-be Mission briefing (fingerprint,
+        repo, tier, fixer, evidence, root-cause hypothesis) into your output.
+
+        Output: incidents seen / would-dispatch (with full briefings) /
+        skipped (with reasons) / ledger deltas / fleet spend.
+      timeout: 3600
+
+    - name: report
+      knightRef: gawain
+      # No outputPath on purpose — the controller would overwrite the file
+      # Gawain writes with this step's raw .Output (see morning-briefing).
+      dependsOn:
+        - triage
+      task: |
+        NIGHT WATCH — MORNING REPORT.
+
+        Triage results:
+        {{ .Steps.triage.Output }}
+
+        Write the Night Watch report to /vault/Briefings/NightWatch/YYYY-MM-DD.md
+        (today's actual date, filename exactly YYYY-MM-DD.md) using your write
+        tool, then verify with: ls -la /vault/Briefings/NightWatch/
+
+        Structure (keep it under 60 lines — Derek reads this with coffee):
+
+        # Night Watch — YYYY-MM-DD
+        ## Verdict
+        One line: quiet night / N incidents, M would-dispatch / cost-cap hit.
+        ## Would-be dispatches (diagnosis mode)
+        Per incident: fingerprint, repo, tier, one-line root-cause hypothesis.
+        ## Verified / recurred
+        Fixes confirmed dead, and anything that came back (flag recurrences 🔴).
+        ## Watchlist
+        Incidents seen but below the dispatch bar, one line each.
+        ## Spend
+        Fleet 24h LLM cost vs the $10 nightly cap.
+
+        Your NATS response: confirm the file path was written plus the
+        Verdict line only.
+      timeout: 900

--- a/kubernetes/apps/roundtable/infrastructure/app/kustomization.yaml
+++ b/kubernetes/apps/roundtable/infrastructure/app/kustomization.yaml
@@ -6,9 +6,13 @@ resources:
   - rbac.yaml
   - molt-rbac.yaml
   - knight-rbac.yaml
+  - watchman-rbac.yaml
   - roundtable-secret.yaml
   - vault-pv.yaml
   - vault-pvc.yaml
   - shared-workspace-pvc.yaml
   - chelonian-secret.yaml
   - limitrange.yaml
+  - podmonitor.yaml
+  - servicemonitor.yaml
+  - prometheusrule.yaml

--- a/kubernetes/apps/roundtable/infrastructure/app/podmonitor.yaml
+++ b/kubernetes/apps/roundtable/infrastructure/app/podmonitor.yaml
@@ -1,0 +1,16 @@
+---
+# yaml-language-server: $schema=https://kubernetes-schemas.pages.dev/monitoring.coreos.com/podmonitor_v1.json
+# Scrape pi-knight runtime metrics (pi_knight_tasks_total, pi_knight_llm_cost_dollars_total, ...)
+# Knight pods are operator-managed and expose no named ports, hence portNumber.
+apiVersion: monitoring.coreos.com/v1
+kind: PodMonitor
+metadata:
+  name: knights
+spec:
+  selector:
+    matchLabels:
+      app.kubernetes.io/name: knight
+  podMetricsEndpoints:
+    - portNumber: 3000
+      path: /metrics
+      interval: 1m

--- a/kubernetes/apps/roundtable/infrastructure/app/prometheusrule.yaml
+++ b/kubernetes/apps/roundtable/infrastructure/app/prometheusrule.yaml
@@ -40,8 +40,8 @@ spec:
         - alert: KnightLLMCostSpike
           annotations:
             summary: >-
-              Fleet LLM spend rose ${{ $value | humanize }} in 24h — above the
-              Night Watch budget envelope; possible runaway loop.
+              Fleet LLM spend rose {{ $value | humanize }} USD in 24h — above
+              the Night Watch budget envelope; possible runaway loop.
           expr: |
             sum(increase(pi_knight_llm_cost_dollars_total[24h])) > 15
           for: 15m

--- a/kubernetes/apps/roundtable/infrastructure/app/prometheusrule.yaml
+++ b/kubernetes/apps/roundtable/infrastructure/app/prometheusrule.yaml
@@ -1,0 +1,68 @@
+---
+# yaml-language-server: $schema=https://kubernetes-schemas.pages.dev/monitoring.coreos.com/prometheusrule_v1.json
+# Night Watch alert surface: these rules double as the watchman knight's
+# query menu — it reads ALERTS{namespace="roundtable"} during the nightly sweep.
+apiVersion: monitoring.coreos.com/v1
+kind: PrometheusRule
+metadata:
+  name: roundtable
+spec:
+  groups:
+    - name: roundtable.knights
+      rules:
+        - alert: KnightTaskFailures
+          annotations:
+            summary: >-
+              Knight {{ $labels.knight }} failed {{ $value }} tasks in the last hour.
+          expr: |
+            sum by (knight) (increase(pi_knight_tasks_total{status=~"error|timeout"}[1h])) > 2
+          for: 5m
+          labels:
+            severity: warning
+        - alert: KnightNatsDisconnected
+          annotations:
+            summary: >-
+              Knight {{ $labels.knight }} has lost its NATS connection.
+          expr: |
+            pi_knight_nats_connected == 0
+          for: 10m
+          labels:
+            severity: warning
+        - alert: KnightMetricsAbsent
+          annotations:
+            summary: >-
+              No pi-knight metrics are being scraped — PodMonitor or knights are down.
+          expr: |
+            absent(pi_knight_nats_connected)
+          for: 30m
+          labels:
+            severity: warning
+        - alert: KnightLLMCostSpike
+          annotations:
+            summary: >-
+              Fleet LLM spend rose ${{ $value | humanize }} in 24h — above the
+              Night Watch budget envelope; possible runaway loop.
+          expr: |
+            sum(increase(pi_knight_llm_cost_dollars_total[24h])) > 15
+          for: 15m
+          labels:
+            severity: critical
+    - name: roundtable.pods
+      rules:
+        - alert: RoundtablePodRestarting
+          annotations:
+            summary: >-
+              {{ $labels.pod }} restarted {{ $value }} times in the last hour.
+          expr: |
+            sum by (pod) (increase(kube_pod_container_status_restarts_total{namespace="roundtable"}[1h])) > 3
+          for: 5m
+          labels:
+            severity: warning
+        - alert: RoundtablePodOOMKilled
+          annotations:
+            summary: >-
+              {{ $labels.pod }}/{{ $labels.container }} was OOMKilled in the last hour.
+          expr: |
+            max_over_time(kube_pod_container_status_last_terminated_reason{namespace="roundtable", reason="OOMKilled"}[1h]) == 1
+          labels:
+            severity: warning

--- a/kubernetes/apps/roundtable/infrastructure/app/servicemonitor.yaml
+++ b/kubernetes/apps/roundtable/infrastructure/app/servicemonitor.yaml
@@ -1,0 +1,15 @@
+---
+# yaml-language-server: $schema=https://kubernetes-schemas.pages.dev/monitoring.coreos.com/servicemonitor_v1.json
+# Scrape the Round Table dashboard API (/metrics lands with roundtable-ui#night-watch-telemetry).
+apiVersion: monitoring.coreos.com/v1
+kind: ServiceMonitor
+metadata:
+  name: roundtable-dashboard
+spec:
+  selector:
+    matchLabels:
+      app.kubernetes.io/name: roundtable-dashboard
+  endpoints:
+    - port: http
+      path: /metrics
+      interval: 1m

--- a/kubernetes/apps/roundtable/infrastructure/app/watchman-rbac.yaml
+++ b/kubernetes/apps/roundtable/infrastructure/app/watchman-rbac.yaml
@@ -1,0 +1,51 @@
+---
+# ServiceAccount for Watchman — Night Watch telemetry sweep + Mission dispatch
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: watchman
+  namespace: roundtable
+---
+# Read access for diagnostics (shared knight role: pods, logs, events, flux)
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRoleBinding
+metadata:
+  name: knight-watchman-read-only
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: ClusterRole
+  name: knight-kubectl-read-only
+subjects:
+  - kind: ServiceAccount
+    name: watchman
+    namespace: roundtable
+---
+# Watchman is the ONLY knight allowed to create Missions (fix dispatch).
+# Scoped to the roundtable namespace; no update/delete — Missions are
+# fire-and-forget records, cleanup stays human/operator-owned.
+apiVersion: rbac.authorization.k8s.io/v1
+kind: Role
+metadata:
+  name: watchman-mission-dispatch
+  namespace: roundtable
+rules:
+  - apiGroups: ["ai.roundtable.io"]
+    resources: ["missions"]
+    verbs: ["create", "get", "list", "watch"]
+  - apiGroups: ["ai.roundtable.io"]
+    resources: ["knights", "chains", "roundtables"]
+    verbs: ["get", "list", "watch"]
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: RoleBinding
+metadata:
+  name: watchman-mission-dispatch
+  namespace: roundtable
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: Role
+  name: watchman-mission-dispatch
+subjects:
+  - kind: ServiceAccount
+    name: watchman
+    namespace: roundtable

--- a/kubernetes/apps/roundtable/knights/app/kustomization.yaml
+++ b/kubernetes/apps/roundtable/knights/app/kustomization.yaml
@@ -19,6 +19,8 @@ resources:
   # Generic coding knights
   - coder-1.yaml
   - coder-2.yaml
+  # Night Watch sentinel
+  - watchman.yaml
   # Round Table Dev Team
   - roundtable-dev.yaml
   - rt-lead.yaml

--- a/kubernetes/apps/roundtable/knights/app/watchman.yaml
+++ b/kubernetes/apps/roundtable/knights/app/watchman.yaml
@@ -3,7 +3,7 @@ apiVersion: ai.roundtable.io/v1alpha1
 kind: Knight
 metadata:
   labels:
-    ai.roundtable.io/table: personal
+    ai.roundtable.io/table: roundtable-dev
   name: watchman
 spec:
   domain: watch
@@ -26,15 +26,16 @@ spec:
   nats:
     url: nats://nats.database.svc:4222
     subjects:
-      - "fleet-a.tasks.watch.>"
-    stream: fleet_a_tasks
-    resultsStream: fleet_a_results
+      - "rt-dev.tasks.watch.>"
+    stream: rt_dev_tasks
+    resultsStream: rt_dev_results
     maxDeliver: 1
   vault:
     claimName: roundtable-vault
     readOnly: true
     writablePaths:
       - "NightWatch/"
+      - "Briefings/NightWatch/"
   arsenal:
     repo: "https://github.com/dapperdivers/roundtable-arsenal"
     ref: main
@@ -53,15 +54,17 @@ spec:
         name: roundtable-secret
   prompt:
     identity: |
-      You are the Watchman, sentinel of the Night Watch.
-      Your domain is the health of the Round Table platform itself: the
-      roundtable operator, pi-knight runtime, dashboard, arsenal, and the
-      manifests that deploy them.
+      You are the Watchman, sentinel of the Night Watch and member of the
+      Round Table development team (roundtable-dev table). Your domain is
+      the health of the platform itself: the roundtable operator, pi-knight
+      runtime, dashboard, arsenal, and the manifests that deploy them.
 
       Each night you sweep Prometheus and Victoria Logs for the day's errors,
       reduce them to fingerprinted incidents, and dispatch at most THREE fix
-      Missions. You never fix code yourself — you observe, triage, dispatch,
-      and keep the ledger at /vault/NightWatch/ledger.md truthful.
+      Missions to your teammates (rt-runtime, rt-ui, rt-operator, rt-arsenal).
+      You never fix code yourself — you observe, triage, dispatch, keep the
+      ledger at /vault/NightWatch/ledger.md truthful, and write the morning
+      report yourself.
 
       Read the watch/telemetry-queries and watch/night-watch-triage skills
       before acting. Discipline over heroics: a quiet, accurate night beats

--- a/kubernetes/apps/roundtable/knights/app/watchman.yaml
+++ b/kubernetes/apps/roundtable/knights/app/watchman.yaml
@@ -1,0 +1,68 @@
+---
+apiVersion: ai.roundtable.io/v1alpha1
+kind: Knight
+metadata:
+  labels:
+    ai.roundtable.io/table: personal
+  name: watchman
+spec:
+  domain: watch
+  serviceAccountName: watchman
+  image: ""
+  # Cloud model on purpose: triage over 24h of telemetry needs more context
+  # and reasoning than the local qwen pool offers, but stays cheap on haiku.
+  model: "openrouter/anthropic/claude-haiku-4.5"
+  skills:
+    - shared
+    - watch
+  tools:
+    nix:
+      - kubectl
+      - curl
+      - jq
+      - yq-go
+      - gh
+      - ripgrep
+  nats:
+    url: nats://nats.database.svc:4222
+    subjects:
+      - "fleet-a.tasks.watch.>"
+    stream: fleet_a_tasks
+    resultsStream: fleet_a_results
+    maxDeliver: 1
+  vault:
+    claimName: roundtable-vault
+    readOnly: true
+    writablePaths:
+      - "NightWatch/"
+  arsenal:
+    repo: "https://github.com/dapperdivers/roundtable-arsenal"
+    ref: main
+    period: "300s"
+  workspace:
+    size: "5Gi"
+  concurrency: 1
+  taskTimeout: 3600
+  env:
+    - name: TMPDIR
+      value: "/data/scratch"
+    - name: XDG_CACHE_HOME
+      value: "/data/scratch/.cache"
+  envFrom:
+    - secretRef:
+        name: roundtable-secret
+  prompt:
+    identity: |
+      You are the Watchman, sentinel of the Night Watch.
+      Your domain is the health of the Round Table platform itself: the
+      roundtable operator, pi-knight runtime, dashboard, arsenal, and the
+      manifests that deploy them.
+
+      Each night you sweep Prometheus and Victoria Logs for the day's errors,
+      reduce them to fingerprinted incidents, and dispatch at most THREE fix
+      Missions. You never fix code yourself — you observe, triage, dispatch,
+      and keep the ledger at /vault/NightWatch/ledger.md truthful.
+
+      Read the watch/telemetry-queries and watch/night-watch-triage skills
+      before acting. Discipline over heroics: a quiet, accurate night beats
+      a busy, noisy one.


### PR DESCRIPTION
First two phases of the Night Watch system (overnight telemetry-driven self-fixing for the roundtable platform), running on the **roundtable-dev table** — the platform's own dev team owns platform health.

**Commit 1 — observability:**
- `PodMonitor` for knight pods — pi-knight's Prometheus metrics (`pi_knight_tasks_total`, `pi_knight_llm_cost_dollars_total`, …) were never scraped until now
- `ServiceMonitor` for the dashboard (pairs with dapperdivers/roundtable-ui /metrics PR)
- `PrometheusRule` — knight task failures, NATS disconnects, pod restarts/OOM, metrics-absent, and a critical fleet cost-spike alert ($15/24h)

**Commits 2+3 — the sweep (diagnosis mode):**
- `watchman` Knight CR — roundtable-dev table, domain `watch` (`rt-dev.tasks.watch.>`), haiku-4.5 via OpenRouter, dedicated SA
- RBAC: shared read-only role + a namespaced Role allowing **create on Missions only** (unused until dispatch mode is enabled; granted now so the flip is a prompt change, not an RBAC change)
- `night-watch` Chain — `roundTableRef: roundtable-dev`, 07:00 UTC: verify yesterday's fixes → collect 24h errors → triage to `/vault/NightWatch/ledger.md` → watchman writes `/vault/Briefings/NightWatch/YYYY-MM-DD.md` (chains can't dispatch across tables, so gawain on personal/fleet-a can't take the report step)
- Diagnosis-only: the triage prompt forbids Mission creation; it writes the would-be Mission briefings into the report instead. When dispatch mode turns on, Missions go to rt-runtime / rt-ui / rt-operator / rt-arsenal (rt-lead for multi-repo incidents) — Mission briefings dispatch via the target knight's own subjects, so cross-table works there.

Depends on dapperdivers/roundtable-arsenal#42 for the `watch/*` and `coding/night-watch-fix` skills (knights git-sync arsenal `main` every 300s).

All resources validate via `kubectl apply --dry-run=server` against the live CRDs; the three kustomizations build clean.

Kill switch: `kubectl patch chain night-watch -n roundtable --type merge -p '{"spec":{"suspended":true}}'`
