### PR TITLE
perf(flux): lower controller concurrency to flatten per-push reconcile burst

### DIFF
--- a/kubernetes/apps/flux-system/flux-operator/instance/helm-values.yaml
+++ b/kubernetes/apps/flux-system/flux-operator/instance/helm-values.yaml
@@ -28,14 +28,16 @@ instance:
         target:
           group: kustomize.toolkit.fluxcd.io
           kind: Kustomization
-      - # Increase the number of workers
+      - # Worker concurrency (base for all controllers; kustomize-controller is
+        # raised separately below). Kept low to flatten the per-push reconcile
+        # burst against Ceph-RBD-backed etcd rather than maximize throughput.
         patch: |
           - op: add
             path: /spec/template/spec/containers/0/args/-
-            value: --concurrent=10
+            value: --concurrent=4
           - op: add
             path: /spec/template/spec/containers/0/args/-
-            value: --requeue-dependency=5s
+            value: --requeue-dependency=30s
         target:
           kind: Deployment
           name: (kustomize-controller|helm-controller|source-controller)
@@ -73,11 +75,14 @@ instance:
         target:
           kind: Deployment
           name: kustomize-controller
-      - # Enable in-memory kustomize builds
+      - # Enable in-memory kustomize builds + kustomize-controller concurrency.
+        # Overrides the base --concurrent=4 above; the single GitRepository source
+        # fans out to ~116 Kustomizations on every push, so this caps how wide
+        # that burst applies in parallel (lower = gentler on etcd, slower sync).
         patch: |
           - op: add
             path: /spec/template/spec/containers/0/args/-
-            value: --concurrent=20
+            value: --concurrent=5
           - op: replace
             path: /spec/template/spec/volumes/0
             value:


### PR DESCRIPTION
## Problem

Every push to `main` triggers a sharp etcd write spike. Root cause is healthy single-source fan-out, not a bug: the one `flux-system` GitRepository feeds **~116 Kustomizations**, and Flux re-applies *all* of them on every push regardless of which paths changed (no per-path change detection). The existing tuning maximized throughput — `kustomize-controller --concurrent=20`, `helm-controller`/`source-controller --concurrent=10` — firing that fan-out as a 20-wide parallel burst of status writes.

etcd now lives on the Ceph `vm-storage` pool (enterprise SSD, but **networked RBD with 3x replication**), so each fsync pays a replication round-trip. The backend is sensitive to concurrent write *bursts*, not total volume — exactly what max concurrency maximizes.

## Change

Lower controller concurrency so the same reconcile work spreads over slightly more wall-clock time instead of a spike:

| controller | before | after |
|---|---|---|
| kustomize-controller | 20 | 5 |
| helm-controller | 10 | 4 |
| source-controller | 10 | 4 |
| `--requeue-dependency` | 5s | 30s |

## Notes

- **No drift pathology exists** — a live scan showed 121/124 Kustomizations `ReconciliationSucceeded` (the 3 exceptions are the known fairwinds CDN digest issue + transient build failures). This only reshapes the burst; it does **not** change total reconcile work.
- Trade-off: a full-tree sync takes ~30–60s longer in wall-clock. Irrelevant for this cluster; the webhook still triggers reconciliation instantly.
- Reversible — bump the two `--concurrent` values back up.