### PR TITLE
fix(kyverno): run admission controller HA (3 replicas + PDB)

### DIFF
--- a/kubernetes/apps/kyverno/kyverno/app/helmrelease.yaml
+++ b/kubernetes/apps/kyverno/kyverno/app/helmrelease.yaml
@@ -31,6 +31,17 @@ spec:
     grafana:
       enabled: true
     admissionController:
+      # HA: keep >1 admission replica so a single pod disruption (e.g. a tuppr
+      # node drain) never empties kyverno-svc endpoints. With failurePolicy=Fail
+      # webhooks, zero endpoints rejects cluster-wide writes and bricks the
+      # control plane (KCM/scheduler crashloop). antiAffinity is on by default,
+      # so replicas spread across nodes.
+      replicas: 3
+      podDisruptionBudget:
+        # Explicit PDB (chart auto-enables one when replicas>1, but make it
+        # declarative) so node drains can never evict all admission pods at once.
+        enabled: true
+        minAvailable: 1
       clusterRole:
         extraResources:
           - apiGroups:


### PR DESCRIPTION
## Problem

On 2026-06-27 the cluster fell into a Kyverno admission-webhook deadlock that crashlooped `kube-controller-manager` and `kube-scheduler` on **all three control-plane nodes** and wedged Flux plus ~20 operators for ~44h.

**Root cause:** the `kyverno-admission-controller` ran with a **single replica** (chart default — no `replicas` set) and **no PodDisruptionBudget**. When that one pod was disrupted (most likely a `tuppr` Talos/k8s rolling node drain — nothing blocked evicting the sole pod), `kyverno-svc` dropped to **zero endpoints**.

Because the resource webhooks use `failurePolicy: Fail`, zero endpoints made the API server reject writes **cluster-wide** with `no endpoints available for service "kyverno-svc"`. The webhooks correctly exclude `kube-system`/`kyverno`, but KCM's job-controller writes Jobs in *every other* namespace — so KCM/scheduler wedged, lost their leader leases, and crashlooped. The resulting API churn prevented the lone admission pod from ever going Ready again → self-sustaining deadlock requiring manual break-glass (temporarily patching the webhooks to `failurePolicy: Ignore`).

## Fix

Make the admission controller highly available so a single pod disruption can never empty `kyverno-svc` endpoints:

- `admissionController.replicas: 3` — `antiAffinity` is on by default, so replicas spread across nodes.
- `admissionController.podDisruptionBudget` `enabled: true` / `minAvailable: 1` — node drains/upgrades can never evict all admission pods at once. (The chart auto-enables a PDB when `replicas > 1`; set explicitly to keep it declarative.)

`failurePolicy: Fail` is intentionally **kept** — the bug was availability, not policy posture. HA + PDB is the correct mitigation rather than weakening enforcement to `Ignore`.

## Verification

Verified the value keys against the live `kyverno` chart `3.8.1` values (`admissionController.replicas`, `admissionController.podDisruptionBudget.{enabled,minAvailable}`, `admissionController.antiAffinity.enabled: true` default). YAML validated. After merge, Flux rolls 3 admission pods; the temporary live `failurePolicy: Ignore` patch is already auto-reverted to `Fail` by Kyverno's webhook-controller now that endpoints are restored.