### PR TITLE
chore(tuppr): restore Sunday 02:00 maintenance window

### DIFF
--- a/kubernetes/apps/system-upgrade/tuppr/plans/talos-upgrade.yaml
+++ b/kubernetes/apps/system-upgrade/tuppr/plans/talos-upgrade.yaml
@@ -18,11 +18,8 @@ spec:
       kind: Node
       expr: status.conditions.exists(c, c.type == "Ready" && c.status == "True")
 
-  # TEMPORARY: maintenance window removed to run the v1.13.3 -> v1.13.5 upgrade
-  # immediately (grows EPHEMERAL after the Proxmox disk resize). RESTORE this
-  # block once the rolling upgrade completes on all nodes.
-  # maintenance:
-  #   windows:
-  #     - start: "0 2 * * 0"  # Sunday 2:00 AM
-  #       duration: "6h"
-  #       timezone: "America/Chicago"
+  maintenance:
+    windows:
+      - start: "0 2 * * 0"  # Sunday 2:00 AM
+        duration: "6h"
+        timezone: "America/Chicago"


### PR DESCRIPTION
## What
Re-add the `maintenance.windows` block to the tuppr `TalosUpgrade/cluster` plan, reverting the temporary removal in #3429.

## Why
The **v1.13.3 → v1.13.5** upgrade is complete — all 11 nodes are on v1.13.5 (`TalosUpgrade: Completed`), and EPHEMERAL grew on the resized worker disks (~48 → ~98 GiB). Future Talos upgrades should once again be gated to the **Sunday 02:00 America/Chicago** window instead of running immediately.

## Note
Safe to merge anytime — nodes are already at the target version, so restoring the window has no effect on the current (completed) upgrade.