### PR TITLE
fix(roundtable): drop checkov from galahad (insecure transitive dep)

### DIFF
--- a/kubernetes/apps/roundtable/knights/app/galahad.yaml
+++ b/kubernetes/apps/roundtable/knights/app/galahad.yaml
@@ -28,7 +28,6 @@ spec:
       - yara
       - trufflehog
       - cosign
-      - checkov
       - tfsec
       # OSINT & threat intel
       - gitleaks       # Secret scanning

--- a/kubernetes/apps/roundtable/operator/app/helmrelease.yaml
+++ b/kubernetes/apps/roundtable/operator/app/helmrelease.yaml
@@ -13,7 +13,7 @@ spec:
   chart:
     spec:
       chart: roundtable-operator
-      version: "0.12.0"
+      version: "0.12.1"
       sourceRef:
         kind: HelmRepository
         name: roundtable
@@ -21,7 +21,7 @@ spec:
   values:
     image:
       repository: ghcr.io/dapperdivers/roundtable
-      tag: 57afcc5b381fc04c1ca4f0bf0129ac0f6c5d0b4d
+      tag: 72bef61e62467decc570d67739b53ba6f53c7ec0
       pullPolicy: Always
 
     # Persistent nix-daemon builder: a single root Deployment owns the shared


### PR DESCRIPTION
galahad's nix build failed after the tooling audit: `checkov` pulls `python3.13-ecdsa-0.19.2`, flagged insecure in nixpkgs, so Nix refuses to build it.

`trivy` (already in galahad) already does IaC misconfiguration scanning, so checkov is redundant — dropping it. `tfsec`/`trufflehog`/`cosign` (all built fine) stay.

This was the only failure of the 18 knights/app rebuilds; the rest published cleanly.