### PR TITLE
fix(externalsecrets): direct key refs for kometa + zigbee2mqtt (heavy 429 hitters)

### DIFF
--- a/kubernetes/apps/home-automation/zigbee2mqtt-garage/app/externalsecret.yaml
+++ b/kubernetes/apps/home-automation/zigbee2mqtt-garage/app/externalsecret.yaml
@@ -18,14 +18,11 @@ spec:
         ZIGBEE2MQTT_CONFIG_ADVANCED_PAN_ID: "{{ .ZIGBEE_PAN_ID }} "
         ZIGBEE2MQTT_CONFIG_ADVANCED_EXT_PAN_ID: "{{ .ZIGBEE_EXT_PAN_ID }}"
         ZIGBEE2MQTT_CONFIG_ADVANCED_NETWORK_KEY: "{{ .ZIGBEE_NETWORK_KEY }}"
-  dataFrom:
-    - find:
-        path: EMQX_MQTT_HOME_USERNAME
-    - find:
-        path: EMQX_MQTT_HOME_PASSWORD
-    - find:
-       path: ZIGBEE_PAN_ID
-    - find:
-        path: ZIGBEE_EXT_PAN_ID
-    - find:
-        path: ZIGBEE_NETWORK_KEY
+  # Direct key references (one GetSecret each) instead of recursive ListSecrets
+  # finds — see memory-bank/systemPatterns.md (ExternalSecrets key references).
+  data:
+    - {secretKey: EMQX_MQTT_HOME_USERNAME, remoteRef: {key: EMQX_MQTT_HOME_USERNAME}}
+    - {secretKey: EMQX_MQTT_HOME_PASSWORD, remoteRef: {key: EMQX_MQTT_HOME_PASSWORD}}
+    - {secretKey: ZIGBEE_PAN_ID, remoteRef: {key: ZIGBEE_PAN_ID}}
+    - {secretKey: ZIGBEE_EXT_PAN_ID, remoteRef: {key: ZIGBEE_EXT_PAN_ID}}
+    - {secretKey: ZIGBEE_NETWORK_KEY, remoteRef: {key: ZIGBEE_NETWORK_KEY}}

--- a/kubernetes/apps/home-automation/zigbee2mqtt/app/externalsecret.yaml
+++ b/kubernetes/apps/home-automation/zigbee2mqtt/app/externalsecret.yaml
@@ -18,14 +18,11 @@ spec:
         ZIGBEE2MQTT_CONFIG_ADVANCED_PAN_ID: "{{ .ZIGBEE_PAN_ID }} "
         ZIGBEE2MQTT_CONFIG_ADVANCED_EXT_PAN_ID: "{{ .ZIGBEE_EXT_PAN_ID }}"
         ZIGBEE2MQTT_CONFIG_ADVANCED_NETWORK_KEY: "{{ .ZIGBEE_NETWORK_KEY }}"
-  dataFrom:
-    - find:
-        path: EMQX_MQTT_HOME_USERNAME
-    - find:
-        path: EMQX_MQTT_HOME_PASSWORD
-    - find:
-       path: ZIGBEE_PAN_ID
-    - find:
-        path: ZIGBEE_EXT_PAN_ID
-    - find:
-        path: ZIGBEE_NETWORK_KEY
+  # Direct key references (one GetSecret each) instead of recursive ListSecrets
+  # finds — see memory-bank/systemPatterns.md (ExternalSecrets key references).
+  data:
+    - {secretKey: EMQX_MQTT_HOME_USERNAME, remoteRef: {key: EMQX_MQTT_HOME_USERNAME}}
+    - {secretKey: EMQX_MQTT_HOME_PASSWORD, remoteRef: {key: EMQX_MQTT_HOME_PASSWORD}}
+    - {secretKey: ZIGBEE_PAN_ID, remoteRef: {key: ZIGBEE_PAN_ID}}
+    - {secretKey: ZIGBEE_EXT_PAN_ID, remoteRef: {key: ZIGBEE_EXT_PAN_ID}}
+    - {secretKey: ZIGBEE_NETWORK_KEY, remoteRef: {key: ZIGBEE_NETWORK_KEY}}

--- a/kubernetes/apps/media/kometa/app/externalsecret.yaml
+++ b/kubernetes/apps/media/kometa/app/externalsecret.yaml
@@ -31,34 +31,22 @@ spec:
         KOMETA_TRAKT_EXPIRES_IN: "{{ .TRAKT_EXPIRES_IN }}"
         KOMETA_TRAKT_REFRESH_TOKEN: "{{ .TRAKT_REFRESH_TOKEN }}"
 
-  dataFrom:
-    - find:
-        path: TMDB_API_KEY
-    - find:
-        path: OMDB_API_KEY
-    - find:
-        path: MDBLIST_API_KEY
-    - find:
-        path: PLEX_BACKUP_TOKEN
-    - find:
-        path: RADARR_API_KEY
-    - find:
-        path: RADARR_UHD_API_KEY
-    - find:
-        path: SONARR_API_KEY
-    - find:
-        path: SONARR_UHD_API_KEY
-    - find:
-        path: TAUTULLI_API_KEY
-    - find:
-        path: TRAKT_CLIENT_ID
-    - find:
-        path: TRAKT_CLIENT_SECRET
-    - find:
-        path: TRAKT_ACCESS_TOKEN
-    - find:
-        path: TRAKT_CREATED_AT
-    - find:
-        path: TRAKT_EXPIRES_IN
-    - find:
-        path: TRAKT_REFRESH_TOKEN
+  # Direct key references (one GetSecret each) instead of 15 recursive
+  # ListSecrets calls per refresh. Keys are known, so this is the documented
+  # approach and removes this ES as the single largest Infisical 429 source.
+  data:
+    - {secretKey: TMDB_API_KEY, remoteRef: {key: TMDB_API_KEY}}
+    - {secretKey: OMDB_API_KEY, remoteRef: {key: OMDB_API_KEY}}
+    - {secretKey: MDBLIST_API_KEY, remoteRef: {key: MDBLIST_API_KEY}}
+    - {secretKey: PLEX_BACKUP_TOKEN, remoteRef: {key: PLEX_BACKUP_TOKEN}}
+    - {secretKey: RADARR_API_KEY, remoteRef: {key: RADARR_API_KEY}}
+    - {secretKey: RADARR_UHD_API_KEY, remoteRef: {key: RADARR_UHD_API_KEY}}
+    - {secretKey: SONARR_API_KEY, remoteRef: {key: SONARR_API_KEY}}
+    - {secretKey: SONARR_UHD_API_KEY, remoteRef: {key: SONARR_UHD_API_KEY}}
+    - {secretKey: TAUTULLI_API_KEY, remoteRef: {key: TAUTULLI_API_KEY}}
+    - {secretKey: TRAKT_CLIENT_ID, remoteRef: {key: TRAKT_CLIENT_ID}}
+    - {secretKey: TRAKT_CLIENT_SECRET, remoteRef: {key: TRAKT_CLIENT_SECRET}}
+    - {secretKey: TRAKT_ACCESS_TOKEN, remoteRef: {key: TRAKT_ACCESS_TOKEN}}
+    - {secretKey: TRAKT_CREATED_AT, remoteRef: {key: TRAKT_CREATED_AT}}
+    - {secretKey: TRAKT_EXPIRES_IN, remoteRef: {key: TRAKT_EXPIRES_IN}}
+    - {secretKey: TRAKT_REFRESH_TOKEN, remoteRef: {key: TRAKT_REFRESH_TOKEN}}

--- a/memory-bank/systemPatterns.md
+++ b/memory-bank/systemPatterns.md
@@ -80,6 +80,20 @@ A comprehensive monitoring stack is implemented:
 5. **Synthetic Monitoring**: Blackbox Exporter and Gatus
 6. **Status Page**: Public status indicators
 
+#### ExternalSecrets: prefer direct key references over `find`
+
+**Decision (the right call): fetch secrets by explicit key, not by `dataFrom.find`, whenever the key name is known.**
+
+- `data[].remoteRef.key` issues a single `GetSecret` call per key — cheap and direct.
+- `dataFrom.find` issues a **recursive `ListSecrets`** over the store path (`/` for the `infisical` store) on *every* refresh. The Infisical provider services it as `CallListSecretsV3Raw`, which Infisical Cloud **rate-limits (HTTP 429)**.
+
+This matters because the find pattern is currently near-universal in this repo (audited: 153/153 ExternalSecrets used `find`, ~317 find blocks, ~304 of them recursive over the `infisical` root). When many refresh together (controller restart, mass reconcile, an outage recovery) they burst past the rate limit and storm `UpdateFailed`/429. Two concentrated cases (`*-postgres-init`, `github-token` × ~20 namespaces) caused real incidents and were fixed first; `kometa` (15 finds), `zigbee2mqtt`, and `zigbee2mqtt-garage` followed as the heaviest remaining hitters.
+
+**Guidance going forward:**
+- New ExternalSecrets with known keys → use `data[].remoteRef.key`. This is also the external-secrets Infisical provider's documented "preferred for specific secrets" approach.
+- Reserve `dataFrom.find` for genuine *discovery* (unknown-ahead-of-time keys, e.g. `^PREFIX.*`). ~27 ESs legitimately need it (e.g. `home-assistant` pulls `.*`); leave those as `find`.
+- Convert remaining anchored-exact `find`/`find.path` ESs opportunistically (or in a verified batch) rather than a single high-risk big-bang — secrets are app-critical and GitOps auto-ships mistakes. A blunt, near-zero-risk mitigation for the rest is widening `refreshInterval`.
+
 ## Component Relationships
 
 ### Kubernetes Namespace Organization


### PR DESCRIPTION
## What

Convert the highest-`find`-count ExternalSecrets to direct `data[].remoteRef.key` lookups, and document the decision as the repo standard.

- `media/kometa`: **15 finds → 15 direct refs**
- `home-automation/zigbee2mqtt`: **5 → 5**
- `home-automation/zigbee2mqtt-garage`: **5 → 5**
- `memory-bank/systemPatterns.md`: new "ExternalSecrets: prefer direct key references over `find`" decision section

## Why

Each `dataFrom.find` is serviced by the Infisical provider as a **recursive `ListSecrets`** over the store root — rate-limited by Infisical Cloud (HTTP 429). These three were the heaviest remaining per-cycle offenders after the `*-postgres-init` (#3421) and `github-token` (#3423) fixes. This removes ~25 recursive root-list calls per refresh.

All keys are known/anchored-exact, so the **rendered secrets are byte-identical** — same keys, same template references, just `GetSecret` instead of `ListSecrets`.

## The standard going forward (documented in systemPatterns.md)

Audit found this pattern is near-universal (153/153 ESs used `find`; ~317 find blocks). Rather than a high-risk big-bang refactor of all 153, the agreed approach is:
- **New/known-key ESs → `remoteRef.key`** (the documented Infisical-provider-preferred method).
- **Reserve `find` for genuine discovery** (~27 ESs legitimately need it, e.g. `home-assistant` pulls `.*`).
- **Convert the rest opportunistically**; widen `refreshInterval` as a blunt mitigation. Secrets are app-critical and GitOps auto-ships mistakes, so verified/incremental beats big-bang.

## Verification

YAML validated; `find` blocks = 0, `remoteRef` count = 15/5/5 (key parity preserved). Post-merge, expect `kometa`/`zigbee2mqtt`(+garage) to keep `SecretSynced: True` with no behavior change and fewer list calls.