### PR TITLE
feat(roundtable): operator 0.11.0 — persistent nix-daemon builder

### DIFF
--- a/kubernetes/apps/roundtable/operator/app/helmrelease.yaml
+++ b/kubernetes/apps/roundtable/operator/app/helmrelease.yaml
@@ -13,7 +13,7 @@ spec:
   chart:
     spec:
       chart: roundtable-operator
-      version: "0.10.4"
+      version: "0.11.0"
       sourceRef:
         kind: HelmRepository
         name: roundtable
@@ -21,8 +21,14 @@ spec:
   values:
     image:
       repository: ghcr.io/dapperdivers/roundtable
-      tag: 78049fc0fd5d47cb8159d2082f4585f61e86382a
+      tag: 89858749a80446d2c3b689950613219fcc63a611
       pullPolicy: Always
+
+    # Persistent nix-daemon builder: a single root Deployment owns the shared
+    # Nix store and builds knight tools dispatched via the roundtable-nix-buildqueue
+    # PVC — replaces the per-knight build Jobs + global store lock.
+    nixBuilder:
+      enabled: true
 
     resources:
       requests:
@@ -36,7 +42,7 @@ spec:
     images:
       piKnight:
         repository: ghcr.io/dapperdivers/pi-knight
-        tag: 7786f1785521a57258cc100351af0a110672afb1
+        tag: 36aa86f97f23776686be01666d2ae2b8e4c69c5f
       dashboard:
         repository: ghcr.io/dapperdivers/roundtable-ui
         tag: 2dbd0af7d181e40f95a263104102b34290fc12dd

--- a/kubernetes/apps/roundtable/operator/app/kustomization.yaml
+++ b/kubernetes/apps/roundtable/operator/app/kustomization.yaml
@@ -4,4 +4,5 @@ apiVersion: kustomize.config.k8s.io/v1beta1
 kind: Kustomization
 resources:
   - nix-store-pvc.yaml
+  - nix-buildqueue-pvc.yaml
   - helmrelease.yaml

--- a/kubernetes/apps/roundtable/operator/app/nix-buildqueue-pvc.yaml
+++ b/kubernetes/apps/roundtable/operator/app/nix-buildqueue-pvc.yaml
@@ -1,0 +1,18 @@
+# yaml-language-server: $schema=https://kubernetes-schemas.pages.dev/v1/persistentvolumeclaim.json
+---
+# Work queue for the persistent nix-daemon builder. The operator writes build
+# requests here and the roundtable-operator-nix-builder Deployment writes
+# results back — a small RWX coordination channel, NOT a Nix store. Both pods
+# mount it; the builder (the store's sole writer) reads requests and publishes
+# profiles into roundtable-nix-store.
+apiVersion: v1
+kind: PersistentVolumeClaim
+metadata:
+  name: roundtable-nix-buildqueue
+  namespace: roundtable
+spec:
+  accessModes: ["ReadWriteMany"]
+  resources:
+    requests:
+      storage: 1Gi
+  storageClassName: cephfs-shared


### PR DESCRIPTION
Deploys the #4 persistent nix-daemon builder (roundtable#130, pi-knight#34+#35).

- New `roundtable-nix-buildqueue` PVC (1Gi RWX cephfs-shared) — operator↔builder work queue.
- Chart `0.10.4 → 0.11.0`, `nixBuilder.enabled: true` (spins up the single root builder Deployment + mounts `/queue` into the operator).
- operator image → `89858749`, pi-knight image → `36aa86f` (includes the bootstrap-under-lock fix #34 + the builder script #35).

Replaces the per-knight build Jobs + global store flock: fleet rebuilds now run concurrently against one nix-daemon (correct store concurrency + derivation dedup), ending the lock-serialized ~2.5h rebuilds that were overrunning the 30-min job deadline.