### PR TITLE
fix(skills): correct stale nginx reference in debug-k8s

### DIFF
--- a/.claude/skills/debug-k8s/SKILL.md
+++ b/.claude/skills/debug-k8s/SKILL.md
@@ -90,7 +90,7 @@ Check the app's manifests for misconfigurations:
 - **OS**: Talos Linux (immutable, no SSH - use `talosctl` for node-level debugging)
 - **CNI**: Cilium with L2 announcements
 - **Storage**: Rook-Ceph (ceph-rbd for RWO, cephfs for RWX), VolSync for backups
-- **Ingress**: NGINX (internal class), Envoy Gateway
+- **Routing**: Envoy Gateway (internal `10.100.0.20` / external `10.100.0.22`) via HTTPRoutes; nginx is gone. See the `gateway-route` skill.
 - **Databases**: CloudNative-PG (postgres), Dragonfly (redis)
 - **Secrets**: External Secrets Operator with Infisical backend
 

--- a/kubernetes/apps/network/envoy-gateway/gateway/kustomization.yaml
+++ b/kubernetes/apps/network/envoy-gateway/gateway/kustomization.yaml
@@ -9,3 +9,4 @@ resources:
   - ./gateway-external.yaml
   - ./httproutes-redirect.yaml
   - ./clienttrafficpolicy.yaml
+  - ./podmonitor.yaml

--- a/kubernetes/apps/network/envoy-gateway/gateway/podmonitor.yaml
+++ b/kubernetes/apps/network/envoy-gateway/gateway/podmonitor.yaml
@@ -1,0 +1,17 @@
+---
+apiVersion: monitoring.coreos.com/v1
+kind: PodMonitor
+metadata:
+  name: envoy-proxy
+spec:
+  # Both managed proxies (external + internal). Envoy already serves the
+  # /stats/prometheus endpoint on the "metrics" port (19001) by default;
+  # this just scrapes it. Per-route byte counters land as
+  # envoy_cluster_upstream_cx_{rx,tx}_bytes_total{envoy_cluster_name="httproute/<ns>/<app>/rule/0"}.
+  selector:
+    matchLabels:
+      app.kubernetes.io/managed-by: envoy-gateway
+      app.kubernetes.io/component: proxy
+  podMetricsEndpoints:
+    - port: metrics
+      path: /stats/prometheus


### PR DESCRIPTION
One-line accuracy fix. `debug-k8s`'s Cluster Context still listed `Ingress: NGINX (internal class), Envoy Gateway`, but nginx was fully decommissioned in the Envoy Gateway migration. Updated to reflect Envoy Gateway + HTTPRoutes (internal `.20` / external `.22`) and cross-link the `gateway-route` skill.