### PR TITLE
fix(observability): bump dcgm-exporter image off stale 2022 pin

### DIFF
--- a/kubernetes/apps/observability/exporters/dcgm-exporter/app/helmrelease.yaml
+++ b/kubernetes/apps/observability/exporters/dcgm-exporter/app/helmrelease.yaml
@@ -35,7 +35,14 @@ spec:
         memory: 512Mi
     image:
       repository: nvcr.io/nvidia/k8s/dcgm-exporter
-      tag: 3.1.7-3.1.4-ubuntu20.04
+      # Pinned to the image that ships with chart 4.8.2 (DCGM 4.5.3). The old
+      # 3.1.7-3.1.4-ubuntu20.04 pin (2022) no longer starts on the current Talos
+      # 6.18 kernel/runtime — containerd timed out creating the shim task
+      # (RunContainerError, 1000+ restarts over ~47h). Pascal P100s lack DCGM
+      # profiling (DCP) support, but the chart already defaults its arguments to
+      # default-counters.csv (no DCGM_FI_PROF_* fields), so that limitation is
+      # avoided — basic GPU telemetry (util/mem/temp/power/clocks) works on Pascal.
+      tag: 4.5.3-4.8.2-distroless
     extraEnv:
       - name: NVIDIA_DRIVER_CAPABILITIES
         value: all


### PR DESCRIPTION
The image was pinned to 3.1.7-3.1.4-ubuntu20.04 (2022) while the chart is
4.8.2. That old build no longer starts on the current Talos 6.18 kernel/
containerd 2.2.5 runtime — every start timed out creating the shim task
(RunContainerError, 1000+ restarts over ~47h), leaving the cluster with no
GPU metrics (the GPUs themselves are healthy; ollama/speaches run fine).

Pin to 4.5.3-4.8.2-distroless, the image that ships with chart 4.8.2. The
P100 Pascal profiling (DCP) limitation is unchanged across versions — it is
a hardware limitation, not a bug any release fixes — but the chart already
defaults to default-counters.csv (no DCGM_FI_PROF_* fields), so basic GPU
telemetry works on Pascal and modern dcgm-exporter skips unsupported fields
gracefully rather than crashing.
