### PR TITLE
feat(ollama): raise HTTPRoute timeout to 300s for LLM generation

### DIFF
--- a/kubernetes/apps/ai/ollama/app/helmrelease.yaml
+++ b/kubernetes/apps/ai/ollama/app/helmrelease.yaml
@@ -152,6 +152,20 @@ spec:
         parentRefs:
           - name: internal
             namespace: network
+        # LLM generation can run far longer than Envoy's ~15s default route
+        # timeout (cold model load + tokens on the time-sliced P100), which
+        # otherwise returns "upstream request timeout" mid-generation.
+        rules:
+          - matches:
+              - path:
+                  type: PathPrefix
+                  value: /
+            backendRefs:
+              - identifier: app
+                port: http
+            timeouts:
+              request: 300s
+              backendRequest: 300s
 
     persistence:
       models:


### PR DESCRIPTION
## Problem
LLM generation over `ollama.chelonianlabs.com` fails — clients get HTTP 500 at **~15.0s** (observed live: `500 | 14.997s | POST /api/chat`). Cause: the route had no timeout, so Envoy's **default ~15s** route timeout aborts the request mid-generation. A cold model load + tokens on the time-sliced P100 takes ~78s, well over 15s. `/api/tags` (instant) worked, which masked it.

## Fix
Add an explicit `route.app.rules` entry with `timeouts.request` and `timeouts.backendRequest` = **300s**, mirroring the previously auto-generated rule (PathPrefix `/` → service `app:http`).

## Safety
Fail-safe: if the chart render were invalid, the HelmRelease upgrade fails and Flux retains the current working route (no outage). The route's backendRef/match are unchanged aside from the added timeouts.

## Verify after merge
```bash
flux reconcile kustomization ollama -n flux-system   # or: -n <ns>
kubectl get httproute ollama -n ai -o jsonpath='{.spec.rules[0].timeouts}'
# then a real generation over the domain should complete instead of 500@15s
```