### PR TITLE
feat(network): scrape Envoy Gateway proxy metrics via PodMonitor

### DIFF
--- a/kubernetes/apps/network/envoy-gateway/gateway/kustomization.yaml
+++ b/kubernetes/apps/network/envoy-gateway/gateway/kustomization.yaml
@@ -9,3 +9,4 @@ resources:
   - ./gateway-external.yaml
   - ./httproutes-redirect.yaml
   - ./clienttrafficpolicy.yaml
+  - ./podmonitor.yaml

--- a/kubernetes/apps/network/envoy-gateway/gateway/podmonitor.yaml
+++ b/kubernetes/apps/network/envoy-gateway/gateway/podmonitor.yaml
@@ -1,0 +1,17 @@
+---
+apiVersion: monitoring.coreos.com/v1
+kind: PodMonitor
+metadata:
+  name: envoy-proxy
+spec:
+  # Both managed proxies (external + internal). Envoy already serves the
+  # /stats/prometheus endpoint on the "metrics" port (19001) by default;
+  # this just scrapes it. Per-route byte counters land as
+  # envoy_cluster_upstream_cx_{rx,tx}_bytes_total{envoy_cluster_name="httproute/<ns>/<app>/rule/0"}.
+  selector:
+    matchLabels:
+      app.kubernetes.io/managed-by: envoy-gateway
+      app.kubernetes.io/component: proxy
+  podMetricsEndpoints:
+    - port: metrics
+      path: /stats/prometheus


### PR DESCRIPTION
## What
Adds a `PodMonitor` for the managed Envoy proxies (external + internal) so Prometheus scrapes the **already-exposed** `/stats/prometheus` endpoint on the `metrics` port (19001).

## Why
Gives us per-route byte counters in Prometheus/Grafana — e.g.:

```
envoy_cluster_upstream_cx_rx_bytes_total{envoy_cluster_name="httproute/media/plex/rule/0"}
```

This is the groundwork for measuring/validating media egress (Plex today, and the upcoming move of media off the Cloudflare tunnel onto a dedicated direct gateway). `rate(...[5m])` gives live throughput; the counter gives cumulative volume.

## Notes
- **No `EnvoyProxy` change** — the metrics port/endpoint are exposed by default; this only scrapes them.
- Prometheus here scrapes all PodMonitors (`podMonitorSelectorNilUsesHelmValues: false`), so no extra labels needed.
- Purely additive; validated with `kubectl kustomize` build + server-side dry-run.