### PR TITLE
chore(roundtable): unmanage chelonian cl-* knights (Flux prune)

### DIFF
--- a/kubernetes/apps/roundtable/chelonian/app/kustomization.yaml
+++ b/kubernetes/apps/roundtable/chelonian/app/kustomization.yaml
@@ -5,15 +5,5 @@ kind: Kustomization
 resources:
   # ChelonianLabs RoundTable
   - roundtable-chelonian.yaml
-  # Repo knights
-  - cl-backend.yaml
-  - cl-frontend.yaml
-  - cl-infra.yaml
-  - cl-turtle.yaml
-  # Support knights
-  - cl-lead.yaml
-  - cl-research.yaml
-  - cl-data.yaml
-  - cl-qa.yaml
   # Chains
   - chelonian-repo-init.yaml

--- a/kubernetes/apps/roundtable/operator/app/helmrelease.yaml
+++ b/kubernetes/apps/roundtable/operator/app/helmrelease.yaml
@@ -13,7 +13,7 @@ spec:
   chart:
     spec:
       chart: roundtable-operator
-      version: "0.12.0"
+      version: "0.12.1"
       sourceRef:
         kind: HelmRepository
         name: roundtable
@@ -21,7 +21,7 @@ spec:
   values:
     image:
       repository: ghcr.io/dapperdivers/roundtable
-      tag: 57afcc5b381fc04c1ca4f0bf0129ac0f6c5d0b4d
+      tag: 72bef61e62467decc570d67739b53ba6f53c7ec0
       pullPolicy: Always
 
     # Persistent nix-daemon builder: a single root Deployment owns the shared


### PR DESCRIPTION
Removes the eight `cl-*` knights from the chelonian kustomization so Flux prunes the live Knight CRs (`prune: true` is set). The `cl-*.yaml` manifests stay in-tree (dormant) so they can be re-added later.

**Note:** `roundtable-chelonian` is currently `suspend=true`, so the prune won't execute until it's resumed.