### PR TITLE
chore(tuppr): trigger Talos 1.13.3→1.13.5 upgrade now (grow disks after Proxmox resize)

### DIFF
--- a/kubernetes/apps/system-upgrade/tuppr/plans/talos-upgrade.yaml
+++ b/kubernetes/apps/system-upgrade/tuppr/plans/talos-upgrade.yaml
@@ -18,8 +18,11 @@ spec:
       kind: Node
       expr: status.conditions.exists(c, c.type == "Ready" && c.status == "True")
 
-  maintenance:
-    windows:
-      - start: "0 2 * * 0"  # Sunday 2:00 AM
-        duration: "6h"
-        timezone: "America/Chicago"
+  # TEMPORARY: maintenance window removed to run the v1.13.3 -> v1.13.5 upgrade
+  # immediately (grows EPHEMERAL after the Proxmox disk resize). RESTORE this
+  # block once the rolling upgrade completes on all nodes.
+  # maintenance:
+  #   windows:
+  #     - start: "0 2 * * 0"  # Sunday 2:00 AM
+  #       duration: "6h"
+  #       timezone: "America/Chicago"


### PR DESCRIPTION
## What
Temporarily comment out the `maintenance.windows` block in the tuppr `TalosUpgrade/cluster` plan so the pending **v1.13.3 → v1.13.5** upgrade runs immediately instead of waiting for the Sunday 02:00 window.

## Why
The Proxmox VM disks were just resized. A Talos upgrade with `rebootMode: powercycle` makes Talos repartition on boot and **grow the EPHEMERAL partition** to fill the new space — there is no online/no-reboot path for OS-disk growth on Talos. The cluster is already one minor behind (talconfig targets v1.13.5), so this is a real, intended version bump, not a same-version trick.

Bonus: the powercycle of `talos-node-gpu-1` clears a wedged GPU CUDA context / zombie pod from earlier testing.

## How it works
- tuppr is deployed and healthy; `TalosUpgrade/cluster` is in `MaintenanceWindow` phase purely because of the window gate.
- Removing the window → tuppr proceeds on next reconcile, rolling one node at a time, waiting for `Node Ready` between each (`policy.timeout: 30m`).

## Operator notes
- **Recommended before merge:** reset the `talos-node-gpu-1` VM in Proxmox first to clear the wedged container, so its drain is clean.
- **After the rolling upgrade finishes on all nodes: revert this commit** to restore the Sunday 02:00 maintenance window.

## Verify
```bash
flux reconcile kustomization tuppr-plans -n flux-system
kubectl get talosupgrade cluster -o wide      # PHASE should leave MaintenanceWindow -> Upgrading
kubectl get nodes -o wide                     # watch versions roll to v1.13.5
```