### PR TITLE
feat(ollama): expand model PVCs 50Gi → 150Gi

### DIFF
--- a/kubernetes/apps/ai/ollama/app/pvc.yaml
+++ b/kubernetes/apps/ai/ollama/app/pvc.yaml
@@ -8,7 +8,7 @@ spec:
     - ReadWriteOnce
   resources:
     requests:
-      storage: 50Gi
+      storage: 150Gi
   storageClassName: ceph-rbd
 ---
 # Per-instance model stores for the knight pool members. Each instance gets
@@ -23,7 +23,7 @@ spec:
     - ReadWriteOnce
   resources:
     requests:
-      storage: 50Gi
+      storage: 150Gi
   storageClassName: ceph-rbd
 ---
 apiVersion: v1
@@ -35,5 +35,5 @@ spec:
     - ReadWriteOnce
   resources:
     requests:
-      storage: 50Gi
+      storage: 150Gi
   storageClassName: ceph-rbd


### PR DESCRIPTION
## What
Bump all three ollama knight-pool model PVCs (`ollama-models`, `ollama-models-1`, `ollama-models-2`) from **50Gi → 150Gi**.

## Why
The model stores are at **92% full (45G / 50G)**, leaving ~4G free — not enough to pull additional GGUF models for evaluation. Immediate driver: testing **[Ornith-1.0](https://huggingface.co/deepreinforce-ai/Ornith-1.0-9B-GGUF)** for local agentic coding:
- 9B GGUF ≈ 6G (Q4) … 9.5G (Q8)
- 35B MoE GGUF ≈ 25G (Q5)

150Gi leaves ~100G free per store, comfortably fitting the existing models plus Ornith variants.

## Safety
- `ceph-rbd` storageClass has `allowVolumeExpansion: true`.
- `rook-pvc-pool` has ~2 TiB available (22% used) — no capacity concern.
- RBD online expansion: PVCs grow in place, **no pod recreate / data loss**. Flux applies the new request; the CSI driver resizes the filesystem on the mounted RWO volumes.

## Verification after merge
\`\`\`bash
flux reconcile kustomization ai -n flux-system
kubectl get pvc -n ai | grep ollama-models   # expect 150Gi
kubectl exec -n ai deploy/ollama -- df -h /models
\`\`\`