### PR TITLE
revert: ExternalSecret direct-key refs (#3423, #3425) — keys live in Infisical subfolders

### DIFF
--- a/kubernetes/apps/home-automation/zigbee2mqtt-garage/app/externalsecret.yaml
+++ b/kubernetes/apps/home-automation/zigbee2mqtt-garage/app/externalsecret.yaml
@@ -18,11 +18,14 @@ spec:
         ZIGBEE2MQTT_CONFIG_ADVANCED_PAN_ID: "{{ .ZIGBEE_PAN_ID }} "
         ZIGBEE2MQTT_CONFIG_ADVANCED_EXT_PAN_ID: "{{ .ZIGBEE_EXT_PAN_ID }}"
         ZIGBEE2MQTT_CONFIG_ADVANCED_NETWORK_KEY: "{{ .ZIGBEE_NETWORK_KEY }}"
-  # Direct key references (one GetSecret each) instead of recursive ListSecrets
-  # finds — see memory-bank/systemPatterns.md (ExternalSecrets key references).
-  data:
-    - {secretKey: EMQX_MQTT_HOME_USERNAME, remoteRef: {key: EMQX_MQTT_HOME_USERNAME}}
-    - {secretKey: EMQX_MQTT_HOME_PASSWORD, remoteRef: {key: EMQX_MQTT_HOME_PASSWORD}}
-    - {secretKey: ZIGBEE_PAN_ID, remoteRef: {key: ZIGBEE_PAN_ID}}
-    - {secretKey: ZIGBEE_EXT_PAN_ID, remoteRef: {key: ZIGBEE_EXT_PAN_ID}}
-    - {secretKey: ZIGBEE_NETWORK_KEY, remoteRef: {key: ZIGBEE_NETWORK_KEY}}
+  dataFrom:
+    - find:
+        path: EMQX_MQTT_HOME_USERNAME
+    - find:
+        path: EMQX_MQTT_HOME_PASSWORD
+    - find:
+       path: ZIGBEE_PAN_ID
+    - find:
+        path: ZIGBEE_EXT_PAN_ID
+    - find:
+        path: ZIGBEE_NETWORK_KEY

--- a/kubernetes/apps/home-automation/zigbee2mqtt/app/externalsecret.yaml
+++ b/kubernetes/apps/home-automation/zigbee2mqtt/app/externalsecret.yaml
@@ -18,11 +18,14 @@ spec:
         ZIGBEE2MQTT_CONFIG_ADVANCED_PAN_ID: "{{ .ZIGBEE_PAN_ID }} "
         ZIGBEE2MQTT_CONFIG_ADVANCED_EXT_PAN_ID: "{{ .ZIGBEE_EXT_PAN_ID }}"
         ZIGBEE2MQTT_CONFIG_ADVANCED_NETWORK_KEY: "{{ .ZIGBEE_NETWORK_KEY }}"
-  # Direct key references (one GetSecret each) instead of recursive ListSecrets
-  # finds — see memory-bank/systemPatterns.md (ExternalSecrets key references).
-  data:
-    - {secretKey: EMQX_MQTT_HOME_USERNAME, remoteRef: {key: EMQX_MQTT_HOME_USERNAME}}
-    - {secretKey: EMQX_MQTT_HOME_PASSWORD, remoteRef: {key: EMQX_MQTT_HOME_PASSWORD}}
-    - {secretKey: ZIGBEE_PAN_ID, remoteRef: {key: ZIGBEE_PAN_ID}}
-    - {secretKey: ZIGBEE_EXT_PAN_ID, remoteRef: {key: ZIGBEE_EXT_PAN_ID}}
-    - {secretKey: ZIGBEE_NETWORK_KEY, remoteRef: {key: ZIGBEE_NETWORK_KEY}}
+  dataFrom:
+    - find:
+        path: EMQX_MQTT_HOME_USERNAME
+    - find:
+        path: EMQX_MQTT_HOME_PASSWORD
+    - find:
+       path: ZIGBEE_PAN_ID
+    - find:
+        path: ZIGBEE_EXT_PAN_ID
+    - find:
+        path: ZIGBEE_NETWORK_KEY

--- a/kubernetes/apps/media/kometa/app/externalsecret.yaml
+++ b/kubernetes/apps/media/kometa/app/externalsecret.yaml
@@ -31,22 +31,34 @@ spec:
         KOMETA_TRAKT_EXPIRES_IN: "{{ .TRAKT_EXPIRES_IN }}"
         KOMETA_TRAKT_REFRESH_TOKEN: "{{ .TRAKT_REFRESH_TOKEN }}"
 
-  # Direct key references (one GetSecret each) instead of 15 recursive
-  # ListSecrets calls per refresh. Keys are known, so this is the documented
-  # approach and removes this ES as the single largest Infisical 429 source.
-  data:
-    - {secretKey: TMDB_API_KEY, remoteRef: {key: TMDB_API_KEY}}
-    - {secretKey: OMDB_API_KEY, remoteRef: {key: OMDB_API_KEY}}
-    - {secretKey: MDBLIST_API_KEY, remoteRef: {key: MDBLIST_API_KEY}}
-    - {secretKey: PLEX_BACKUP_TOKEN, remoteRef: {key: PLEX_BACKUP_TOKEN}}
-    - {secretKey: RADARR_API_KEY, remoteRef: {key: RADARR_API_KEY}}
-    - {secretKey: RADARR_UHD_API_KEY, remoteRef: {key: RADARR_UHD_API_KEY}}
-    - {secretKey: SONARR_API_KEY, remoteRef: {key: SONARR_API_KEY}}
-    - {secretKey: SONARR_UHD_API_KEY, remoteRef: {key: SONARR_UHD_API_KEY}}
-    - {secretKey: TAUTULLI_API_KEY, remoteRef: {key: TAUTULLI_API_KEY}}
-    - {secretKey: TRAKT_CLIENT_ID, remoteRef: {key: TRAKT_CLIENT_ID}}
-    - {secretKey: TRAKT_CLIENT_SECRET, remoteRef: {key: TRAKT_CLIENT_SECRET}}
-    - {secretKey: TRAKT_ACCESS_TOKEN, remoteRef: {key: TRAKT_ACCESS_TOKEN}}
-    - {secretKey: TRAKT_CREATED_AT, remoteRef: {key: TRAKT_CREATED_AT}}
-    - {secretKey: TRAKT_EXPIRES_IN, remoteRef: {key: TRAKT_EXPIRES_IN}}
-    - {secretKey: TRAKT_REFRESH_TOKEN, remoteRef: {key: TRAKT_REFRESH_TOKEN}}
+  dataFrom:
+    - find:
+        path: TMDB_API_KEY
+    - find:
+        path: OMDB_API_KEY
+    - find:
+        path: MDBLIST_API_KEY
+    - find:
+        path: PLEX_BACKUP_TOKEN
+    - find:
+        path: RADARR_API_KEY
+    - find:
+        path: RADARR_UHD_API_KEY
+    - find:
+        path: SONARR_API_KEY
+    - find:
+        path: SONARR_UHD_API_KEY
+    - find:
+        path: TAUTULLI_API_KEY
+    - find:
+        path: TRAKT_CLIENT_ID
+    - find:
+        path: TRAKT_CLIENT_SECRET
+    - find:
+        path: TRAKT_ACCESS_TOKEN
+    - find:
+        path: TRAKT_CREATED_AT
+    - find:
+        path: TRAKT_EXPIRES_IN
+    - find:
+        path: TRAKT_REFRESH_TOKEN

--- a/kubernetes/flux/components/common/alerts/github/externalsecret.yaml
+++ b/kubernetes/flux/components/common/alerts/github/externalsecret.yaml
@@ -18,12 +18,6 @@ spec:
         # notification dispatch failed with "github token ... must be specified".
         token: "{{ .FLUX_GITHUB_TOKEN }}"
 
-  # Direct key reference (one GetSecret call) instead of dataFrom.find, which
-  # does a recursive ListSecrets over the store root (/) — ~20 copies of this ES
-  # (one per namespace, via the common component) hammering that list endpoint is
-  # a chronic source of Infisical 429s. The key is known, so a direct ref is the
-  # documented approach (external-secrets.io/latest/provider/infisical).
-  data:
-    - secretKey: FLUX_GITHUB_TOKEN
-      remoteRef:
-        key: FLUX_GITHUB_TOKEN
+  dataFrom:
+    - find:
+        path: FLUX_GITHUB_TOKEN

--- a/memory-bank/systemPatterns.md
+++ b/memory-bank/systemPatterns.md
@@ -80,20 +80,6 @@ A comprehensive monitoring stack is implemented:
 5. **Synthetic Monitoring**: Blackbox Exporter and Gatus
 6. **Status Page**: Public status indicators
 
-#### ExternalSecrets: prefer direct key references over `find`
-
-**Decision (the right call): fetch secrets by explicit key, not by `dataFrom.find`, whenever the key name is known.**
-
-- `data[].remoteRef.key` issues a single `GetSecret` call per key — cheap and direct.
-- `dataFrom.find` issues a **recursive `ListSecrets`** over the store path (`/` for the `infisical` store) on *every* refresh. The Infisical provider services it as `CallListSecretsV3Raw`, which Infisical Cloud **rate-limits (HTTP 429)**.
-
-This matters because the find pattern is currently near-universal in this repo (audited: 153/153 ExternalSecrets used `find`, ~317 find blocks, ~304 of them recursive over the `infisical` root). When many refresh together (controller restart, mass reconcile, an outage recovery) they burst past the rate limit and storm `UpdateFailed`/429. Two concentrated cases (`*-postgres-init`, `github-token` × ~20 namespaces) caused real incidents and were fixed first; `kometa` (15 finds), `zigbee2mqtt`, and `zigbee2mqtt-garage` followed as the heaviest remaining hitters.
-
-**Guidance going forward:**
-- New ExternalSecrets with known keys → use `data[].remoteRef.key`. This is also the external-secrets Infisical provider's documented "preferred for specific secrets" approach.
-- Reserve `dataFrom.find` for genuine *discovery* (unknown-ahead-of-time keys, e.g. `^PREFIX.*`). ~27 ESs legitimately need it (e.g. `home-assistant` pulls `.*`); leave those as `find`.
-- Convert remaining anchored-exact `find`/`find.path` ESs opportunistically (or in a verified batch) rather than a single high-risk big-bang — secrets are app-critical and GitOps auto-ships mistakes. A blunt, near-zero-risk mitigation for the rest is widening `refreshInterval`.
-
 ## Component Relationships
 
 ### Kubernetes Namespace Organization


### PR DESCRIPTION
## Why revert

PRs #3423 (github-token) and #3425 (kometa, zigbee2mqtt, zigbee2mqtt-garage) switched ExternalSecrets from `dataFrom.find` to direct `data[].remoteRef.key`. That broke them — `SecretSyncedError: Secret does not exist`.

**Root cause:** the secrets live in **Infisical subfolders**, and a direct `remoteRef.key` does a **non-recursive `GetSecret`** at the store path (`/`). `dataFrom.find` worked because it searches **recursively**. On this cluster, `find` is load-bearing for subfolder resolution, not just a style choice.

Apps stayed up the whole time (`deletionPolicy: Retain` kept the last-good secret values), but sync was dead.

This restores the original, working, readable multi-find form. #3421 (postgres-init) is unaffected — it stayed on `find`. #3422 (github token key name → `token`) is preserved.

## Follow-up

The efficiency win is still wanted, done correctly: convert to direct refs **with full subfolder paths** (`remoteRef.key: Folder/KEY`) once the Infisical folder layout is mapped. Tracked separately.