### PR TITLE
feat(media): enable Tautulli TheMovieDB lookup via env (GitOps)

### DIFF
--- a/kubernetes/apps/media/tautulli/app/helmrelease.yaml
+++ b/kubernetes/apps/media/tautulli/app/helmrelease.yaml
@@ -33,6 +33,10 @@ spec:
             env:
               TZ: ${TIME_ZONE}
               TAUTULLI__PORT: &port 8181
+              # Tautulli v2.15.3+ maps TAUTULLI_<UPPER_KEY> env vars onto config.ini
+              # settings, so general settings can be GitOps-declared instead of clicked
+              # in the GUI. Enables TheMovieDB metadata lookup (API key already present).
+              TAUTULLI_THEMOVIEDB_LOOKUP: "1"
             probes:
               liveness: &probes
                 enabled: true


### PR DESCRIPTION
Tautulli v2.15.3+ maps `TAUTULLI_<UPPER_KEY>` env → config.ini. Sets `TAUTULLI_THEMOVIEDB_LOOKUP=1` (API key already present) so the setting is declarative instead of GUI-only. Will verify config.ini reflects it post-deploy.