### PR TITLE
fix(externalsecrets): folder-scoped refs for github-token, kometa, zigbee2mqtt

### DIFF
--- a/kubernetes/apps/home-automation/zigbee2mqtt-garage/app/externalsecret.yaml
+++ b/kubernetes/apps/home-automation/zigbee2mqtt-garage/app/externalsecret.yaml
@@ -18,14 +18,8 @@ spec:
         ZIGBEE2MQTT_CONFIG_ADVANCED_PAN_ID: "{{ .ZIGBEE_PAN_ID }} "
         ZIGBEE2MQTT_CONFIG_ADVANCED_EXT_PAN_ID: "{{ .ZIGBEE_EXT_PAN_ID }}"
         ZIGBEE2MQTT_CONFIG_ADVANCED_NETWORK_KEY: "{{ .ZIGBEE_NETWORK_KEY }}"
+  # One folder-scoped recursive find (these keys live in /Infrastructure) instead
+  # of 5 separate root-level finds — one ListSecrets call against that folder.
   dataFrom:
     - find:
-        path: EMQX_MQTT_HOME_USERNAME
-    - find:
-        path: EMQX_MQTT_HOME_PASSWORD
-    - find:
-       path: ZIGBEE_PAN_ID
-    - find:
-        path: ZIGBEE_EXT_PAN_ID
-    - find:
-        path: ZIGBEE_NETWORK_KEY
+        path: /Infrastructure

--- a/kubernetes/apps/home-automation/zigbee2mqtt/app/externalsecret.yaml
+++ b/kubernetes/apps/home-automation/zigbee2mqtt/app/externalsecret.yaml
@@ -18,14 +18,8 @@ spec:
         ZIGBEE2MQTT_CONFIG_ADVANCED_PAN_ID: "{{ .ZIGBEE_PAN_ID }} "
         ZIGBEE2MQTT_CONFIG_ADVANCED_EXT_PAN_ID: "{{ .ZIGBEE_EXT_PAN_ID }}"
         ZIGBEE2MQTT_CONFIG_ADVANCED_NETWORK_KEY: "{{ .ZIGBEE_NETWORK_KEY }}"
+  # One folder-scoped recursive find (these keys live in /Infrastructure) instead
+  # of 5 separate root-level finds — one ListSecrets call against that folder.
   dataFrom:
     - find:
-        path: EMQX_MQTT_HOME_USERNAME
-    - find:
-        path: EMQX_MQTT_HOME_PASSWORD
-    - find:
-       path: ZIGBEE_PAN_ID
-    - find:
-        path: ZIGBEE_EXT_PAN_ID
-    - find:
-        path: ZIGBEE_NETWORK_KEY
+        path: /Infrastructure

--- a/kubernetes/apps/media/kometa/app/externalsecret.yaml
+++ b/kubernetes/apps/media/kometa/app/externalsecret.yaml
@@ -31,34 +31,9 @@ spec:
         KOMETA_TRAKT_EXPIRES_IN: "{{ .TRAKT_EXPIRES_IN }}"
         KOMETA_TRAKT_REFRESH_TOKEN: "{{ .TRAKT_REFRESH_TOKEN }}"
 
+  # One folder-scoped recursive find (all these keys live in /Downloads) instead
+  # of 15 separate root-level finds — one ListSecrets call against a small folder.
+  # The template above selects the keys it needs.
   dataFrom:
     - find:
-        path: TMDB_API_KEY
-    - find:
-        path: OMDB_API_KEY
-    - find:
-        path: MDBLIST_API_KEY
-    - find:
-        path: PLEX_BACKUP_TOKEN
-    - find:
-        path: RADARR_API_KEY
-    - find:
-        path: RADARR_UHD_API_KEY
-    - find:
-        path: SONARR_API_KEY
-    - find:
-        path: SONARR_UHD_API_KEY
-    - find:
-        path: TAUTULLI_API_KEY
-    - find:
-        path: TRAKT_CLIENT_ID
-    - find:
-        path: TRAKT_CLIENT_SECRET
-    - find:
-        path: TRAKT_ACCESS_TOKEN
-    - find:
-        path: TRAKT_CREATED_AT
-    - find:
-        path: TRAKT_EXPIRES_IN
-    - find:
-        path: TRAKT_REFRESH_TOKEN
+        path: /Downloads

--- a/kubernetes/flux/components/common/alerts/github/externalsecret.yaml
+++ b/kubernetes/flux/components/common/alerts/github/externalsecret.yaml
@@ -18,6 +18,10 @@ spec:
         # notification dispatch failed with "github token ... must be specified".
         token: "{{ .FLUX_GITHUB_TOKEN }}"
 
-  dataFrom:
-    - find:
-        path: FLUX_GITHUB_TOKEN
+  # Direct key reference (one GetSecret, no recursive list) — the key lives at
+  # /External_Services in Infisical, so the path must be qualified. This ES is a
+  # common component in ~20 namespaces, so the cheap GetSecret matters.
+  data:
+    - secretKey: FLUX_GITHUB_TOKEN
+      remoteRef:
+        key: /External_Services/FLUX_GITHUB_TOKEN

--- a/memory-bank/systemPatterns.md
+++ b/memory-bank/systemPatterns.md
@@ -80,6 +80,17 @@ A comprehensive monitoring stack is implemented:
 5. **Synthetic Monitoring**: Blackbox Exporter and Gatus
 6. **Status Page**: Public status indicators
 
+#### ExternalSecrets: fetch by folder-scoped path, not root-recursive `find`
+
+Secrets in Infisical are organised into **folders** (e.g. `/Downloads`, `/Infrastructure`, `/External_Services`, `/Infrastructure/Postgres/<app>`). The `infisical` ClusterSecretStore is rooted at `/` with `recursive: true`. How an ExternalSecret references keys has a large effect on Infisical Cloud's rate limit (it 429s on `ListSecrets`/`CallListSecretsV3Raw`):
+
+- ❌ **Root-recursive `find`** (`dataFrom.find` with the store at `/`) lists **all ~230 secrets** every refresh. Multiple `find` blocks = multiple full-tree lists. This is the historical default and the main 429 source.
+- ❌ **Bare-key direct ref** (`remoteRef.key: KEY`) **does not work** — `GetSecret` is non-recursive at the store path (`/`), so a key in a subfolder returns `Secret does not exist`. (This broke a batch of ESs once; reverted.)
+- ✅ **Single known key → direct ref with the full path:** `remoteRef.key: /External_Services/FLUX_GITHUB_TOKEN` — one cheap `GetSecret`, no list.
+- ✅ **Several keys in one folder → one folder-scoped find:** `dataFrom: [{ find: { path: /Downloads } }]` — one `ListSecrets` of a small folder, and the `template` selects the keys it needs.
+
+**Rule of thumb:** never leave a `find` rooted at `/`. Use a path-qualified `remoteRef.key` for single keys, or scope a single `find` to the keys' folder for groups. To discover where a key lives, list secrets recursively via the Infisical API (universal-auth creds in `external-secrets/infiscal-auth-secret`) — each secret reports its `secretPath`. Audited state: 153 ESs, ~317 finds, ~304 rooted at `/`; convert opportunistically (postgres-init, github-token, kometa, zigbee2mqtt done) rather than a risky big-bang.
+
 ## Component Relationships
 
 ### Kubernetes Namespace Organization


### PR DESCRIPTION
## What

Redo the `find`→efficient conversion **correctly**, using the now-known Infisical folder layout. (Supersedes the reverted #3423/#3425, which used bare `remoteRef.key` and broke because the keys live in subfolders.)

| ES | Before | After | Folder |
|---|---|---|---|
| `github-token` (×~20 ns) | `find.path: FLUX_GITHUB_TOKEN` | `remoteRef.key: /External_Services/FLUX_GITHUB_TOKEN` (direct GET) | `/External_Services` |
| `kometa` | 15 root finds | `find.path: /Downloads` | `/Downloads` |
| `zigbee2mqtt` | 5 root finds | `find.path: /Infrastructure` | `/Infrastructure` |
| `zigbee2mqtt-garage` | 5 root finds | `find.path: /Infrastructure` | `/Infrastructure` |

## Why this is the clean form

The `infisical` store is rooted at `/` (recursive). Keys live in **subfolders** (discovered via the Infisical API). So:
- bare `remoteRef.key: KEY` → `Secret does not exist` (non-recursive GET at `/`) ❌ — this is what broke #3423/#3425
- root `find` → lists all ~230 secrets every refresh ❌ (the 429 source)
- **path-qualified `remoteRef.key`** (single key) or **folder-scoped `find.path`** (groups) ✅ — cheap and correct

Both forms were **verified live** (`SecretSynced`, identical rendered secret keys) before committing this time.

## Docs

`memory-bank/systemPatterns.md` updated with the accurate guidance + the bare-key pitfall, and how to discover a key's folder (Infisical API, `secretPath`).