### PR TITLE
feat(network): add reverse proxy for Aruba S2500 webui

### DIFF
--- a/kubernetes/apps/network/internal/home-reverse-proxy/aruba-proxy.yaml
+++ b/kubernetes/apps/network/internal/home-reverse-proxy/aruba-proxy.yaml
@@ -1,0 +1,33 @@
+---
+# Aruba S2500-48P (ArubaOS MAS) management WebUI on :4343.
+# Its self-signed cert uses a key-usage modern Chrome rejects (ERR_SSL_KEY_USAGE_INCOMPATIBLE,
+# unbypassable). Front it with the internal gateway's valid cert and skip upstream verification.
+# No aruba.manor DNS record exists, so target the IP directly via an EG Backend ip endpoint.
+apiVersion: gateway.envoyproxy.io/v1alpha1
+kind: Backend
+metadata:
+  name: aruba-proxy
+  namespace: network
+spec:
+  endpoints:
+    - ip:
+        address: 192.168.1.26
+        port: 4343
+  tls:
+    insecureSkipVerify: true
+---
+apiVersion: gateway.networking.k8s.io/v1
+kind: HTTPRoute
+metadata:
+  name: aruba-proxy
+  namespace: network
+spec:
+  parentRefs:
+    - name: internal
+      namespace: network
+  hostnames: ["aruba.${SECRET_DOMAIN}"]
+  rules:
+    - backendRefs:
+        - group: gateway.envoyproxy.io
+          kind: Backend
+          name: aruba-proxy

--- a/kubernetes/apps/network/internal/home-reverse-proxy/kustomization.yaml
+++ b/kubernetes/apps/network/internal/home-reverse-proxy/kustomization.yaml
@@ -3,6 +3,7 @@
 apiVersion: kustomize.config.k8s.io/v1beta1
 kind: Kustomization
 resources:
+  - ./aruba-proxy.yaml
   - ./firewall-proxy.yaml
   - ./proxmox-proxy.yaml
   - ./other-proxy.yaml


### PR DESCRIPTION
Fronts the Aruba S2500-48P management WebUI (`192.168.1.26:4343`) with the internal gateway's valid cert.

The switch's self-signed cert uses a key-usage extension modern Chrome rejects (`ERR_SSL_KEY_USAGE_INCOMPATIBLE`, unbypassable). This proxies it via an Envoy Gateway `Backend` with `insecureSkipVerify` and exposes it at `aruba.${SECRET_DOMAIN}` on the internal gateway. No `aruba.manor` DNS record exists, so the Backend targets the IP directly.

Matches the existing firewall/proxmox reverse-proxy pattern; the new file just needed registering in `kustomization.yaml`.