### PR TITLE
chore(network): raise ntfy memory limits

### DIFF
--- a/kubernetes/apps/network/ntfy/app/helmrelease.yaml
+++ b/kubernetes/apps/network/ntfy/app/helmrelease.yaml
@@ -71,9 +71,9 @@ spec:
             resources:
               requests:
                 cpu: 10m
-                memory: 32Mi
+                memory: 64Mi
               limits:
-                memory: 128Mi
+                memory: 256Mi
     defaultPodOptions:
       securityContext:
         runAsNonRoot: true


### PR DESCRIPTION
Bump ntfy requests 32Mi->64Mi and limit 128Mi->256Mi for headroom. The
server recently restarted and the 128Mi limit was tight for the alert
notification bridge target.
