### PR TITLE
fix(flux): fetch github token via direct key ref to stop Infisical 429s

### DIFF
--- a/kubernetes/flux/components/common/alerts/github/externalsecret.yaml
+++ b/kubernetes/flux/components/common/alerts/github/externalsecret.yaml
@@ -18,6 +18,12 @@ spec:
         # notification dispatch failed with "github token ... must be specified".
         token: "{{ .FLUX_GITHUB_TOKEN }}"
 
-  dataFrom:
-    - find:
-        path: FLUX_GITHUB_TOKEN
+  # Direct key reference (one GetSecret call) instead of dataFrom.find, which
+  # does a recursive ListSecrets over the store root (/) — ~20 copies of this ES
+  # (one per namespace, via the common component) hammering that list endpoint is
+  # a chronic source of Infisical 429s. The key is known, so a direct ref is the
+  # documented approach (external-secrets.io/latest/provider/infisical).
+  data:
+    - secretKey: FLUX_GITHUB_TOKEN
+      remoteRef:
+        key: FLUX_GITHUB_TOKEN


### PR DESCRIPTION
## Problem

The `github-token` ExternalSecret (a **common component instantiated in ~20 namespaces**) fetches its single key with:

```yaml
dataFrom:
  - find:
      path: FLUX_GITHUB_TOKEN
```

The Infisical provider services `find` with a **recursive `ListSecrets` over the store root (`/`)**. With ~20 copies refreshing, that's ~20 recursive root-list calls per cycle against Infisical Cloud — a chronic `429` source (observed rate-limiting `github-token` reconciles in the external-secrets controller logs: `CallListSecretsV3Raw … status-code=429`).

## Fix

The key name is known, so use a **direct `data[].remoteRef.key` reference** — one `GetSecret` call, no list — which is the [documented approach](https://external-secrets.io/latest/provider/infisical/) for named secrets (`find` is intended for *dynamic discovery*, not known keys):

```yaml
data:
  - secretKey: FLUX_GITHUB_TOKEN
    remoteRef:
      key: FLUX_GITHUB_TOKEN
```

The template still resolves `.FLUX_GITHUB_TOKEN`. Switching `dataFrom`→`data` also bumps the spec, so the secret re-renders cleanly with the `token` key from #3422.

## Context — this is a systemic pattern, not a one-off

A cluster-wide audit of ExternalSecrets:

| Metric | Count |
|---|---|
| Total ExternalSecrets | **153** |
| Using `find` (dataFrom) | **153 (100%)** |
| Using direct refs (`data`) | **0** |
| Total `find` blocks per refresh cycle | **317** |
| …of which hit the `infisical` (root `/`) store | **304** |

So the whole secret layer fetches via recursive list. This PR converts the worst-amplified case (github-token × ~20 namespaces). The same `find`→`remoteRef.key` conversion is the recommended remediation for the rest where keys are known; tracked as follow-up rather than boiled-the-ocean here.

## Verification

YAML validated. Post-merge + reconcile, expect `github-token` reconciles to stop 429-ing and the `github-token-secret`s to carry the `token` key. (Note: notifications still require a valid PAT — the current `FLUX_GITHUB_TOKEN` returns `401 Bad credentials` and needs rotating in Infisical; separate from this fix.)