### PR TITLE
fix(flux): store github notifier token under the key Flux expects (token)

### DIFF
--- a/kubernetes/flux/components/common/alerts/github/externalsecret.yaml
+++ b/kubernetes/flux/components/common/alerts/github/externalsecret.yaml
@@ -13,7 +13,10 @@ spec:
     template:
       engineVersion: v2
       data:
-        github-token-secret: "{{ .FLUX_GITHUB_TOKEN }}"
+        # Flux's github Provider reads the token from the key named "token";
+        # the previous key (github-token-secret) was never found, so every
+        # notification dispatch failed with "github token ... must be specified".
+        token: "{{ .FLUX_GITHUB_TOKEN }}"
 
   dataFrom:
     - find:


### PR DESCRIPTION
## Problem

`NotificationDispatchFailed` warnings fire on every Flux reconcile, cluster-wide (~89+ events): `failed to initialize notifier for provider 'github': github token or github app details must be specified`.

The github `Provider` is a common component applied to **every** namespace, so this misconfiguration is repeated everywhere.

## Root cause

The token value is present and valid — but stored under the **wrong key**. The ExternalSecret templates the PAT into a secret key literally named `github-token-secret`:

```yaml
target:
  name: github-token-secret
  template:
    data:
      github-token-secret: "{{ .FLUX_GITHUB_TOKEN }}"   # <-- wrong key
```

Flux's github notification provider reads the token from the key **`token`**. It never finds it → every dispatch fails.

## Fix

Rename the template **key** (not the secret name) to `token`. The `Provider.spec.secretRef.name: github-token-secret` and the secret's name are unchanged, so nothing else needs to move.

## Verification

After merge + reconcile, External Secrets re-renders the secret with the `token` key, and Flux Kustomization notifications dispatch successfully (the `NotificationDispatchFailed` events stop).