### PR TITLE
feat(roundtable): knight tooling audit — fill role gaps + standardize toolsets

### DIFF
--- a/kubernetes/apps/roundtable/chelonian/app/cl-backend.yaml
+++ b/kubernetes/apps/roundtable/chelonian/app/cl-backend.yaml
@@ -19,6 +19,11 @@ spec:
       - ripgrep
       - python3
       - gnumake
+      - fd
+      - tree
+      - yq-go
+      - bat
+      - delta
   nats:
     url: nats://nats.database.svc:4222
     subjects:

--- a/kubernetes/apps/roundtable/chelonian/app/cl-data.yaml
+++ b/kubernetes/apps/roundtable/chelonian/app/cl-data.yaml
@@ -18,6 +18,10 @@ spec:
       - curl
       - ripgrep
       - python3
+      - duckdb
+      - sqlite
+      - csvkit
+      - miller
   nats:
     url: nats://nats.database.svc:4222
     subjects:

--- a/kubernetes/apps/roundtable/chelonian/app/cl-frontend.yaml
+++ b/kubernetes/apps/roundtable/chelonian/app/cl-frontend.yaml
@@ -17,7 +17,12 @@ spec:
       - jq
       - curl
       - ripgrep
-      - nodejs
+      - nodejs_22
+      - fd
+      - tree
+      - yq-go
+      - bat
+      - delta
   nats:
     url: nats://nats.database.svc:4222
     subjects:

--- a/kubernetes/apps/roundtable/chelonian/app/cl-infra.yaml
+++ b/kubernetes/apps/roundtable/chelonian/app/cl-infra.yaml
@@ -17,8 +17,13 @@ spec:
       - jq
       - curl
       - ripgrep
-      - yq
+      - yq-go
       - tree
+      - kubectl
+      - kubernetes-helm
+      - k9s
+      - stern
+      - kustomize
   nats:
     url: nats://nats.database.svc:4222
     subjects:

--- a/kubernetes/apps/roundtable/chelonian/app/cl-lead.yaml
+++ b/kubernetes/apps/roundtable/chelonian/app/cl-lead.yaml
@@ -17,8 +17,9 @@ spec:
       - jq
       - tree
       - curl
-      - yq
+      - yq-go
       - ripgrep
+      - fd
   nats:
     url: nats://nats.database.svc:4222
     subjects:

--- a/kubernetes/apps/roundtable/chelonian/app/cl-qa.yaml
+++ b/kubernetes/apps/roundtable/chelonian/app/cl-qa.yaml
@@ -17,8 +17,14 @@ spec:
       - jq
       - curl
       - ripgrep
-      - nodejs
+      - nodejs_22
       - python3
+      - fd
+      - tree
+      - yq-go
+      - bat
+      - delta
+      - shellcheck
   nats:
     url: nats://nats.database.svc:4222
     subjects:

--- a/kubernetes/apps/roundtable/chelonian/app/cl-research.yaml
+++ b/kubernetes/apps/roundtable/chelonian/app/cl-research.yaml
@@ -16,6 +16,10 @@ spec:
       - jq
       - curl
       - ripgrep
+      - wget
+      - lynx
+      - pup
+      - httpie
   nats:
     url: nats://nats.database.svc:4222
     subjects:

--- a/kubernetes/apps/roundtable/chelonian/app/cl-turtle.yaml
+++ b/kubernetes/apps/roundtable/chelonian/app/cl-turtle.yaml
@@ -17,7 +17,10 @@ spec:
       - jq
       - curl
       - ripgrep
-      - nodejs
+      - nodejs_22
+      - fd
+      - tree
+      - yq-go
   nats:
     url: nats://nats.database.svc:4222
     subjects:

--- a/kubernetes/apps/roundtable/knights/app/agravain.yaml
+++ b/kubernetes/apps/roundtable/knights/app/agravain.yaml
@@ -28,6 +28,10 @@ spec:
       - testssl
       - sqlmap
       - nuclei
+      - katana
+      - naabu
+      - dalfox
+      - gowitness
       # - zaproxy  # Package broken/missing in nixpkgs
       - feroxbuster
       - socat

--- a/kubernetes/apps/roundtable/knights/app/bedivere.yaml
+++ b/kubernetes/apps/roundtable/knights/app/bedivere.yaml
@@ -16,6 +16,8 @@ spec:
   tools:
     nix:
       - python3
+      - curl
+      - jq
   nats:
     url: nats://nats.database.svc:4222
     subjects:

--- a/kubernetes/apps/roundtable/knights/app/coder-1.yaml
+++ b/kubernetes/apps/roundtable/knights/app/coder-1.yaml
@@ -21,10 +21,12 @@ spec:
       - tree
       - curl
       - nodejs_22
-      - yq
+      - yq-go
       - ripgrep
       - python3
       - fd
+      - bat
+      - delta
   nats:
     url: nats://nats.database.svc:4222
     subjects:

--- a/kubernetes/apps/roundtable/knights/app/coder-2.yaml
+++ b/kubernetes/apps/roundtable/knights/app/coder-2.yaml
@@ -23,10 +23,12 @@ spec:
       - tree
       - curl
       - nodejs_22
-      - yq
+      - yq-go
       - ripgrep
       - python3
       - fd
+      - bat
+      - delta
   nats:
     url: nats://nats.database.svc:4222
     subjects:

--- a/kubernetes/apps/roundtable/knights/app/galahad.yaml
+++ b/kubernetes/apps/roundtable/knights/app/galahad.yaml
@@ -26,6 +26,10 @@ spec:
       - nuclei
       - trivy
       - yara
+      - trufflehog
+      - cosign
+      - checkov
+      - tfsec
       # OSINT & threat intel
       - gitleaks       # Secret scanning
       - grype          # Container image vuln scanner

--- a/kubernetes/apps/roundtable/knights/app/gawain.yaml
+++ b/kubernetes/apps/roundtable/knights/app/gawain.yaml
@@ -20,13 +20,15 @@ spec:
   tools:
     nix:
       - gh
-      - yq
+      - yq-go
       - python3
       - go
       - gnumake
       - jq
       - tree
       - curl
+      - fd
+      - ripgrep
   nats:
     url: nats://nats.database.svc:4222
     subjects:

--- a/kubernetes/apps/roundtable/knights/app/kay.yaml
+++ b/kubernetes/apps/roundtable/knights/app/kay.yaml
@@ -24,6 +24,8 @@ spec:
       - bat
       - fd
       - eza
+      - yt-dlp
+      - pandoc
       - python3          # Required for fetch-news.py and arsenal scripts
       - jq               # JSON processing for API responses
       # Research & Data Processing (Added 2026-03-23)

--- a/kubernetes/apps/roundtable/knights/app/lancelot.yaml
+++ b/kubernetes/apps/roundtable/knights/app/lancelot.yaml
@@ -17,6 +17,7 @@ spec:
     nix:
       - python3
       - lynx
+      - pandoc
       - jq             # JSON processing (Added 2026-04-06)
       - yq-go          # YAML processing (Added 2026-04-06)
       - curl           # HTTP requests (Added 2026-04-06)

--- a/kubernetes/apps/roundtable/knights/app/patsy.yaml
+++ b/kubernetes/apps/roundtable/knights/app/patsy.yaml
@@ -19,6 +19,8 @@ spec:
       - bat
       - delta
       - sqlite
+      - ripgrep
+      - ripgrep-all
       # Added 2026-03-09 - Fleet self-improvement assessment
       - fd               # Fast file discovery for vault indexing
       - fzf              # Interactive fuzzy finder for vault exploration

--- a/kubernetes/apps/roundtable/knights/app/percival.yaml
+++ b/kubernetes/apps/roundtable/knights/app/percival.yaml
@@ -20,6 +20,9 @@ spec:
       - sqlite
       - units
       - dateutils
+      - python3
+      - jq
+      - curl
   nats:
     url: nats://nats.database.svc:4222
     subjects:

--- a/kubernetes/apps/roundtable/knights/app/rt-arsenal.yaml
+++ b/kubernetes/apps/roundtable/knights/app/rt-arsenal.yaml
@@ -19,8 +19,9 @@ spec:
       - jq
       - tree
       - curl
-      - yq
+      - yq-go
       - ripgrep
+      - fd
   nats:
     url: nats://nats.database.svc:4222
     subjects:

--- a/kubernetes/apps/roundtable/knights/app/rt-lead.yaml
+++ b/kubernetes/apps/roundtable/knights/app/rt-lead.yaml
@@ -19,8 +19,9 @@ spec:
       - jq
       - tree
       - curl
-      - yq
+      - yq-go
       - ripgrep
+      - fd
   nats:
     url: nats://nats.database.svc:4222
     subjects:

--- a/kubernetes/apps/roundtable/knights/app/rt-operator.yaml
+++ b/kubernetes/apps/roundtable/knights/app/rt-operator.yaml
@@ -21,8 +21,10 @@ spec:
       - jq
       - tree
       - curl
-      - yq
+      - yq-go
       - ripgrep
+      - kubectl
+      - fd
   nats:
     url: nats://nats.database.svc:4222
     subjects:

--- a/kubernetes/apps/roundtable/knights/app/rt-runtime.yaml
+++ b/kubernetes/apps/roundtable/knights/app/rt-runtime.yaml
@@ -20,9 +20,10 @@ spec:
       - tree
       - curl
       - nodejs_22
-      - yq
+      - yq-go
       - ripgrep
       - python3
+      - fd
   nats:
     url: nats://nats.database.svc:4222
     subjects:

--- a/kubernetes/apps/roundtable/knights/app/rt-ui.yaml
+++ b/kubernetes/apps/roundtable/knights/app/rt-ui.yaml
@@ -20,8 +20,10 @@ spec:
       - tree
       - curl
       - nodejs_22
-      - yq
+      - yq-go
       - ripgrep
+      - fd
+      - bat
   nats:
     url: nats://nats.database.svc:4222
     subjects:

--- a/kubernetes/apps/roundtable/knights/app/watchman.yaml
+++ b/kubernetes/apps/roundtable/knights/app/watchman.yaml
@@ -23,6 +23,8 @@ spec:
       - yq-go
       - gh
       - ripgrep
+      - stern
+      - k9s
   nats:
     url: nats://nats.database.svc:4222
     subjects:


### PR DESCRIPTION
A pass across all knights' nix tools — fixing role-critical gaps, standardizing inconsistencies, and adding polish. Only the changed knights rebuild (parallel, via the shared nix-daemon builder).

## Role-critical gaps
- **cl-infra** (devops, had *zero* k8s tools): +kubectl, kubernetes-helm, k9s, stern, kustomize
- **cl-data** (data, no data tools): +duckdb, sqlite, csvkit, miller
- **percival** (finance, no python): +python3, jq, curl
- **patsy** (vault, no content search): +ripgrep, ripgrep-all
- **bedivere** (home): +curl, jq
- **rt-operator** (operator, no kubectl): +kubectl, fd

## Consistency
- `yq` → `yq-go` and `nodejs` → `nodejs_22` fleet-wide (they were silently split)
- Common coder baseline (fd/tree/bat/delta) across the cl-*/rt-* coders
- **cl-research** given a real web-research kit (+wget, lynx, pup, httpie)

## Polish
- **agravain**: +katana, naabu, dalfox, gowitness (modern recon/XSS/screenshotting)
- **galahad**: +trufflehog, cosign, checkov, tfsec (secrets/sig/IaC scanning)
- **kay**: +yt-dlp, pandoc · **lancelot**: +pandoc

24 knight specs touched. `tristan`/`gareth` left as-is (already coherent). New package names validate at build time — any typo fails only that one knight's build (isolated, surfaced as a NixBuildFailed event), so blast radius is one knight.

Note: `autoresearch` (0 tools) is an unmanaged orphan CR not in GitOps — handled separately.