### PR TITLE
feat(observability): Flux-manage prometheus-operator-crds (close CRD drift)

### DIFF
--- a/kubernetes/apps/kube-system/kustomization.yaml
+++ b/kubernetes/apps/kube-system/kustomization.yaml
@@ -17,4 +17,5 @@ resources:
   - ./gpu-plugins/intel-device-plugin/ks.yaml
   - ./node-feature-discovery/ks.yaml
   - ./nut-upsd/ks.yaml
+  - ./prometheus-operator-crds/ks.yaml
   - ./reflector/ks.yaml

--- a/kubernetes/apps/kube-system/prometheus-operator-crds/app/helmrelease.yaml
+++ b/kubernetes/apps/kube-system/prometheus-operator-crds/app/helmrelease.yaml
@@ -1,0 +1,26 @@
+---
+# yaml-language-server: $schema=https://raw.githubusercontent.com/fluxcd-community/flux2-schemas/main/helmrelease-helm-v2.json
+apiVersion: helm.toolkit.fluxcd.io/v2
+kind: HelmRelease
+metadata:
+  name: prometheus-operator-crds
+spec:
+  interval: 30m
+  chartRef:
+    kind: OCIRepository
+    name: prometheus-operator-crds
+  install:
+    remediation:
+      retries: 3
+  upgrade:
+    cleanupOnFail: true
+    remediation:
+      strategy: rollback
+      retries: 3
+  values:
+    # This chart ships the monitoring.coreos.com CRDs as templates (not in crds/),
+    # so Helm — and therefore Flux — can upgrade them in place. resource-policy=keep
+    # protects them from deletion if the release is ever removed.
+    crds:
+      annotations:
+        helm.sh/resource-policy: keep

--- a/kubernetes/apps/kube-system/prometheus-operator-crds/app/kustomization.yaml
+++ b/kubernetes/apps/kube-system/prometheus-operator-crds/app/kustomization.yaml
@@ -1,0 +1,7 @@
+---
+# yaml-language-server: $schema=https://json.schemastore.org/kustomization
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+resources:
+  - ./helmrelease.yaml
+  - ./ocirepository.yaml

--- a/kubernetes/apps/kube-system/prometheus-operator-crds/app/ocirepository.yaml
+++ b/kubernetes/apps/kube-system/prometheus-operator-crds/app/ocirepository.yaml
@@ -1,0 +1,14 @@
+---
+# yaml-language-server: $schema=https://kubernetes-schemas.pages.dev/source.toolkit.fluxcd.io/ocirepository_v1.json
+apiVersion: source.toolkit.fluxcd.io/v1
+kind: OCIRepository
+metadata:
+  name: prometheus-operator-crds
+spec:
+  interval: 5m
+  layerSelector:
+    mediaType: application/vnd.cncf.helm.chart.content.v1.tar+gzip
+    operation: copy
+  ref:
+    tag: 30.0.0
+  url: oci://ghcr.io/prometheus-community/charts/prometheus-operator-crds

--- a/kubernetes/apps/kube-system/prometheus-operator-crds/ks.yaml
+++ b/kubernetes/apps/kube-system/prometheus-operator-crds/ks.yaml
@@ -3,28 +3,21 @@
 apiVersion: kustomize.toolkit.fluxcd.io/v1
 kind: Kustomization
 metadata:
-  name: &app kube-prometheus-stack
-  namespace: &namespace observability
+  name: &app prometheus-operator-crds
+  namespace: &namespace kube-system
 spec:
   targetNamespace: *namespace
   commonMetadata:
     labels:
       app.kubernetes.io/name: *app
-  dependsOn:
-    - name: external-secrets-stores
-      namespace: external-secrets
-    - name: prometheus-operator-crds
-      namespace: kube-system
-  path: ./kubernetes/apps/observability/kube-prometheus-stack/app
-  prune: true
+  path: ./kubernetes/apps/kube-system/prometheus-operator-crds/app
+  # CRDs must never be pruned by Flux — deleting them cascades to every CR.
+  prune: false
   sourceRef:
     kind: GitRepository
     name: flux-system
     namespace: flux-system
-  wait: false
+  wait: true
   interval: 30m
   retryInterval: 1m
   timeout: 5m
-  postBuild:
-    substitute:
-      APP: *app

--- a/kubernetes/bootstrap/apps/helmfile.yaml
+++ b/kubernetes/bootstrap/apps/helmfile.yaml
@@ -18,7 +18,7 @@ releases:
   - name: prometheus-operator-crds
     namespace: kube-system
     chart: oci://ghcr.io/prometheus-community/charts/prometheus-operator-crds
-    version: 29.0.0
+    version: 30.0.0
     values:
       - crds:
           annotations:
@@ -29,40 +29,48 @@ releases:
     chart: cilium/cilium
     version: 1.19.5
     values: ['{{ requiredEnv "KUBERNETES_DIR" }}/apps/kube-system/cilium/app/helm-values.yaml']
-    needs: ['kube-system/prometheus-operator-crds']
+    needs: ["kube-system/prometheus-operator-crds"]
 
   - name: coredns
     namespace: kube-system
     chart: oci://ghcr.io/coredns/charts/coredns
     version: 1.46.0
     values: ['{{ requiredEnv "KUBERNETES_DIR" }}/apps/kube-system/coredns/app/helm-values.yaml']
-    needs: ['kube-system/cilium']
+    needs: ["kube-system/cilium"]
 
   - name: cert-manager
     namespace: cert-manager
     chart: jetstack/cert-manager
     version: v1.20.3
-    values: ['{{ requiredEnv "KUBERNETES_DIR" }}/apps/cert-manager/cert-manager/app/helm-values.yaml']
-    needs: ['kube-system/coredns']
+    values:
+      ['{{ requiredEnv "KUBERNETES_DIR" }}/apps/cert-manager/cert-manager/app/helm-values.yaml']
+    needs: ["kube-system/coredns"]
 
   - name: external-secrets
     namespace: external-secrets
     chart: oci://ghcr.io/external-secrets/charts/external-secrets
     version: 2.7.0
-    values: ['{{ requiredEnv "KUBERNETES_DIR" }}/apps/external-secrets/external-secrets/app/helm-values.yaml']
-    needs: ['cert-manager/cert-manager']
+    values:
+      [
+        '{{ requiredEnv "KUBERNETES_DIR" }}/apps/external-secrets/external-secrets/app/helm-values.yaml',
+      ]
+    needs: ["cert-manager/cert-manager"]
 
   - name: flux-operator
     namespace: flux-system
     chart: oci://ghcr.io/controlplaneio-fluxcd/charts/flux-operator
     version: 0.53.0
-    values: ['{{ requiredEnv "KUBERNETES_DIR" }}/apps/flux-system/flux-operator/app/helm-values.yaml']
-    needs: ['cert-manager/cert-manager']
+    values:
+      ['{{ requiredEnv "KUBERNETES_DIR" }}/apps/flux-system/flux-operator/app/helm-values.yaml']
+    needs: ["cert-manager/cert-manager"]
 
   - name: flux-instance
     namespace: flux-system
     chart: oci://ghcr.io/controlplaneio-fluxcd/charts/flux-instance
     version: 0.53.0
     wait: false
-    values: ['{{ requiredEnv "KUBERNETES_DIR" }}/apps/flux-system/flux-operator/instance/helm-values.yaml']
-    needs: ['flux-system/flux-operator']
+    values:
+      [
+        '{{ requiredEnv "KUBERNETES_DIR" }}/apps/flux-system/flux-operator/instance/helm-values.yaml',
+      ]
+    needs: ["flux-system/flux-operator"]

--- a/kubernetes/bootstrap/helmfile.yaml
+++ b/kubernetes/bootstrap/helmfile.yaml
@@ -18,40 +18,45 @@ releases:
   - name: prometheus-operator-crds
     namespace: observability
     chart: oci://ghcr.io/prometheus-community/charts/prometheus-operator-crds
-    version: 29.0.0
+    version: 30.0.0
 
   - name: cilium
     namespace: kube-system
     chart: cilium/cilium
     version: 1.19.5
     values: ['{{ requiredEnv "KUBERNETES_DIR" }}/apps/kube-system/cilium/app/helm-values.yaml']
-    needs: ['observability/prometheus-operator-crds']
+    needs: ["observability/prometheus-operator-crds"]
 
   - name: coredns
     namespace: kube-system
     chart: oci://ghcr.io/coredns/charts/coredns
     version: 1.46.0
     values: ['{{ requiredEnv "KUBERNETES_DIR" }}/apps/kube-system/coredns/app/helm-values.yaml']
-    needs: ['kube-system/cilium']
+    needs: ["kube-system/cilium"]
 
   - name: cert-manager
     namespace: cert-manager
     chart: jetstack/cert-manager
     version: v1.20.3
-    values: ['{{ requiredEnv "KUBERNETES_DIR" }}/apps/cert-manager/cert-manager/app/helm-values.yaml']
-    needs: ['kube-system/coredns']
+    values:
+      ['{{ requiredEnv "KUBERNETES_DIR" }}/apps/cert-manager/cert-manager/app/helm-values.yaml']
+    needs: ["kube-system/coredns"]
 
   - name: flux-operator
     namespace: flux-system
     chart: oci://ghcr.io/controlplaneio-fluxcd/charts/flux-operator
     version: 0.53.0
-    values: ['{{ requiredEnv "KUBERNETES_DIR" }}/apps/flux-system/flux-operator/app/helm-values.yaml']
-    needs: ['cert-manager/cert-manager']
+    values:
+      ['{{ requiredEnv "KUBERNETES_DIR" }}/apps/flux-system/flux-operator/app/helm-values.yaml']
+    needs: ["cert-manager/cert-manager"]
 
   - name: flux-instance
     namespace: flux-system
     chart: oci://ghcr.io/controlplaneio-fluxcd/charts/flux-instance
     version: 0.53.0
     wait: false
-    values: ['{{ requiredEnv "KUBERNETES_DIR" }}/apps/flux-system/flux-operator/instance/helm-values.yaml']
-    needs: ['flux-system/flux-operator']
+    values:
+      [
+        '{{ requiredEnv "KUBERNETES_DIR" }}/apps/flux-system/flux-operator/instance/helm-values.yaml',
+      ]
+    needs: ["flux-system/flux-operator"]


### PR DESCRIPTION
## What

Makes `prometheus-operator-crds` a **Flux-managed** app so the monitoring CRDs upgrade automatically with Renovate + Flux, instead of being frozen by the run-once bootstrap helmfile.

## Why

The CRDs were installed **only** via `bootstrap/{,apps/}helmfile.yaml` (run-once, not reconciled by Flux). They froze at **v0.79.2** while Flux kept upgrading the operator to **v0.91** — a 12-version drift, tolerated only because the CRDs are backward-compatible. Renovate bumped the helmfile pin but nobody re-ran the helmfile, so it never applied.

## How

- New `kubernetes/apps/kube-system/prometheus-operator-crds/` app: `OCIRepository` + `HelmRelease` pinned to chart **30.0.0** (operator v0.92 CRDs).
- Release name + namespace (`prometheus-operator-crds` / `kube-system`) **match the live CRDs' existing Helm ownership metadata**, so Flux's first reconcile cleanly *adopts* them — no "resource already exists" conflict.
- `ks` is `prune: false` (CRDs must never be pruned — it cascades to every CR) and keeps `crds.annotations: helm.sh/resource-policy: keep`.
- `kube-prometheus-stack` ks now `dependsOn` the CRD app (CRDs reconcile first).
- Bootstrap helmfiles bumped 29.0.0 → 30.0.0 to stay in sync for fresh installs.

## Supersedes

- Closes #3359 (the helmfile-only version bump — folded in here).

## Notes / rollout

- The chart ships CRDs as **templates** (not `crds/`), so Helm/Flux upgrade them in place.
- After merge, Flux adopts + upgrades the live CRDs to v0.92, closing the drift. Pairs with #3376 (operator → v0.92.1).