### PR TITLE
fix(media): move Plex off P100 GPU to CPU transcoding

### DIFF
--- a/kubernetes/apps/media/plex/app/configmap.yaml
+++ b/kubernetes/apps/media/plex/app/configmap.yaml
@@ -29,77 +29,79 @@ data:
   PLEX_PREFERENCE_2: "ButlerEndHour=11"
 
   # Database Tasks
-  PLEX_PREFERENCE_3: "ButlerTaskBackupDatabase=1"  # Backup every 3 days
-  PLEX_PREFERENCE_4: "ButlerTaskOptimizeDatabase=0"  # Disabled - ImageMaid optimizes daily at 11:30
+  PLEX_PREFERENCE_3: "ButlerTaskBackupDatabase=1" # Backup every 3 days
+  PLEX_PREFERENCE_4: "ButlerTaskOptimizeDatabase=0" # Disabled - ImageMaid optimizes daily at 11:30
   PLEX_PREFERENCE_5: "ButlerDatabaseBackupPath=/config/Library/Application Support/Plex Media Server/Plug-in Support/Databases/Backups"
 
   # Cache & Bundle Cleanup
-  PLEX_PREFERENCE_6: "ButlerTaskCleanOldBundles=0"  # Disabled - ImageMaid cleans bundles daily at 11:30
-  PLEX_PREFERENCE_7: "ButlerTaskCleanOldCacheFiles=1"  # Clean cache weekly (general cache, not PhotoTranscoder)
+  PLEX_PREFERENCE_6: "ButlerTaskCleanOldBundles=0" # Disabled - ImageMaid cleans bundles daily at 11:30
+  PLEX_PREFERENCE_7: "ButlerTaskCleanOldCacheFiles=1" # Clean cache weekly (general cache, not PhotoTranscoder)
 
   # Media Analysis (disable deep analysis to reduce load)
-  PLEX_PREFERENCE_8: "ButlerTaskDeepMediaAnalysis=0"  # Disabled - resource intensive
-  PLEX_PREFERENCE_9: "ButlerTaskUpgradeMediaAnalysis=0"  # Disabled - let Plex handle automatically
+  PLEX_PREFERENCE_8: "ButlerTaskDeepMediaAnalysis=0" # Disabled - resource intensive
+  PLEX_PREFERENCE_9: "ButlerTaskUpgradeMediaAnalysis=0" # Disabled - let Plex handle automatically
 
   # Library Refresh (disabled - Kometa already triggers refreshes)
-  PLEX_PREFERENCE_10: "ButlerTaskRefreshLocalMedia=0"  # Disabled - Kometa handles this
-  PLEX_PREFERENCE_11: "ButlerTaskRefreshLibraries=0"  # Disabled - use manual/Kometa scans
-  PLEX_PREFERENCE_12: "ButlerTaskRefreshPeriodicMetadata=0"  # Disabled
+  PLEX_PREFERENCE_10: "ButlerTaskRefreshLocalMedia=0" # Disabled - Kometa handles this
+  PLEX_PREFERENCE_11: "ButlerTaskRefreshLibraries=0" # Disabled - use manual/Kometa scans
+  PLEX_PREFERENCE_12: "ButlerTaskRefreshPeriodicMetadata=0" # Disabled
 
   # Additional Butler Tasks
-  PLEX_PREFERENCE_13: "ButlerTaskRefreshEpgGuides=0"  # Disabled - no live TV/DVR
-  PLEX_PREFERENCE_14: "ButlerTaskGenerateMediaIndexFiles=1"  # Enable - helps with search performance
+  PLEX_PREFERENCE_13: "ButlerTaskRefreshEpgGuides=0" # Disabled - no live TV/DVR
+  PLEX_PREFERENCE_14: "ButlerTaskGenerateMediaIndexFiles=1" # Enable - helps with search performance
 
   # Automatic Library Scanning (for network mounts where inotify doesn't work)
-  PLEX_PREFERENCE_15: "ScheduledLibraryUpdatesEnabled=1"  # Enable periodic library scans
-  PLEX_PREFERENCE_16: "ScheduledLibraryUpdateInterval=3600"  # Scan every hour (3600 seconds)
-  PLEX_PREFERENCE_17: "FSEventLibraryUpdatesEnabled=1"  # Enable auto-updates (may not work on NFS/CephFS)
-  PLEX_PREFERENCE_18: "FSEventLibraryPartialScanEnabled=1"  # Only scan changed folders
+  PLEX_PREFERENCE_15: "ScheduledLibraryUpdatesEnabled=1" # Enable periodic library scans
+  PLEX_PREFERENCE_16: "ScheduledLibraryUpdateInterval=3600" # Scan every hour (3600 seconds)
+  PLEX_PREFERENCE_17: "FSEventLibraryUpdatesEnabled=1" # Enable auto-updates (may not work on NFS/CephFS)
+  PLEX_PREFERENCE_18: "FSEventLibraryPartialScanEnabled=1" # Only scan changed folders
 
   # Network & Remote Access
   # EnableIPv6 removed - already persisted in Preferences.xml; env var caused duplicate XML attribute
-  PLEX_PREFERENCE_20: "GdmEnabled=1"  # Enable local network discovery (GDM)
+  PLEX_PREFERENCE_20: "GdmEnabled=1" # Enable local network discovery (GDM)
 
   # DLNA (if you use it for other devices)
-  PLEX_PREFERENCE_21: "DlnaEnabled=1"  # Enable DLNA server
+  PLEX_PREFERENCE_21: "DlnaEnabled=1" # Enable DLNA server
 
   # Transcoding
-  PLEX_PREFERENCE_22: "TranscoderTempDirectory=/transcode"  # Use memory-backed transcode directory
-  PLEX_PREFERENCE_23: "TranscoderThrottleBuffer=120"  # Buffer 120s before throttling (default: 300s)
+  PLEX_PREFERENCE_22: "TranscoderTempDirectory=/transcode" # Use memory-backed transcode directory
+  PLEX_PREFERENCE_23: "TranscoderThrottleBuffer=120" # Buffer 120s before throttling (default: 300s)
 
   # Bandwidth Settings (unlimited - 2.5Gbps uplink)
-  PLEX_PREFERENCE_24: "WanTotalMaxUploadRate=0"  # Unlimited total upload bandwidth (0 = unlimited)
+  PLEX_PREFERENCE_24: "WanTotalMaxUploadRate=0" # Unlimited total upload bandwidth (0 = unlimited)
 
   # Background Transcoding Quality (for sync/downloads)
   # Options: ultrafast, superfast, veryfast, faster, fast, medium, slow, slower, veryslow
-  PLEX_PREFERENCE_25: "TranscoderH264BackgroundPreset=medium"  # Medium preset (balanced quality/speed)
+  PLEX_PREFERENCE_25: "TranscoderH264BackgroundPreset=medium" # Medium preset (balanced quality/speed)
 
-  # Hardware Transcoding & Quality
-  # Leveraging 2 NVIDIA GPU slices (8GB VRAM) for maximum quality transcoding
-  PLEX_PREFERENCE_26: "HardwareAcceleratedCodecs=1"  # Enable NVIDIA GPU hardware acceleration
-  PLEX_PREFERENCE_27: "TranscoderQuality=3"  # Maximum quality (0=auto, 1=speed, 2=quality, 3=max)
-  PLEX_PREFERENCE_28: "TranscodeCountLimit=10"  # Allow 10 simultaneous transcode streams
-  PLEX_PREFERENCE_29: "TranscoderToneMapping=1"  # Enable HDR to SDR tone mapping
-  PLEX_PREFERENCE_30: "HardwareAcceleratedEncoders=1"  # Explicitly enable GPU encoders
+  # Transcoding & Quality (SOFTWARE only)
+  # The P100 (GP100) has no NVENC encoder, so Plex runs on CPU-only large nodes.
+  # Hardware acceleration is DISABLED — leaving it on makes Plex try a nonexistent
+  # GPU device and stall the transcode decision.
+  PLEX_PREFERENCE_26: "HardwareAcceleratedCodecs=0" # No usable GPU; software decode
+  PLEX_PREFERENCE_27: "TranscoderQuality=0" # Auto (let Plex balance for CPU realtime)
+  PLEX_PREFERENCE_28: "TranscodeCountLimit=4" # Cap concurrent CPU transcodes (16-core node)
+  PLEX_PREFERENCE_29: "TranscoderToneMapping=0" # HDR tone-mapping is too costly on CPU
+  PLEX_PREFERENCE_30: "HardwareAcceleratedEncoders=0" # No NVENC on P100; software encode
 
   # Content Detection Features
   # Run ASAP with available CPU/GPU resources for best UX
-  PLEX_PREFERENCE_31: "GenerateIntroMarkerBehavior=asap"  # Detect intros immediately when media added
-  PLEX_PREFERENCE_32: "GenerateCreditsMarkerBehavior=asap"  # Generate credits markers immediately
-  PLEX_PREFERENCE_33: "GenerateCommercialMarkerBehavior=never"  # Disable - no commercials in personal media
-  PLEX_PREFERENCE_34: "MarkerSource=any"  # Use both online and local detection (try online first)
-  PLEX_PREFERENCE_35: "GenerateChapterThumbBehavior=asap"  # Generate chapter thumbnails immediately
+  PLEX_PREFERENCE_31: "GenerateIntroMarkerBehavior=asap" # Detect intros immediately when media added
+  PLEX_PREFERENCE_32: "GenerateCreditsMarkerBehavior=asap" # Generate credits markers immediately
+  PLEX_PREFERENCE_33: "GenerateCommercialMarkerBehavior=never" # Disable - no commercials in personal media
+  PLEX_PREFERENCE_34: "MarkerSource=any" # Use both online and local detection (try online first)
+  PLEX_PREFERENCE_35: "GenerateChapterThumbBehavior=asap" # Generate chapter thumbnails immediately
 
   # Performance Optimization
   # Tuned for large libraries with 32GB RAM available
-  PLEX_PREFERENCE_36: "DatabaseCacheSize=2048"  # 2GB database cache (recommended for 15k+ items)
-  PLEX_PREFERENCE_37: "LongRunningJobThreads=4"  # Parallel threads for Sonic/intro/credits analysis
+  PLEX_PREFERENCE_36: "DatabaseCacheSize=2048" # 2GB database cache (recommended for 15k+ items)
+  PLEX_PREFERENCE_37: "LongRunningJobThreads=4" # Parallel threads for Sonic/intro/credits analysis
 
   # Network & Security
-  PLEX_PREFERENCE_38: "SecureConnections=preferred"  # Prefer HTTPS, allow HTTP fallback
-  PLEX_PREFERENCE_39: "RelayEnabled=0"  # Disable Plex Relay (2 Mbps limitation)
-  PLEX_PREFERENCE_40: "TreatWanIpAsLocal=1"  # Improve performance with internal DNS routing
+  PLEX_PREFERENCE_38: "SecureConnections=preferred" # Prefer HTTPS, allow HTTP fallback
+  PLEX_PREFERENCE_39: "RelayEnabled=0" # Disable Plex Relay (2 Mbps limitation)
+  PLEX_PREFERENCE_40: "TreatWanIpAsLocal=1" # Improve performance with internal DNS routing
 
   # Video Preview Thumbnails (BIF files)
   # Disabled per TRaSH guides - high disk I/O and storage cost
-  PLEX_PREFERENCE_41: "GenerateBIFBehavior=never"  # Disable video preview thumbnails
+  PLEX_PREFERENCE_41: "GenerateBIFBehavior=never" # Disable video preview thumbnails

--- a/kubernetes/apps/media/plex/app/helmrelease.yaml
+++ b/kubernetes/apps/media/plex/app/helmrelease.yaml
@@ -18,10 +18,6 @@ spec:
       strategy: rollback
       retries: 3
   dependsOn:
-    - name: intel-device-plugin-gpu
-      namespace: kube-system
-    - name: nvidia-device-plugin
-      namespace: kube-system
     - name: volsync
       namespace: storage
   values:
@@ -30,8 +26,21 @@ spec:
         annotations:
           reloader.stakater.com/auto: "true"
         pod:
-          nodeSelector:
-            nvidia.feature.node.kubernetes.io/gpu: "true"
+          # The P100 (GP100) has no NVENC encoder, so hardware transcoding is
+          # impossible on the GPU node — Plex was stalling on a dead NVENC path.
+          # Pin Plex to the high-CPU large nodes (16 cores each) for software
+          # transcoding instead.
+          affinity:
+            nodeAffinity:
+              requiredDuringSchedulingIgnoredDuringExecution:
+                nodeSelectorTerms:
+                  - matchExpressions:
+                      - key: kubernetes.io/hostname
+                        operator: In
+                        values:
+                          - talos-node-large-1
+                          - talos-node-large-2
+                          - talos-node-large-3
         containers:
           app:
             image:
@@ -42,8 +51,6 @@ spec:
               PLEX_LAN_NETWORKS: 192.168.1.0/24,10.100.0.0/24,10.69.0.0/16
               PLEX_ADVERTISE_URL: https://plex.${SECRET_DOMAIN_MEDIA}:443,http://${PLEX_VIP_GATEWAY}:32400
               PLEX_NO_AUTH_NETWORKS: 192.168.1.0/24,10.69.0.0/16
-              NVIDIA_DRIVER_CAPABILITIES: all
-              NVIDIA_VISIBLE_DEVICES: all
             envFrom:
               - configMapRef:
                   name: plex-preferences
@@ -55,11 +62,9 @@ spec:
               requests:
                 cpu: 4000m
                 memory: 12Gi
-                nvidia.com/gpu: 1
               limits:
                 cpu: 8000m
                 memory: 32Gi
-                nvidia.com/gpu: 1
           imagemaid:
             image:
               repository: docker.io/kometateam/imagemaid
@@ -82,7 +87,6 @@ spec:
               limits:
                 memory: 2Gi
     defaultPodOptions:
-      runtimeClassName: nvidia
       securityContext:
         runAsNonRoot: true
         runAsUser: 1000
@@ -97,7 +101,7 @@ spec:
         type: LoadBalancer
         controller: *app
         annotations:
-          lbipam.cilium.io/ips: &ip ${PLEX_VIP_GATEWAY}
+          lbipam.cilium.io/ips: ${PLEX_VIP_GATEWAY}
         ports:
           http:
             port: &port 32400
@@ -152,7 +156,7 @@ spec:
                   value: /
             backendRefs:
               - identifier: app
-                port: 32400
+                port: *port
             timeouts:
               request: 0s
               backendRequest: 0s


### PR DESCRIPTION
The Tesla P100 (GP100) has **no NVENC encoder**, so HW transcoding can never work — Plex was stalling on a dead NVENC path (`nvidia-smi` hung inside the pod), causing slow/504 transcode decisions on remote playback after the gateway cutover.

- Remove `nvidia.com/gpu`, NVIDIA env, `runtimeClassName: nvidia`, GPU device-plugin `dependsOn`.
- `nodeAffinity` → `talos-node-large-{1,2,3}` (16 cores each) for software transcoding. Config PVC is `ceph-rbd` (network RWO) → reschedules cleanly.
- Disable HW-accel prefs + sane CPU values (TranscoderQuality=auto, ToneMapping=0, CountLimit=4).

Verify: Plex pod Running on a large node; remote transcode plays without 504/stall.