### PR TITLE
feat(auth): kubectl login via Authentik OIDC + group RBAC

### DIFF
--- a/docs/src/SUMMARY.md
+++ b/docs/src/SUMMARY.md
@@ -21,5 +21,6 @@
 - [Installation](operations/installation.md)
 - [Maintenance](operations/maintenance.md)
 - [Troubleshooting](operations/troubleshooting.md)
+- [SSO Cluster Access](operations/sso-cluster-access.md)
 - [Network Operations](operations/network-runbook.md)
 - [VolSync Resource Flow](planning/volsync-resource-flow.md)

--- a/docs/src/architecture/network-topology.md
+++ b/docs/src/architecture/network-topology.md
@@ -9,6 +9,58 @@ The network spans two buildings — **house** and **garage/shop** — joined by 
 wireless bridge (~1 Gbps). The garage holds the core (Brocade) and the high-speed Ceph
 distribution switch (Arista); the house holds the access switch (Aruba) and the OPNsense router.
 
+## Bandwidth & Link Diagram
+
+> At-a-glance view of devices, links, and aggregated speeds. Rendered from the Mermaid
+> source below (kept in-doc as the source of truth for the topology infographic).
+
+```mermaid
+flowchart LR
+internet([Internet — AT&T Fiber — 2.5 Gbps]):::wan
+
+  subgraph HOUSE
+    direction TB
+    opn[OPNsense<br/>Router / Firewall — .1]:::fw
+    aruba[Aruba S2500-48P<br/>Access / PoE — .26]:::sw
+    ws[10G workstation]:::client
+    clients[Clients / PoE]:::client
+    nray7[MikroTik NRay — .7]:::radio
+  end
+
+  subgraph GARAGE_SHOP[GARAGE / SHOP]
+    direction TB
+    nray8[MikroTik NRay — .8]:::radio
+    css[MikroTik CSS326 — .27]:::sw
+    brocade[Brocade ICX6610<br/>Core / L3 — .20]:::core
+    arista[Arista 7050<br/>Ceph Distribution — .21]:::core
+    pmox[Proxmox cluster x4<br/>Talos K8s + Ceph]:::server
+    netboot[netboot.xyz<br/>PXE — .10 · Proxmox LXC]:::server
+  end
+
+  internet -->|2.5G| opn
+  opn ==>|10G| aruba
+  aruba ==>|10G| ws
+  aruba -->|1G| clients
+  aruba -->|1G| nray7
+  nray7 -. "60GHz Wireless Bridge<br/>~1 Gbps · bottleneck / SPOF" .-> nray8
+  nray8 -->|1G| css
+  css ==>|10G SFP+| brocade
+  brocade ====|"80G LACP (2×40G)"| arista
+  arista ====|"2×40G Ceph → Arista (80G bond)"| pmox
+  brocade ==>|"2×10G VM LAG (20G)"| pmox
+  brocade -->|"2×1G mgmt LAG (2G)"| pmox
+  brocade -->|1G IPMI| pmox
+  netboot -.-> pmox
+
+  classDef wan     fill:#0b2a3a,stroke:#38bdf8,color:#e6f6ff,stroke-width:2px;
+  classDef fw      fill:#12324a,stroke:#38bdf8,color:#e6f6ff,stroke-width:2px;
+  classDef sw      fill:#12324a,stroke:#5eead4,color:#e6fffb,stroke-width:2px;
+  classDef core    fill:#1a2e12,stroke:#a3e635,color:#f7ffe6,stroke-width:2px;
+  classDef server  fill:#2a1436,stroke:#e879f9,color:#fdebff,stroke-width:2px;
+  classDef radio   fill:#3a2a0b,stroke:#f59e0b,color:#fff7e6,stroke-width:2px;
+  classDef client  fill:#1b2430,stroke:#94a3b8,color:#e2e8f0,stroke-width:2px;
+```
+
 ---
 
 ## Device Inventory
@@ -56,15 +108,17 @@ All switch management interfaces sit on VLAN 1 (192.168.1.0/24).
 
 ## Layer 3 / Routing (verified)
 
-- **OPNsense** (house) — default gateway for VLAN 1 (192.168.1.1) and VLAN 100 (10.100.0.1);
-  upstream internet (AT&T fiber).
+- **OPNsense** (house) — default gateway for VLAN 1 (192.168.1.1) and VLAN 100 (10.100.0.1).
+  Upstream internet: **AT&T Fiber, 2.5 Gbps**. Connects to the house fabric over **10G fiber**
+  (`mce0`/`mce1`, `10Gbase-SR`, both active) — this is the house backbone.
 - **Brocade ICX6610** — SVIs: `ve1` 192.168.1.20/24, `ve100` 10.100.0.10/24,
   `ve200` 10.200.0.254/24. Jumbo frames enabled globally. Two default routes point at OPNsense:
   `0.0.0.0/0 → 192.168.1.1` and `0.0.0.0/0 → 10.100.0.1`.
 - **Arista 7050** — `no ip routing`; pure L2. Management only: `Management1` 192.168.1.21/24,
   default route `0.0.0.0/0 → 192.168.1.1`.
 - **Aruba S2500** — L2 access. `vlan 1` IP via DHCP (currently 192.168.1.26),
-  `vlan 100` 10.100.0.26/24, dedicated OOB `mgmt` port 172.16.0.254/24.
+  `vlan 100` 10.100.0.26/24, dedicated OOB `mgmt` port 172.16.0.254/24. **10G SFP+ to OPNsense**
+  (house backbone); can serve **10G to select house clients** (e.g. a workstation), 1G to the rest.
 
 ---
 

--- a/docs/src/operations/sso-cluster-access.md
+++ b/docs/src/operations/sso-cluster-access.md
@@ -1,0 +1,97 @@
+# SSO Cluster Access (kubectl via Authentik OIDC)
+
+Daily `kubectl` access authenticates against **Authentik** (OIDC). Group membership
+in Authentik maps to cluster RBAC. This is layered _on top of_ the existing x509
+admin kubeconfig, which remains the untouchable **break-glass** path.
+
+## How it fits together
+
+| Path                  | Depends on Authentik? | Use                                 |
+| --------------------- | --------------------- | ----------------------------------- |
+| OIDC (`kubelogin`)    | Yes                   | Daily, per-user, revocable, audited |
+| x509 admin kubeconfig | **No**                | Break-glass                         |
+| `talosctl kubeconfig` | **No**                | Break-glass of last resort          |
+
+The kube-apiserver runs multiple authenticators at once — OIDC is _additive_. The
+apiserver validates the x509 admin cert entirely locally against the cluster CA, so
+it works even if Authentik is completely down. The OIDC flags use the legacy
+`--oidc-*` form, which fetches JWKS lazily: an unreachable Authentik degrades only
+OIDC token validation, it never blocks apiserver startup.
+
+- **Provider**: Authentik `Kubernetes OIDC`, public/PKCE client, `client_id: kubectl`.
+- **Issuer**: `https://sso.chelonianlabs.com/application/o/kubectl/` (trailing slash required).
+- **apiserver flags**: `kubernetes/bootstrap/talos/patches/controller/cluster.yaml`.
+- **RBAC**: `kubernetes/apps/kube-system/oidc-rbac/` binds
+  `oidc:kubernetes-admins` → `cluster-admin` and `oidc:kubernetes-viewers` → `view`.
+
+## Access tiers
+
+| Authentik group      | Cluster role       |
+| -------------------- | ------------------ |
+| `kubernetes-admins`  | `cluster-admin`    |
+| `kubernetes-viewers` | `view` (read-only) |
+
+Grant access by adding a user to the group in Authentik; revoke by removing them.
+
+## Client setup (one-time)
+
+Install the exec credential plugin:
+
+```bash
+kubectl krew install oidc-login   # provides `kubectl oidc-login` / kubelogin
+```
+
+Add an OIDC user and context to `~/.kube/config` (leave the existing admin context
+untouched):
+
+```yaml
+users:
+  - name: oidc
+    user:
+      exec:
+        apiVersion: client.authentication.k8s.io/v1beta1
+        command: kubectl
+        args:
+          - oidc-login
+          - get-token
+          - --oidc-issuer-url=https://sso.chelonianlabs.com/application/o/kubectl/
+          - --oidc-client-id=kubectl
+          - --oidc-use-pkce
+          - --oidc-extra-scope=profile
+          - --oidc-extra-scope=email
+          - --oidc-extra-scope=offline_access
+```
+
+Then add a context that pairs this user with the existing cluster, e.g.:
+
+```bash
+kubectl config set-context dapper-oidc --cluster=<existing-cluster> --user=oidc
+```
+
+`--oidc-use-pkce` means no client secret is needed; `offline_access` gives a refresh
+token so you are not re-prompted every hour.
+
+Verify:
+
+```bash
+kubectl --context dapper-oidc auth whoami          # -> oidc:<you> + oidc:kubernetes-admins
+kubectl --context dapper-oidc auth can-i '*' '*'   # -> yes (admins)
+```
+
+## Break-glass (when Authentik is down or misbehaving)
+
+Neither path below touches Authentik:
+
+1. **x509 admin kubeconfig** — switch back to the original admin context:
+   ```bash
+   kubectl config use-context <admin-context>
+   ```
+2. **Regenerate from Talos** — the Talos mTLS PKI is fully independent of Authentik:
+   ```bash
+   talosctl kubeconfig ./break-glass-kubeconfig
+   export KUBECONFIG=./break-glass-kubeconfig
+   ```
+
+Keep a copy of `talosconfig` / the admin kubeconfig backed up **off-cluster**. That
+backup is what makes the circular-dependency concern (Authentik runs _on_ the cluster
+you need it to reach) a non-issue.

--- a/kubernetes/apps/kube-system/kustomization.yaml
+++ b/kubernetes/apps/kube-system/kustomization.yaml
@@ -17,5 +17,6 @@ resources:
   - ./gpu-plugins/intel-device-plugin/ks.yaml
   - ./node-feature-discovery/ks.yaml
   - ./nut-upsd/ks.yaml
+  - ./oidc-rbac/ks.yaml
   - ./prometheus-operator-crds/ks.yaml
   - ./reflector/ks.yaml

--- a/kubernetes/apps/kube-system/oidc-rbac/app/kustomization.yaml
+++ b/kubernetes/apps/kube-system/oidc-rbac/app/kustomization.yaml
@@ -1,0 +1,6 @@
+# yaml-language-server: $schema=https://json.schemastore.org/kustomization
+---
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+resources:
+  - ./rbac.yaml

--- a/kubernetes/apps/kube-system/oidc-rbac/app/rbac.yaml
+++ b/kubernetes/apps/kube-system/oidc-rbac/app/rbac.yaml
@@ -1,0 +1,30 @@
+---
+# Maps Authentik groups (delivered via the apiserver oidc-groups-claim, prefixed
+# with "oidc:") to cluster RBAC. Group membership in Authentik = cluster access;
+# revoke there and access dies. The x509 admin kubeconfig is unaffected by these
+# and remains break-glass.
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRoleBinding
+metadata:
+  name: oidc-kubernetes-admins
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: ClusterRole
+  name: cluster-admin
+subjects:
+  - apiGroup: rbac.authorization.k8s.io
+    kind: Group
+    name: "oidc:kubernetes-admins"
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRoleBinding
+metadata:
+  name: oidc-kubernetes-viewers
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: ClusterRole
+  name: view
+subjects:
+  - apiGroup: rbac.authorization.k8s.io
+    kind: Group
+    name: "oidc:kubernetes-viewers"

--- a/kubernetes/apps/kube-system/oidc-rbac/ks.yaml
+++ b/kubernetes/apps/kube-system/oidc-rbac/ks.yaml
@@ -1,0 +1,22 @@
+---
+# yaml-language-server: $schema=https://kubernetes-schemas.pages.dev/kustomize.toolkit.fluxcd.io/kustomization_v1.json
+apiVersion: kustomize.toolkit.fluxcd.io/v1
+kind: Kustomization
+metadata:
+  name: &app oidc-rbac
+  namespace: &namespace kube-system
+spec:
+  targetNamespace: *namespace
+  commonMetadata:
+    labels:
+      app.kubernetes.io/name: *app
+  path: ./kubernetes/apps/kube-system/oidc-rbac/app
+  prune: true
+  sourceRef:
+    kind: GitRepository
+    name: flux-system
+    namespace: flux-system
+  wait: true
+  interval: 30m
+  retryInterval: 1m
+  timeout: 5m

--- a/kubernetes/apps/security/authentik/app/blueprints-oidc.yaml
+++ b/kubernetes/apps/security/authentik/app/blueprints-oidc.yaml
@@ -108,3 +108,42 @@ data:
         attrs:
           users:
             - !Find [authentik_core.user, [username, mackleyder]]
+      # kubectl — native k8s apiserver OIDC. Deliberately NOT the &oidc anchor:
+      # a CLI has no safe place for a client_secret, so this is a PUBLIC (PKCE)
+      # client with a PINNED client_id (Talos apiserver oidc-client-id references
+      # it verbatim, avoiding the auto-generated-id chicken-and-egg). Adds the
+      # offline_access scope so kubelogin can silently refresh. Redirect URIs are
+      # kubelogin's loopback listener. Issuer: https://sso.${SECRET_DOMAIN}/application/o/kubectl/
+      - model: authentik_providers_oauth2.oauth2provider
+        identifiers: { name: Kubernetes OIDC }
+        id: kubectl-oidc
+        attrs:
+          client_type: public
+          client_id: kubectl
+          grant_types: [authorization_code, refresh_token]
+          sub_mode: hashed_user_id
+          include_claims_in_id_token: true
+          authorization_flow: !Find [authentik_flows.flow, [slug, default-provider-authorization-implicit-consent]]
+          invalidation_flow: !Find [authentik_flows.flow, [slug, default-provider-invalidation-flow]]
+          signing_key: !Find [authentik_crypto.certificatekeypair, [name, authentik Self-signed Certificate]]
+          property_mappings:
+            - !Find [authentik_providers_oauth2.scopemapping, [managed, goauthentik.io/providers/oauth2/scope-openid]]
+            - !Find [authentik_providers_oauth2.scopemapping, [managed, goauthentik.io/providers/oauth2/scope-email]]
+            - !Find [authentik_providers_oauth2.scopemapping, [managed, goauthentik.io/providers/oauth2/scope-profile]]
+            - !Find [authentik_providers_oauth2.scopemapping, [managed, goauthentik.io/providers/oauth2/scope-offline_access]]
+          redirect_uris:
+            - { matching_mode: strict, url: "http://localhost:8000", redirect_uri_type: authorization }
+            - { matching_mode: strict, url: "http://localhost:18000", redirect_uri_type: authorization }
+      - model: authentik_core.application
+        identifiers: { slug: kubectl }
+        attrs: { name: Kubernetes (kubectl), group: internal, provider: !KeyOf kubectl-oidc, meta_icon: "https://cdn.jsdelivr.net/gh/selfhst/icons/svg/kubernetes.svg" }
+      # kubernetes-admins → cluster-admin, kubernetes-viewers → view (bound by the
+      # oidc-rbac ClusterRoleBindings). Membership here drives cluster access via
+      # the groups claim (apiserver oidc-groups-claim). viewers starts empty.
+      - model: authentik_core.group
+        identifiers: { name: kubernetes-admins }
+        attrs:
+          users:
+            - !Find [authentik_core.user, [username, mackleyder]]
+      - model: authentik_core.group
+        identifiers: { name: kubernetes-viewers }

--- a/kubernetes/bootstrap/talos/patches/controller/cluster.yaml
+++ b/kubernetes/bootstrap/talos/patches/controller/cluster.yaml
@@ -12,6 +12,17 @@ cluster:
       max-mutating-requests-inflight: "400"
       # Reduce watch cache memory usage
       default-watch-cache-size: "100"
+      # Authentik OIDC login (kubectl via kubelogin). Additive to x509 cert auth,
+      # which stays the untouchable break-glass. Legacy flags on purpose: the
+      # apiserver fetches JWKS lazily, so a down/unreachable Authentik never blocks
+      # apiserver startup (only OIDC token validation degrades; cert auth is intact).
+      # Issuer needs the trailing slash. sso.* uses a public LE cert -> no oidc-ca-file.
+      oidc-issuer-url: "https://sso.chelonianlabs.com/application/o/kubectl/"
+      oidc-client-id: "kubectl"
+      oidc-username-claim: "preferred_username"
+      oidc-username-prefix: "oidc:"
+      oidc-groups-claim: "groups"
+      oidc-groups-prefix: "oidc:"
     resources:
       requests:
         cpu: 500m
@@ -35,12 +46,12 @@ cluster:
   etcd:
     extraArgs:
       listen-metrics-urls: http://0.0.0.0:2381
-      quota-backend-bytes: "1073741824"  # 1 GiB (double peak usage of ~350MB)
+      quota-backend-bytes: "1073741824" # 1 GiB (double peak usage of ~350MB)
       # Widen raft timeouts to tolerate ~20-22ms WAL fsync latency on Proxmox VM
       # disks (SSD/hardware migration ruled out). Stops leader flapping when a
       # heartbeat is delayed by a slow fsync. election-timeout is 10x heartbeat.
-      heartbeat-interval: "250"   # default 100ms
-      election-timeout: "2500"    # default 1000ms
+      heartbeat-interval: "250" # default 100ms
+      election-timeout: "2500" # default 1000ms
     advertisedSubnets:
       - 10.100.0.0/24
   proxy:


### PR DESCRIPTION
## What

Native kube-apiserver **OIDC auth against Authentik** for \`kubectl\`, layered as an *additive, revocable* convenience on top of the existing x509 admin kubeconfig — which stays untouched as break-glass. Authentik group membership maps to cluster RBAC.

This is **Phase 1** of a larger SSO effort (Headlamp web UI and a step-ca SSH CA are planned follow-ups).

## Changes

- **Authentik** (\`blueprints-oidc.yaml\`): a public/PKCE \`kubectl\` OIDC provider with a **pinned \`client_id: kubectl\`** (a CLI has no safe place for a secret; pinning avoids the auto-generated-id chicken-and-egg with Talos). Adds \`kubernetes-admins\` / \`kubernetes-viewers\` groups.
- **Talos** (\`patches/controller/cluster.yaml\`): apiserver \`oidc-*\` flags. Legacy flag form on purpose — JWKS is fetched lazily, so a down/unreachable Authentik **never blocks apiserver startup**; only OIDC token validation degrades, cert auth is intact.
- **oidc-rbac** (\`kube-system/oidc-rbac/\`): ClusterRoleBindings \`oidc:kubernetes-admins\`→\`cluster-admin\`, \`oidc:kubernetes-viewers\`→\`view\`.
- **docs**: SSO cluster-access + break-glass runbook.

## Rollout (after merge)

1. Reconcile → Authentik creates the \`kubectl\` client + groups.
2. \`task talos:generate-config && task talos:apply-cluster\` (rolling apiserver restart).
3. Local kubeconfig via \`kubelogin\` (see docs), then verify \`kubectl auth whoami\` / \`can-i\`.

## Break-glass preserved

The x509 admin kubeconfig (cert exp Feb 2027) and \`talosctl kubeconfig\` regeneration both validate locally with **zero Authentik dependency**. Verification includes confirming break-glass still works with Authentik "out of the loop."

## Note to verify live

Confirm Authentik's \`profile\` scope emits the \`groups\` claim in the ID token (Grafana's Admin mapping implies it does). If not, add a dedicated groups scope mapping.