### PR TITLE
chore(observability): drop goldilocks recommender prometheus storage

### DIFF
--- a/kubernetes/apps/observability/goldilocks/app/helmrelease.yaml
+++ b/kubernetes/apps/observability/goldilocks/app/helmrelease.yaml
@@ -40,12 +40,12 @@ spec:
       enabled: true
       recommender:
         # Advisory-only (all VPAs are updateMode: Off) — no need for minute-fresh
-        # recommendations. Hourly loop + Prometheus history storage keeps this
-        # off etcd (no VPACheckpoint writes) and slashes status-write churn.
+        # recommendations. An hourly loop alone cuts status + checkpoint writes to
+        # ~0.1/s (171 objects/hour), so default checkpoint storage is fine; the
+        # Prometheus history backend was dropped (its queries assume the old
+        # cadvisor label schema and error against kube-prometheus-stack).
         extraArgs:
           recommender-interval: 1h
-          storage: prometheus
-          prometheus-address: http://kube-prometheus-stack-prometheus.observability.svc.cluster.local:9090
     dashboard:
       enabled: true
       resources:


### PR DESCRIPTION
Follow-up to #3492.

The hourly `recommender-interval` from #3492 already cuts VPA status + checkpoint writes to ~0.1/s (171 objects/hour), so default checkpoint storage is negligible. Meanwhile the `storage=prometheus` backend **errored** in practice — the VPA recommender hardcodes the legacy cadvisor label schema (`job=kubernetes-cadvisor`, `pod_name`) which doesn't match kube-prometheus-stack (`job=kubelet`, `pod`):

```
E cluster_feeder.go:224 "Cannot get cluster history"
  err="...expected query to return a matrix; got result type model.Vector"
```

So history seeding never worked, and it would cold-start on every restart. Dropping it (keeping just `recommender-interval: 1h`) is simpler and error-free.