### PR TITLE
fix(roundtable): monitoring resources need explicit namespace

### DIFF
--- a/kubernetes/apps/roundtable/infrastructure/app/podmonitor.yaml
+++ b/kubernetes/apps/roundtable/infrastructure/app/podmonitor.yaml
@@ -6,6 +6,7 @@ apiVersion: monitoring.coreos.com/v1
 kind: PodMonitor
 metadata:
   name: knights
+  namespace: roundtable
 spec:
   selector:
     matchLabels:

--- a/kubernetes/apps/roundtable/infrastructure/app/prometheusrule.yaml
+++ b/kubernetes/apps/roundtable/infrastructure/app/prometheusrule.yaml
@@ -6,6 +6,7 @@ apiVersion: monitoring.coreos.com/v1
 kind: PrometheusRule
 metadata:
   name: roundtable
+  namespace: roundtable
 spec:
   groups:
     - name: roundtable.knights

--- a/kubernetes/apps/roundtable/infrastructure/app/servicemonitor.yaml
+++ b/kubernetes/apps/roundtable/infrastructure/app/servicemonitor.yaml
@@ -5,6 +5,7 @@ apiVersion: monitoring.coreos.com/v1
 kind: ServiceMonitor
 metadata:
   name: roundtable-dashboard
+  namespace: roundtable
 spec:
   selector:
     matchLabels:


### PR DESCRIPTION
The infrastructure Kustomization has no targetNamespace — every resource
in the dir carries metadata.namespace, which the new PodMonitor/
ServiceMonitor/PrometheusRule lacked. Server-side apply rejected them.
