### PR TITLE
fix(media): raise Plex HelmRelease timeout to 15m for node migration

### DIFF
--- a/kubernetes/apps/media/plex/app/helmrelease.yaml
+++ b/kubernetes/apps/media/plex/app/helmrelease.yaml
@@ -6,6 +6,11 @@ metadata:
   name: &app plex
 spec:
   interval: 30m
+  # Generous timeout: moving Plex between nodes means the ceph-rbd (RWO) config
+  # volume must detach from the old node and reattach on the new one, then Plex
+  # cold-starts its DB. This exceeds the 5m helm default and was triggering a
+  # rollback loop during the GPU->CPU node move.
+  timeout: 15m
   chartRef:
     kind: OCIRepository
     name: app-template


### PR DESCRIPTION
The GPU→CPU node move needs the `ceph-rbd` RWO config volume to detach/reattach across nodes + Plex cold start, exceeding the 5m helm default → rollback loop. Set `spec.timeout: 15m`.