### PR TITLE
fix(kyverno): collapse postgres-init ExternalSecret finds to stop Infisical 429s

### DIFF
--- a/kubernetes/apps/kyverno/kyverno/policies/postgres-init/clusterpolicy-externalsecret.yaml
+++ b/kubernetes/apps/kyverno/kyverno/policies/postgres-init/clusterpolicy-externalsecret.yaml
@@ -55,16 +55,15 @@ spec:
                   INIT_POSTGRES_DBNAME: "{{ request.object.metadata.annotations.\"postgres-init.home.arpa/dbname\" || request.object.metadata.name }}"
                   INIT_POSTGRES_USER: '\{{ .{{ request.object.metadata.annotations."postgres-init.home.arpa/user-key" }} }}'
                   INIT_POSTGRES_PASS: '\{{ .{{ request.object.metadata.annotations."postgres-init.home.arpa/pass-key" }} }}'
+            # Static superuser + per-app postgres creds — rarely rotate, so a long
+            # refresh keeps recursive ListSecrets calls off the rate-limited
+            # infisical-postgres store (/Infrastructure/Postgres).
+            refreshInterval: 6h
             dataFrom:
+              # Single recursive find (one Infisical ListSecrets call) instead of
+              # four. All four keys are exact matches, so an anchored alternation is
+              # equivalent — four separate finds meant 4x the list calls per refresh,
+              # which is what triggered the HTTP 429 storm on this store.
               - find:
                   name:
-                    regexp: ^POSTGRES_SUPER_USER$
-              - find:
-                  name:
-                    regexp: ^POSTGRES_SUPER_PASS$
-              - find:
-                  name:
-                    regexp: "^{{ request.object.metadata.annotations.\"postgres-init.home.arpa/user-key\" }}$"
-              - find:
-                  name:
-                    regexp: "^{{ request.object.metadata.annotations.\"postgres-init.home.arpa/pass-key\" }}$"
+                    regexp: "^(POSTGRES_SUPER_USER|POSTGRES_SUPER_PASS|{{ request.object.metadata.annotations.\"postgres-init.home.arpa/user-key\" }}|{{ request.object.metadata.annotations.\"postgres-init.home.arpa/pass-key\" }})$"


### PR DESCRIPTION
## Problem

The `*-postgres-init` ExternalSecrets generated by the `postgres-init-externalsecret` ClusterPolicy are storming `UpdateFailed` events — **thousands each** (`litellm` ~3.9k, `atuin` ~4.2k, `firefly` ~2.7k, `paperless-ngx`), and still actively firing (`HTTP 429` from Infisical Cloud as recently as minutes ago).

**Root cause:** the generated ExternalSecret used **four separate `dataFrom.find` blocks**. Each `find` triggers its own **recursive `ListSecrets`** call against the `infisical-postgres` store (`/Infrastructure/Postgres`, `recursive: true`). Four finds × four postgres-backed apps refreshing hourly = a burst of recursive list calls that trips Infisical Cloud's rate limit (`CallListSecretsV3Raw → 429`).

Evidence it's the find-count, not the store or creds: on the **same** `infisical-postgres` store, every 1-find and 2-find ExternalSecret (`litellm-postgres`, `authentik-postgres`, `cloudnative-pg`, `atuin`) syncs cleanly with **zero** `UpdateFailed` — only the 4-find `*-postgres-init` ones storm.

## Fix

All four regexes are **anchored exact matches** (`^POSTGRES_SUPER_USER$`, `^POSTGRES_SUPER_PASS$`, `^{user-key}$`, `^{pass-key}$`), so they collapse into a **single anchored alternation** `find` — semantically identical, but **one list call per refresh instead of four**. Also widen `refreshInterval` to `6h` (these are static superuser/app creds that rarely rotate).

Net: ~16 recursive list calls/hr → ~0.7/hr. The template still resolves (`find` returns keys by their real names, which match the `.POSTGRES_SUPER_USER` / `.{user-key}` references). The policy has `synchronize: true`, so the change **propagates to the four existing generated ExternalSecrets** with no app redeploys.

### Why not direct `remoteRef.key` (GET instead of LIST)?
Cheaper still, but the store is `recursive: true` over `/Infrastructure/Postgres`, so a key in a subfolder would need its exact path — a small risk of breaking resolution. Keeping a single recursive `find` preserves the search semantics while removing the call-volume problem.

## Notes / follow-up

This same multi-`find` pattern is widespread across the repo (50+ ExternalSecrets, a few with 5–6 finds, `media/kometa` with 15) but only the postgres-init ones currently 429 — likely because they share the smaller/throttled `infisical-postgres` project path. If 429s reappear elsewhere, the same collapse applies. Out of scope here.

## Verification

YAML validated. Value keys (`spec.refreshInterval`, `dataFrom[].find.name.regexp`) are standard external-secrets v1. After merge + Flux reconcile, expect `litellm/atuin/firefly/paperless-ngx-postgres-init` to keep `SecretSynced: True` while `UpdateFailed` events stop.