### PR TITLE
feat(headlamp): SSO web dashboard via Authentik OIDC (per-user RBAC)

### DIFF
--- a/docs/src/operations/sso-cluster-access.md
+++ b/docs/src/operations/sso-cluster-access.md
@@ -56,7 +56,7 @@ users:
           - get-token
           - --oidc-issuer-url=https://sso.chelonianlabs.com/application/o/kubectl/
           - --oidc-client-id=kubectl
-          - --oidc-use-pkce
+          - --oidc-pkce-method=S256
           - --oidc-extra-scope=profile
           - --oidc-extra-scope=email
           - --oidc-extra-scope=offline_access
@@ -68,7 +68,7 @@ Then add a context that pairs this user with the existing cluster, e.g.:
 kubectl config set-context dapper-oidc --cluster=<existing-cluster> --user=oidc
 ```
 
-`--oidc-use-pkce` means no client secret is needed; `offline_access` gives a refresh
+`--oidc-pkce-method=S256` means no client secret is needed; `offline_access` gives a refresh
 token so you are not re-prompted every hour.
 
 Verify:

--- a/kubernetes/apps/kube-system/headlamp/app/externalsecret.yaml
+++ b/kubernetes/apps/kube-system/headlamp/app/externalsecret.yaml
@@ -1,0 +1,25 @@
+---
+# yaml-language-server: $schema=https://kubernetes-schemas.pages.dev/external-secrets.io/externalsecret_v1beta1.json
+apiVersion: external-secrets.io/v1
+kind: ExternalSecret
+metadata:
+  name: headlamp-oidc
+spec:
+  secretStoreRef:
+    kind: ClusterSecretStore
+    name: infisical
+  target:
+    name: headlamp-oidc-secret
+    template:
+      engineVersion: v2
+      data:
+        # client_id is pinned in the Authentik blueprint; issuer + scopes are static.
+        # Only the client_secret is a real secret (Authentik-generated → Infisical).
+        OIDC_CLIENT_ID: "headlamp"
+        OIDC_CLIENT_SECRET: "{{ .HEADLAMP_OIDC_CLIENT_SECRET }}"
+        OIDC_ISSUER_URL: "https://sso.${SECRET_DOMAIN}/application/o/headlamp/"
+        OIDC_SCOPES: "openid profile email kubernetes-audience"
+  dataFrom:
+    - find:
+        name:
+          regexp: ^HEADLAMP_OIDC_CLIENT_SECRET$

--- a/kubernetes/apps/kube-system/headlamp/app/helmrelease.yaml
+++ b/kubernetes/apps/kube-system/headlamp/app/helmrelease.yaml
@@ -1,0 +1,40 @@
+---
+# yaml-language-server: $schema=https://kubernetes-schemas.pages.dev/helm.toolkit.fluxcd.io/helmrelease_v2.json
+apiVersion: helm.toolkit.fluxcd.io/v2
+kind: HelmRelease
+metadata:
+  name: headlamp
+spec:
+  interval: 1h
+  chart:
+    spec:
+      chart: headlamp
+      version: 0.43.0
+      sourceRef:
+        kind: HelmRepository
+        name: headlamp
+        namespace: flux-system
+  install:
+    remediation:
+      retries: 3
+  upgrade:
+    remediation:
+      retries: 3
+  values:
+    fullnameOverride: headlamp
+    config:
+      oidc:
+        # client_id/secret/issuer/scopes come from the Infisical-backed secret below.
+        externalSecret:
+          enabled: true
+          name: headlamp-oidc-secret
+          hasScopes: true
+    # Per-user RBAC: Headlamp forwards the logged-in user's OIDC token to the apiserver,
+    # so the pod SA must NOT hold cluster perms. The chart's default binds the SA to
+    # cluster-admin — disable it, or everyone reaching Headlamp would be admin.
+    clusterRoleBinding:
+      create: false
+    serviceAccount:
+      create: true
+    ingress:
+      enabled: false

--- a/kubernetes/apps/kube-system/headlamp/app/httproute.yaml
+++ b/kubernetes/apps/kube-system/headlamp/app/httproute.yaml
@@ -1,0 +1,14 @@
+---
+apiVersion: gateway.networking.k8s.io/v1
+kind: HTTPRoute
+metadata:
+  name: headlamp
+spec:
+  parentRefs:
+    - name: internal
+      namespace: network
+  hostnames: ["headlamp.${SECRET_DOMAIN}"]
+  rules:
+    - backendRefs:
+        - name: headlamp
+          port: 80

--- a/kubernetes/apps/kube-system/headlamp/app/kustomization.yaml
+++ b/kubernetes/apps/kube-system/headlamp/app/kustomization.yaml
@@ -1,0 +1,8 @@
+# yaml-language-server: $schema=https://json.schemastore.org/kustomization
+---
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+resources:
+  - ./externalsecret.yaml
+  - ./helmrelease.yaml
+  - ./httproute.yaml

--- a/kubernetes/apps/kube-system/headlamp/ks.yaml
+++ b/kubernetes/apps/kube-system/headlamp/ks.yaml
@@ -1,0 +1,22 @@
+---
+# yaml-language-server: $schema=https://kubernetes-schemas.pages.dev/kustomize.toolkit.fluxcd.io/kustomization_v1.json
+apiVersion: kustomize.toolkit.fluxcd.io/v1
+kind: Kustomization
+metadata:
+  name: &app headlamp
+  namespace: &namespace kube-system
+spec:
+  targetNamespace: *namespace
+  commonMetadata:
+    labels:
+      app.kubernetes.io/name: *app
+  path: ./kubernetes/apps/kube-system/headlamp/app
+  prune: true
+  sourceRef:
+    kind: GitRepository
+    name: flux-system
+    namespace: flux-system
+  wait: true
+  interval: 30m
+  retryInterval: 1m
+  timeout: 5m

--- a/kubernetes/apps/kube-system/kustomization.yaml
+++ b/kubernetes/apps/kube-system/kustomization.yaml
@@ -10,6 +10,7 @@ resources:
   - ./cilium/ks.yaml
   - ./coredns/ks.yaml
   - ./descheduler/ks.yaml
+  - ./headlamp/ks.yaml
   - ./metrics-server/ks.yaml
   - ./reloader/ks.yaml
   - ./spegel/ks.yaml

--- a/kubernetes/apps/security/authentik/app/blueprints-oidc.yaml
+++ b/kubernetes/apps/security/authentik/app/blueprints-oidc.yaml
@@ -147,3 +147,33 @@ data:
             - !Find [authentik_core.user, [username, mackleyder]]
       - model: authentik_core.group
         identifiers: { name: kubernetes-viewers }
+      # Headlamp (web k8s dashboard) — confidential OIDC client, per-user RBAC via
+      # token pass-through (Headlamp forwards the user's id_token to the apiserver).
+      # The apiserver runs --oidc-client-id=kubectl, so the token's aud MUST contain
+      # `kubectl`; Headlamp's own verifier needs `headlamp`. This scope mapping sets
+      # aud to BOTH (apiserver does array-contains matching). Requested via the
+      # `kubernetes-audience` scope in Headlamp's OIDC_SCOPES.
+      - model: authentik_providers_oauth2.scopemapping
+        identifiers: { name: Kubernetes API audience }
+        id: k8s-audience
+        attrs:
+          scope_name: kubernetes-audience
+          description: "Sets token aud to [headlamp, kubectl] so kube-apiserver (oidc-client-id=kubectl) accepts Headlamp-forwarded tokens"
+          expression: |
+            return {"aud": ["headlamp", "kubectl"]}
+      - model: authentik_providers_oauth2.oauth2provider
+        identifiers: { name: Headlamp OIDC }
+        id: headlamp-oidc
+        attrs:
+          <<: *oidc
+          client_id: headlamp   # pinned; Authentik still generates the client_secret (→ Infisical HEADLAMP_OIDC_CLIENT_SECRET)
+          property_mappings:     # re-list the anchor's 3 + the audience mapping (override replaces the whole list)
+            - !Find [authentik_providers_oauth2.scopemapping, [managed, goauthentik.io/providers/oauth2/scope-openid]]
+            - !Find [authentik_providers_oauth2.scopemapping, [managed, goauthentik.io/providers/oauth2/scope-email]]
+            - !Find [authentik_providers_oauth2.scopemapping, [managed, goauthentik.io/providers/oauth2/scope-profile]]
+            - !KeyOf k8s-audience
+          redirect_uris:
+            - { matching_mode: strict, url: "https://headlamp.${SECRET_DOMAIN}/oidc-callback", redirect_uri_type: authorization }
+      - model: authentik_core.application
+        identifiers: { slug: headlamp }
+        attrs: { name: Headlamp, group: internal, provider: !KeyOf headlamp-oidc, meta_icon: "https://cdn.jsdelivr.net/gh/selfhst/icons/svg/headlamp.svg", meta_launch_url: "https://headlamp.${SECRET_DOMAIN}" }

--- a/kubernetes/flux/meta/repositories/helm/headlamp.yaml
+++ b/kubernetes/flux/meta/repositories/helm/headlamp.yaml
@@ -1,0 +1,10 @@
+---
+apiVersion: source.toolkit.fluxcd.io/v1
+kind: HelmRepository
+metadata:
+  name: headlamp
+  namespace: flux-system
+spec:
+  interval: 1h
+  url: https://kubernetes-sigs.github.io/headlamp/
+  timeout: 3m

--- a/kubernetes/flux/meta/repositories/helm/kustomization.yaml
+++ b/kubernetes/flux/meta/repositories/helm/kustomization.yaml
@@ -12,6 +12,7 @@ resources:
   - ./emqx.yaml
   - ./external-secrets.yaml
   - ./fairwinds.yaml
+  - ./headlamp.yaml
   - ./infisical.yaml
   - ./intel.yaml
   - ./k8s-gateway.yaml


### PR DESCRIPTION
## What

**Phase 2** of the SSO effort: [Headlamp](https://headlamp.dev) — a web Kubernetes dashboard — behind the same Authentik SSO, with **per-user RBAC** (it forwards each logged-in user's OIDC token to the apiserver, so admins get admin and viewers get view, mirroring kubectl). Also includes the deprecated-flag doc fix from Phase 1.

## The audience crux (and fix)

The apiserver runs `--oidc-client-id=kubectl`, so it only accepts tokens whose `aud` contains `kubectl`. Headlamp needs a **confidential** client (it can't do secret-less public/PKCE) and forwards a token whose `aud` = its own client_id. Fix: an Authentik **scope mapping** (`kubernetes-audience`) sets the token `aud` to `[headlamp, kubectl]` — Headlamp's own verifier is satisfied by `headlamp`, the apiserver by `kubectl` (apiserver does array-*contains* matching). The public `kubectl` CLI client is untouched.

## Security note

The chart's default binds its ServiceAccount to **cluster-admin** — **disabled** here (`clusterRoleBinding.create: false`). Headlamp uses *only* the forwarded user token, so the pod SA holds no cluster perms.

## Deploy sequence (after merge)

1. Reconcile → Authentik creates the `headlamp` provider + generates a **client_secret**.
2. Copy that secret into Infisical as **`HEADLAMP_OIDC_CLIENT_SECRET`** (ExternalSecret `find:name` picks it up). *Headlamp won't start until this exists.*
3. Headlamp comes up at `https://headlamp.${SECRET_DOMAIN}`.
4. **Verify live**: log in, decode the id_token, confirm `aud` = `[headlamp, kubectl]` and that a viewer sees read-only. (If Authentik doesn't override `aud` as expected, adjust the scope mapping — risk is isolated to Headlamp.)

## Files
- `security/authentik/app/blueprints-oidc.yaml` — headlamp provider + `k8s-audience` scope mapping + app
- `kube-system/headlamp/` — chart 0.43.0, OIDC via ExternalSecret, internal HTTPRoute
- `flux/meta/repositories/helm/headlamp.yaml` — HelmRepository