### PR TITLE
fix(network): run media Envoy as a DaemonSet for ETP=Local

### DIFF
--- a/kubernetes/apps/network/envoy-gateway/gateway/gateway-media.yaml
+++ b/kubernetes/apps/network/envoy-gateway/gateway/gateway-media.yaml
@@ -1,10 +1,11 @@
 ---
 # Dedicated EnvoyProxy for the media Gateway. Unlike the class-wide proxy
 # (externalTrafficPolicy: Cluster, which SNATs and hides the client IP), this
-# one uses Local so the real remote client IP survives to Envoy's access logs —
-# required for per-IP rate-limiting and CrowdSec accuracy on the WAN-facing
-# media surface. A gateway-scoped parametersRef fully REPLACES the class-wide
-# config for this gateway, so it must restate the Kubernetes provider.
+# one uses Local so the real remote client IP survives all the way to Plex
+# (Envoy forwards it via X-Forwarded-For) — so Tautulli logs real remote
+# viewer IPs, and a future Envoy rate-limit/CrowdSec policy can see per-IP.
+# A gateway-scoped parametersRef fully REPLACES the class-wide config for this
+# gateway, so it must restate the Kubernetes provider.
 apiVersion: gateway.envoyproxy.io/v1alpha1
 kind: EnvoyProxy
 metadata:
@@ -14,10 +15,28 @@ spec:
   provider:
     type: Kubernetes
     kubernetes:
+      # Run Envoy as a DaemonSet (one pod per node) instead of the default
+      # single Deployment. externalTrafficPolicy: Local only forwards to a
+      # node-LOCAL backend, and Cilium L2 can announce the VIP from ANY node
+      # (the l2-policy selects all nodes, with no endpoint-awareness). A pod on
+      # every node guarantees the announcer always has a local backend — no
+      # blackhole. The control-plane toleration is required because the L2
+      # announcer can be a control-plane node (the internal gw already is), and
+      # those carry a NoSchedule taint a default DaemonSet would skip.
+      envoyDaemonSet:
+        patch:
+          type: StrategicMerge
+          value:
+            spec:
+              template:
+                spec:
+                  tolerations:
+                    - key: node-role.kubernetes.io/control-plane
+                      operator: Exists
+                      effect: NoSchedule
       envoyService:
-        # Required for Cilium L2 announcements (matches the class-wide proxy).
-        # Local preserves the source IP; Cilium announces the VIP from a node
-        # running a ready envoy-media pod.
+        # Preserve the real client source IP (no SNAT). Paired with the
+        # DaemonSet above so every potential L2 announcer has a local backend.
         patch:
           type: StrategicMerge
           value:


### PR DESCRIPTION
## Why

Follow-up to #3446. The media Gateway uses `externalTrafficPolicy: Local` to preserve the real client IP (so Tautulli logs real remote viewer IPs, and a future Envoy rate-limit can see per-IP). But verification showed `Local` blackholes WAN traffic as built:

- Cilium L2 announced the media VIP from `talos-node-gpu-1`, while the only Envoy-media pod was on `talos-node-large-1`.
- `cilium-dbg service list` proof: on the announcer node the external LB frontend `10.100.0.31:443` had **zero backends** (Local only forwards to a node-local pod).
- The cluster `l2-policy` selects **all** nodes and is endpoint-unaware, so the announcer is essentially random.

## Fix

Switch the media `EnvoyProxy` from the default single Deployment to a **DaemonSet** (one Envoy per node) so the L2 announcer always has a local backend. Add a `node-role.kubernetes.io/control-plane` toleration because the announcer can be a control-plane node (the `internal` gw already announces from `talos-control-3`), which carries a NoSchedule taint a default DaemonSet would skip.

`external`/`internal` gateways are unaffected (they use `Cluster` and don't need this).

## Verify post-merge
- An `envoy-network-media` pod Running on every node (incl. all 3 control planes).
- On the L2 announcer node, `cilium-dbg service list | grep 10.100.0.31` shows a backend for the external frontend.