### PR TITLE
feat(roundtable): operator 0.12.0 — knights mount shared Nix store read-only

### DIFF
--- a/kubernetes/apps/roundtable/operator/app/helmrelease.yaml
+++ b/kubernetes/apps/roundtable/operator/app/helmrelease.yaml
@@ -13,7 +13,7 @@ spec:
   chart:
     spec:
       chart: roundtable-operator
-      version: "0.11.0"
+      version: "0.12.0"
       sourceRef:
         kind: HelmRepository
         name: roundtable
@@ -21,7 +21,7 @@ spec:
   values:
     image:
       repository: ghcr.io/dapperdivers/roundtable
-      tag: 89858749a80446d2c3b689950613219fcc63a611
+      tag: 57afcc5b381fc04c1ca4f0bf0129ac0f6c5d0b4d
       pullPolicy: Always
 
     # Persistent nix-daemon builder: a single root Deployment owns the shared


### PR DESCRIPTION
The #13 cutover deploy. Knights stop using per-pod nix PVCs and instead mount `roundtable-nix-store` **read-only**, sourcing the profile the daemon builder publishes.

- Chart `0.11.0 → 0.12.0`, operator image → `57afcc5b`. Operator-only change; pi-knight stays `36aa86f`, `nixBuilder` stays enabled.
- Reversible: per-knight PVCs remain until the separate decommission step, so reverting restores the old mounts with data intact.
- osd.21 marked out; Ceph recovery handled in a separate workstream.