### PR TITLE
feat(media): cut Plex over to the media gateway (direct WAN, off tunnel)

### DIFF
--- a/kubernetes/apps/media/plex/app/helmrelease.yaml
+++ b/kubernetes/apps/media/plex/app/helmrelease.yaml
@@ -125,13 +125,15 @@ spec:
             protocol: UDP
     route:
       app:
+        # Plex streams direct over the WAN via the dedicated media gateway, NOT
+        # the Cloudflare tunnel. external-dns derives the record target from the
+        # media Gateway (grey-cloud ipv4 -> WAN), so no route-level target here.
         annotations:
-          external-dns.alpha.kubernetes.io/target: "external.${SECRET_DOMAIN_MEDIA}"
           gatus.home-operations.com/endpoint: |-
             path: /web/index.html
         hostnames: ["{{ .Release.Name }}.${SECRET_DOMAIN_MEDIA}"]
         parentRefs:
-          - name: external
+          - name: media
             namespace: network
     persistence:
       config:


### PR DESCRIPTION
## Phase 2 cutover

Flips the Plex HTTPRoute from the `external` gateway (Cloudflare tunnel) to the dedicated `media` gateway (direct WAN, `10.100.0.31`).

- `parentRefs`: `external/network` → `media/network`
- Drop route-level `external-dns target` (`external.${SECRET_DOMAIN_MEDIA}`) — the media Gateway's gateway-level target (grey-cloud `ipv4` → WAN, `cloudflare-proxied=false`) now drives the record.
- Keep the gatus probe annotation.

### Already in place
- OPNsense WAN TCP 443 → `10.100.0.31:443` port-forward + associated pass rule (live, health green).
- Plex prefs managed in-repo: advertise URL `https://plex.turtleassmedia.com:443`, `PLEX_LAN_NETWORKS` includes pod CIDR `10.69.0.0/16` (so Plex trusts Envoy's `X-Forwarded-For` → Tautulli logs real remote IPs), `SecureConnections=preferred`, `RelayEnabled=0`.

### Verify post-merge
- `dig +short plex.turtleassmedia.com` → `108.250.25.36` (grey/direct, not 104.x/172.x).
- Plex HTTPRoute attaches to `media` gateway; remote stream plays; bytes climb on the media gw; tunnel idle for Plex.

Rollback: revert this commit (route back to `external/network`) → external-dns re-proxies via tunnel within a reconcile.