### PR TITLE
fix(media): force plex DNS grey (cloudflare-proxied=false)

### DIFF
--- a/kubernetes/apps/media/plex/app/helmrelease.yaml
+++ b/kubernetes/apps/media/plex/app/helmrelease.yaml
@@ -126,9 +126,14 @@ spec:
     route:
       app:
         # Plex streams direct over the WAN via the dedicated media gateway, NOT
-        # the Cloudflare tunnel. external-dns derives the record target from the
+        # the Cloudflare tunnel. external-dns inherits the record target from the
         # media Gateway (grey-cloud ipv4 -> WAN), so no route-level target here.
+        # But the Gateway-level cloudflare-proxied=false is NOT inherited onto
+        # route records (external-dns falls back to the global --cloudflare-proxied
+        # default), so set it per-route: plex must be grey/DNS-only to bypass the
+        # Cloudflare proxy and reach the WAN directly.
         annotations:
+          external-dns.alpha.kubernetes.io/cloudflare-proxied: "false"
           gatus.home-operations.com/endpoint: |-
             path: /web/index.html
         hostnames: ["{{ .Release.Name }}.${SECRET_DOMAIN_MEDIA}"]


### PR DESCRIPTION
Follow-up to #3451. The Plex CNAME was created proxied (orange) because external-dns inherits the media Gateway's `target` annotation but not its `cloudflare-proxied: false`. Set it per-route so plex resolves grey/DNS-only → ipv4 (DDNS→WAN) → media gateway, bypassing the Cloudflare proxy.

Verify: Cloudflare `plex` CNAME `proxied=false`; `dig +short plex.turtleassmedia.com` = 108.250.25.36.