### PR TITLE
feat(observability): route Plex alerts to dedicated ntfy 'plex' topic + fix CPU alert

### DIFF
--- a/kubernetes/apps/media/plex/app/prometheusrule.yaml
+++ b/kubernetes/apps/media/plex/app/prometheusrule.yaml
@@ -68,18 +68,16 @@ spec:
 
         - alert: PlexHighCPUUsage
           annotations:
-            summary: Plex CPU usage is critically high
+            summary: Plex CPU usage is high
             description: >-
-              Plex container in {{ $labels.namespace }}/{{ $labels.pod }} is using
-              {{ $value | humanizePercentage }} of its CPU limit for more than 10 minutes.
-              This may impact streaming quality.
+              Plex container in {{ $labels.namespace }}/{{ $labels.pod }} has been using
+              {{ $value | humanize }} CPU cores for more than 10 minutes. There is no CPU
+              limit, so this is absolute usage — sustained high load means heavy/parallel
+              software transcoding (expect possible buffering and node/storage pressure).
           expr: |
-            (
+            sum by (namespace, pod) (
               rate(container_cpu_usage_seconds_total{namespace="media", pod=~"plex-.*", container="app"}[5m])
-              /
-              container_spec_cpu_quota{namespace="media", pod=~"plex-.*", container="app"}
-              * 100000
-            ) > 0.90
+            ) > 12
           for: 10m
           labels:
             severity: warning

--- a/kubernetes/apps/observability/alertmanager-ntfy/app/resources/config.yml
+++ b/kubernetes/apps/observability/alertmanager-ntfy/app/resources/config.yml
@@ -3,8 +3,12 @@ http:
 ntfy:
   baseurl: http://ntfy.network.svc.cluster.local:8080
   notification:
-    # Dedicated topic so cluster alerts are separate from the gatus status topic.
-    topic: alertmanager
+    # Topic routing via gval expression (alexbakker/alertmanager-ntfy v1.2.1):
+    # media-namespace alerts (Plex) -> "plex" topic; everything else stays on
+    # "alertmanager". A plain word stays literal; this expression is auto-detected
+    # because it contains chars outside ^[-_A-Za-z0-9]{1,64}$. Accessor verified
+    # against source: labels["<name>"] (top-level, JSON-tag keys).
+    topic: 'labels["namespace"] == "media" ? "plex" : "alertmanager"'
     templates:
       # Title: severity emoji + alert name, scannable at a glance.
       title: |-


### PR DESCRIPTION
- Fix `PlexHighCPUUsage` (dead after CPU limit removal — divided by `container_spec_cpu_quota`=-1) → absolute cores (`sum rate > 12` for 10m).
- Route media-namespace alerts (Plex = only PrometheusRule there) to a new `plex` ntfy topic via a gval `topic` expression on alertmanager-ntfy; all other alerts unchanged on `alertmanager`. Accessor verified against v1.2.1 source.