### PR TITLE
docs(authentik-auth): Proxmox/non-web OIDC consumer recipe + gotchas

### DIFF
--- a/.claude/skills/authentik-auth/SKILL.md
+++ b/.claude/skills/authentik-auth/SKILL.md
@@ -118,6 +118,12 @@ ConfigMap `authentik-oidc`).
 Full recipe — adopting an existing app vs. creating a new one, the `!Env` creds
 pattern, and the blueprint YAML — see [`references/oidc.md`](references/oidc.md).
 
+**Non-web-app consumers (Proxmox VE and similar appliances)** follow the same Authentik
+blueprint side, but the _consumer_ is configured **outside Git** (PVE realm lives in
+`/etc/pve/domains.cfg`, set via `ssh`+`pveum`, not an app HR). Recipe + the
+issuer-trailing-slash / group-naming / headless-validation gotchas are in
+[`references/oidc.md`](references/oidc.md) → "Non-web-app OIDC consumers".
+
 ---
 
 ## Gotchas
@@ -134,3 +140,11 @@ pattern, and the blueprint YAML — see [`references/oidc.md`](references/oidc.m
   retire an app, remove its entries AND `DELETE` the live provider+app via the API (apps first).
 - `blueprints.yaml` was bootstrapped once from live state by a throwaway script; it is **hand-maintained
   now** (no codegen in the Flux flow).
+- **OIDC issuer trailing slash:** strict OIDC consumers (e.g. Proxmox) exact-match the configured
+  issuer against Authentik's discovery `issuer`, which is published **with** a trailing slash
+  (`.../application/o/<slug>/`). Drop it and the consumer rejects every token. See oidc.md.
+- **Groups need no extra scope mapping:** Authentik's default `profile` scope already emits a `groups`
+  claim (names) and `preferred_username`; with `include_claims_in_id_token` they're in the ID token.
+- **Flaky OIDC login (timeout _or_ 401) is usually transient Authentik slowness, not config** — single
+  `authentik-server` replica stalls; the 401 is the ~60s auth code expiring mid-stall. See memory
+  `project-authentik-stability`.

--- a/.claude/skills/authentik-auth/references/oidc.md
+++ b/.claude/skills/authentik-auth/references/oidc.md
@@ -55,3 +55,64 @@ actual/open-webui/proxmox are done. DR caveat: re-enter the secret once on a fro
 **Do NOT** add an OIDC provider to the outpost `providers:` list (that's forward-auth only).
 **Migrating an existing OIDC app:** first read its current client_id/secret from the API and put them
 in Infisical, so the `!Env` blueprint is a no-op (otherwise it overwrites the creds and breaks login).
+
+---
+
+## Non-web-app OIDC consumers (Proxmox VE, and similar appliances)
+
+Some OIDC clients aren't web apps with an app HelmRelease — they're appliances configured
+**outside Git**. Proxmox is the canonical case (set up 2026-06-30; see memory
+`project-proxmox-oidc`). The Authentik blueprint side is normal (provider+app in
+`blueprints-oidc.yaml`, creds preserved-live by omission); the _consumer_ side is the twist.
+
+**Proxmox VE realm** lives in `/etc/pve/domains.cfg` — cluster-replicated, so configure on ANY
+one node via `ssh` + `pveum`. NOT GitOps. PVE 8.x:
+
+```bash
+pveum realm add authentik --type openid \
+  --issuer-url 'https://sso.${SECRET_DOMAIN}/application/o/proxmox/' \   # TRAILING SLASH — required
+  --client-id <id> --client-key <secret> \
+  --username-claim preferred_username \
+  --groups-claim groups --autocreate 1 --default 0
+pveum group add proxmox-admins-authentik           # PVE names synced groups <claim>-<realm>
+pveum acl modify / --group proxmox-admins-authentik --role Administrator
+```
+
+Authentik group `proxmox-admins` (declare it + membership in `blueprints-oidc.yaml` as an
+`authentik_core.group` entry) → PVE syncs it as `proxmox-admins-authentik`.
+
+**Gotchas (all cost real debug time):**
+
+- **Issuer trailing slash (exact match).** PVE string-compares the configured `issuer-url` against
+  the discovery doc's `issuer` field. Authentik publishes it **with** a trailing slash
+  (`.../application/o/<slug>/`), so the realm `issuer-url` MUST include it. No-slash →
+  `Validation error: unexpected issuer URI`. (Discovery _fetch_ works either way; only the equality
+  check is strict.) This is general to any strict OIDC consumer, not just PVE.
+- **`username-claim` = `preferred_username`.** Authentik does NOT emit a bare `username` claim
+  (the `profile` scope gives `preferred_username` + `nickname`). Users land as `<name>@authentik`.
+- **Groups need no custom scope mapping.** Authentik's default `profile` scope already returns a
+  `groups` claim (list of group names); with `include_claims_in_id_token: true` (the `&oidc` anchor)
+  it's in the ID token. Just set `groups-claim groups` on the consumer.
+- **PVE group naming `<claim>-<realm>`.** Pre-create `<group>-authentik` + its ACL before first
+  login, and keep `groups-autocreate 0` so PVE doesn't spawn a group for every Authentik group the
+  user is in.
+- **Redirect URI = the browser origin**, i.e. the reverse-proxy host the user visits
+  (`https://proxmox.${SECRET_DOMAIN}`), because PVE builds `redirect_uri` from `window.location.origin`.
+  List every proxied host that serves the GUI. Strip stale ones.
+
+**Headless validation (no browser):**
+
+```bash
+# PVE builds the authorize URL → proves realm config + discovery fetch + issuer match
+AUTHURL=$(ssh proxmox-01 "pvesh create /access/openid/auth-url --realm authentik \
+  --redirect-url https://proxmox.${SECRET_DOMAIN}" | tr -d '"')
+curl -sk -o /dev/null -w '%{http_code}\n' "$AUTHURL"    # 302 into default-authentication-flow = good
+# Read live provider creds to feed the consumer:
+TOKEN=$(kubectl -n security get secret authentik-secret -o jsonpath='{.data.AUTHENTIK_BOOTSTRAP_TOKEN}' | base64 -d)
+curl -sk -H "Authorization: Bearer $TOKEN" "https://sso.${SECRET_DOMAIN}/api/v3/providers/oauth2/?search=Proxmox"
+```
+
+**Flaky login during bring-up is usually NOT your config.** Intermittent `upstream request timeout`
+(Envoy 15s) and `authentication failure (401)` both trace to Authentik being briefly slow (single
+replica) — the 401 is a single-use auth code (~60s) expiring mid-stall. Confirm via the token+userinfo
+`200`s in the authentik-server log. See memory `project-authentik-stability`.


### PR DESCRIPTION
Captures learnings from wiring native OIDC for the ChelonianLabs Proxmox cluster against Authentik.

**`references/oidc.md`** — new section *"Non-web-app OIDC consumers (Proxmox VE, and similar appliances)"*: full `pveum` realm recipe, the gotchas (issuer trailing-slash exact-match, `username-claim=preferred_username`, default `profile` scope already carries `groups`, PVE `<group>-<realm>` group naming, redirect-uri = browser origin), and a headless `pvesh auth-url` validation trick.

**`SKILL.md`** — pointer from Part B + three general gotchas hoisted to the top-level list.

Docs-only; no manifest changes.