### PR TITLE
feat(observability): add per-port switch Grafana dashboards

### DIFF
--- a/kubernetes/apps/observability/grafana/instance/dashboards/snmp-all-switches.json
+++ b/kubernetes/apps/observability/grafana/instance/dashboards/snmp-all-switches.json
@@ -22,7 +22,7 @@
       {
         "name": "device",
         "type": "query",
-        "datasource": { "type": "prometheus", "uid": "${datasource}" },
+        "datasource": { "type": "prometheus", "uid": "$${datasource}" },
         "query": "label_values(ifIndex, target)",
         "refresh": 2,
         "includeAll": true,
@@ -46,7 +46,7 @@
       "type": "stat",
       "title": "Ports up",
       "gridPos": { "h": 4, "w": 4, "x": 0, "y": 1 },
-      "datasource": { "type": "prometheus", "uid": "${datasource}" },
+      "datasource": { "type": "prometheus", "uid": "$${datasource}" },
       "targets": [
         { "refId": "A", "expr": "count(ifOperStatus{target=\"$device\"} == 1) or vector(0)" }
       ],
@@ -56,7 +56,7 @@
           "links": [
             {
               "title": "Open port detail",
-              "url": "/d/snmp-switch-ports?var-device=${device}&${__url_time_range}",
+              "url": "/d/snmp-switch-ports?var-device=$${device}&$${__url_time_range}",
               "targetBlank": false
             }
           ]
@@ -74,7 +74,7 @@
       "type": "stat",
       "title": "Down (admin-up)",
       "gridPos": { "h": 4, "w": 4, "x": 4, "y": 1 },
-      "datasource": { "type": "prometheus", "uid": "${datasource}" },
+      "datasource": { "type": "prometheus", "uid": "$${datasource}" },
       "targets": [
         {
           "refId": "A",
@@ -104,7 +104,7 @@
       "type": "stat",
       "title": "Inbound",
       "gridPos": { "h": 4, "w": 4, "x": 8, "y": 1 },
-      "datasource": { "type": "prometheus", "uid": "${datasource}" },
+      "datasource": { "type": "prometheus", "uid": "$${datasource}" },
       "targets": [
         { "refId": "A", "expr": "sum(rate(ifHCInOctets{target=\"$device\"}[5m]) * 8) or vector(0)" }
       ],
@@ -123,7 +123,7 @@
       "type": "stat",
       "title": "Outbound",
       "gridPos": { "h": 4, "w": 4, "x": 12, "y": 1 },
-      "datasource": { "type": "prometheus", "uid": "${datasource}" },
+      "datasource": { "type": "prometheus", "uid": "$${datasource}" },
       "targets": [
         {
           "refId": "A",
@@ -145,7 +145,7 @@
       "type": "stat",
       "title": "Error+discard rate",
       "gridPos": { "h": 4, "w": 4, "x": 16, "y": 1 },
-      "datasource": { "type": "prometheus", "uid": "${datasource}" },
+      "datasource": { "type": "prometheus", "uid": "$${datasource}" },
       "targets": [
         {
           "refId": "A",
@@ -177,7 +177,7 @@
       "type": "stat",
       "title": "Ports total",
       "gridPos": { "h": 4, "w": 4, "x": 20, "y": 1 },
-      "datasource": { "type": "prometheus", "uid": "${datasource}" },
+      "datasource": { "type": "prometheus", "uid": "$${datasource}" },
       "targets": [{ "refId": "A", "expr": "count(ifOperStatus{target=\"$device\"}) or vector(0)" }],
       "fieldConfig": {
         "defaults": { "color": { "mode": "fixed", "fixedColor": "text" } },
@@ -194,7 +194,7 @@
       "type": "timeseries",
       "title": "Per-port throughput (top 10 in / out)",
       "gridPos": { "h": 8, "w": 24, "x": 0, "y": 5 },
-      "datasource": { "type": "prometheus", "uid": "${datasource}" },
+      "datasource": { "type": "prometheus", "uid": "$${datasource}" },
       "targets": [
         {
           "refId": "A",

--- a/kubernetes/apps/observability/grafana/instance/dashboards/snmp-all-switches.json
+++ b/kubernetes/apps/observability/grafana/instance/dashboards/snmp-all-switches.json
@@ -1,0 +1,223 @@
+{
+  "annotations": { "list": [] },
+  "editable": true,
+  "graphTooltip": 1,
+  "title": "Network / All Switches",
+  "uid": "snmp-all-switches",
+  "tags": ["network", "snmp", "switch"],
+  "timezone": "",
+  "schemaVersion": 39,
+  "time": { "from": "now-3h", "to": "now" },
+  "refresh": "1m",
+  "templating": {
+    "list": [
+      {
+        "name": "datasource",
+        "type": "datasource",
+        "query": "prometheus",
+        "current": {},
+        "hide": 0,
+        "label": "Datasource"
+      },
+      {
+        "name": "device",
+        "type": "query",
+        "datasource": { "type": "prometheus", "uid": "${datasource}" },
+        "query": "label_values(ifIndex, target)",
+        "refresh": 2,
+        "includeAll": true,
+        "multi": true,
+        "current": { "text": "All", "value": "$__all" },
+        "label": "Device",
+        "sort": 1
+      }
+    ]
+  },
+  "panels": [
+    {
+      "type": "row",
+      "title": "$device",
+      "collapsed": false,
+      "repeat": "device",
+      "repeatDirection": "v",
+      "gridPos": { "h": 1, "w": 24, "x": 0, "y": 0 }
+    },
+    {
+      "type": "stat",
+      "title": "Ports up",
+      "gridPos": { "h": 4, "w": 4, "x": 0, "y": 1 },
+      "datasource": { "type": "prometheus", "uid": "${datasource}" },
+      "targets": [
+        { "refId": "A", "expr": "count(ifOperStatus{target=\"$device\"} == 1) or vector(0)" }
+      ],
+      "fieldConfig": {
+        "defaults": {
+          "color": { "mode": "fixed", "fixedColor": "green" },
+          "links": [
+            {
+              "title": "Open port detail",
+              "url": "/d/snmp-switch-ports?var-device=${device}&${__url_time_range}",
+              "targetBlank": false
+            }
+          ]
+        },
+        "overrides": []
+      },
+      "options": {
+        "colorMode": "value",
+        "graphMode": "none",
+        "textMode": "value",
+        "reduceOptions": { "calcs": ["lastNotNull"] }
+      }
+    },
+    {
+      "type": "stat",
+      "title": "Down (admin-up)",
+      "gridPos": { "h": 4, "w": 4, "x": 4, "y": 1 },
+      "datasource": { "type": "prometheus", "uid": "${datasource}" },
+      "targets": [
+        {
+          "refId": "A",
+          "expr": "count((ifOperStatus{target=\"$device\"} == 2) and on (instance, ifIndex) (ifAdminStatus == 1)) or vector(0)"
+        }
+      ],
+      "fieldConfig": {
+        "defaults": {
+          "color": { "mode": "thresholds" },
+          "thresholds": {
+            "steps": [
+              { "color": "green", "value": null },
+              { "color": "red", "value": 1 }
+            ]
+          }
+        },
+        "overrides": []
+      },
+      "options": {
+        "colorMode": "background",
+        "graphMode": "none",
+        "textMode": "value",
+        "reduceOptions": { "calcs": ["lastNotNull"] }
+      }
+    },
+    {
+      "type": "stat",
+      "title": "Inbound",
+      "gridPos": { "h": 4, "w": 4, "x": 8, "y": 1 },
+      "datasource": { "type": "prometheus", "uid": "${datasource}" },
+      "targets": [
+        { "refId": "A", "expr": "sum(rate(ifHCInOctets{target=\"$device\"}[5m]) * 8) or vector(0)" }
+      ],
+      "fieldConfig": {
+        "defaults": { "unit": "bps", "color": { "mode": "fixed", "fixedColor": "blue" } },
+        "overrides": []
+      },
+      "options": {
+        "colorMode": "value",
+        "graphMode": "area",
+        "textMode": "value",
+        "reduceOptions": { "calcs": ["lastNotNull"] }
+      }
+    },
+    {
+      "type": "stat",
+      "title": "Outbound",
+      "gridPos": { "h": 4, "w": 4, "x": 12, "y": 1 },
+      "datasource": { "type": "prometheus", "uid": "${datasource}" },
+      "targets": [
+        {
+          "refId": "A",
+          "expr": "sum(rate(ifHCOutOctets{target=\"$device\"}[5m]) * 8) or vector(0)"
+        }
+      ],
+      "fieldConfig": {
+        "defaults": { "unit": "bps", "color": { "mode": "fixed", "fixedColor": "purple" } },
+        "overrides": []
+      },
+      "options": {
+        "colorMode": "value",
+        "graphMode": "area",
+        "textMode": "value",
+        "reduceOptions": { "calcs": ["lastNotNull"] }
+      }
+    },
+    {
+      "type": "stat",
+      "title": "Error+discard rate",
+      "gridPos": { "h": 4, "w": 4, "x": 16, "y": 1 },
+      "datasource": { "type": "prometheus", "uid": "${datasource}" },
+      "targets": [
+        {
+          "refId": "A",
+          "expr": "sum(rate(ifInErrors{target=\"$device\"}[5m]) + rate(ifOutErrors{target=\"$device\"}[5m]) + rate(ifInDiscards{target=\"$device\"}[5m]) + rate(ifOutDiscards{target=\"$device\"}[5m])) or vector(0)"
+        }
+      ],
+      "fieldConfig": {
+        "defaults": {
+          "unit": "pps",
+          "color": { "mode": "thresholds" },
+          "thresholds": {
+            "steps": [
+              { "color": "green", "value": null },
+              { "color": "yellow", "value": 0.5 },
+              { "color": "red", "value": 5 }
+            ]
+          }
+        },
+        "overrides": []
+      },
+      "options": {
+        "colorMode": "background",
+        "graphMode": "area",
+        "textMode": "value",
+        "reduceOptions": { "calcs": ["lastNotNull"] }
+      }
+    },
+    {
+      "type": "stat",
+      "title": "Ports total",
+      "gridPos": { "h": 4, "w": 4, "x": 20, "y": 1 },
+      "datasource": { "type": "prometheus", "uid": "${datasource}" },
+      "targets": [{ "refId": "A", "expr": "count(ifOperStatus{target=\"$device\"}) or vector(0)" }],
+      "fieldConfig": {
+        "defaults": { "color": { "mode": "fixed", "fixedColor": "text" } },
+        "overrides": []
+      },
+      "options": {
+        "colorMode": "value",
+        "graphMode": "none",
+        "textMode": "value",
+        "reduceOptions": { "calcs": ["lastNotNull"] }
+      }
+    },
+    {
+      "type": "timeseries",
+      "title": "Per-port throughput (top 10 in / out)",
+      "gridPos": { "h": 8, "w": 24, "x": 0, "y": 5 },
+      "datasource": { "type": "prometheus", "uid": "${datasource}" },
+      "targets": [
+        {
+          "refId": "A",
+          "expr": "topk(10, rate(ifHCInOctets{target=\"$device\"}[5m]) * 8)",
+          "legendFormat": "{{ifName}} in"
+        },
+        {
+          "refId": "B",
+          "expr": "topk(10, rate(ifHCOutOctets{target=\"$device\"}[5m]) * 8)",
+          "legendFormat": "{{ifName}} out"
+        }
+      ],
+      "fieldConfig": {
+        "defaults": {
+          "unit": "bps",
+          "custom": { "drawStyle": "line", "fillOpacity": 10, "showPoints": "never" }
+        },
+        "overrides": []
+      },
+      "options": {
+        "legend": { "displayMode": "table", "placement": "right", "calcs": ["max", "mean"] },
+        "tooltip": { "mode": "multi", "sort": "desc" }
+      }
+    }
+  ]
+}

--- a/kubernetes/apps/observability/grafana/instance/dashboards/snmp-fabric-overview.json
+++ b/kubernetes/apps/observability/grafana/instance/dashboards/snmp-fabric-overview.json
@@ -1,0 +1,407 @@
+{
+  "annotations": { "list": [] },
+  "editable": true,
+  "graphTooltip": 1,
+  "title": "Network / Fabric Overview",
+  "uid": "snmp-fabric-overview",
+  "tags": ["network", "snmp", "switch"],
+  "timezone": "",
+  "schemaVersion": 39,
+  "time": { "from": "now-3h", "to": "now" },
+  "refresh": "1m",
+  "templating": {
+    "list": [
+      {
+        "name": "datasource",
+        "type": "datasource",
+        "query": "prometheus",
+        "current": {},
+        "hide": 0,
+        "label": "Datasource"
+      }
+    ]
+  },
+  "panels": [
+    {
+      "type": "table",
+      "title": "Fabric health — click a device to drill into its ports",
+      "gridPos": { "h": 8, "w": 24, "x": 0, "y": 0 },
+      "datasource": { "type": "prometheus", "uid": "${datasource}" },
+      "targets": [
+        {
+          "refId": "A",
+          "instant": true,
+          "format": "table",
+          "expr": "count by (target) (ifOperStatus == 1)"
+        },
+        {
+          "refId": "B",
+          "instant": true,
+          "format": "table",
+          "expr": "count by (target) ((ifOperStatus == 2) and on (instance, ifIndex) (ifAdminStatus == 1))"
+        },
+        {
+          "refId": "C",
+          "instant": true,
+          "format": "table",
+          "expr": "sum by (target) (rate(ifHCInOctets[5m]) * 8)"
+        },
+        {
+          "refId": "D",
+          "instant": true,
+          "format": "table",
+          "expr": "sum by (target) (rate(ifHCOutOctets[5m]) * 8)"
+        },
+        {
+          "refId": "E",
+          "instant": true,
+          "format": "table",
+          "expr": "sum by (target) (rate(ifInErrors[5m]) + rate(ifOutErrors[5m]) + rate(ifInDiscards[5m]) + rate(ifOutDiscards[5m]))"
+        }
+      ],
+      "transformations": [
+        { "id": "merge", "options": {} },
+        {
+          "id": "organize",
+          "options": {
+            "excludeByName": { "Time": true },
+            "renameByName": {
+              "target": "Device",
+              "Value #A": "Ports up",
+              "Value #B": "Down (admin-up)",
+              "Value #C": "Aggregate in",
+              "Value #D": "Aggregate out",
+              "Value #E": "Err+discard rate"
+            },
+            "indexByName": {
+              "target": 0,
+              "Value #A": 1,
+              "Value #B": 2,
+              "Value #C": 3,
+              "Value #D": 4,
+              "Value #E": 5
+            }
+          }
+        }
+      ],
+      "fieldConfig": {
+        "defaults": {},
+        "overrides": [
+          {
+            "matcher": { "id": "byName", "options": "Device" },
+            "properties": [
+              {
+                "id": "links",
+                "value": [
+                  {
+                    "title": "Open ${__value.text} port detail",
+                    "url": "/d/snmp-switch-ports?var-device=${__value.text}&${__url_time_range}",
+                    "targetBlank": false
+                  }
+                ]
+              },
+              { "id": "custom.cellOptions", "value": { "type": "color-text" } },
+              { "id": "color", "value": { "mode": "fixed", "fixedColor": "blue" } }
+            ]
+          },
+          {
+            "matcher": { "id": "byName", "options": "Down (admin-up)" },
+            "properties": [
+              { "id": "noValue", "value": "0" },
+              {
+                "id": "custom.cellOptions",
+                "value": { "type": "color-background", "mode": "gradient" }
+              },
+              {
+                "id": "thresholds",
+                "value": {
+                  "steps": [
+                    { "color": "transparent", "value": null },
+                    { "color": "red", "value": 1 }
+                  ]
+                }
+              }
+            ]
+          },
+          {
+            "matcher": { "id": "byName", "options": "Aggregate in" },
+            "properties": [{ "id": "unit", "value": "bps" }]
+          },
+          {
+            "matcher": { "id": "byName", "options": "Aggregate out" },
+            "properties": [{ "id": "unit", "value": "bps" }]
+          },
+          {
+            "matcher": { "id": "byName", "options": "Err+discard rate" },
+            "properties": [
+              { "id": "unit", "value": "pps" },
+              {
+                "id": "custom.cellOptions",
+                "value": { "type": "color-background", "mode": "gradient" }
+              },
+              {
+                "id": "thresholds",
+                "value": {
+                  "steps": [
+                    { "color": "transparent", "value": null },
+                    { "color": "yellow", "value": 0.5 },
+                    { "color": "red", "value": 5 }
+                  ]
+                }
+              }
+            ]
+          }
+        ]
+      },
+      "options": {
+        "showHeader": true,
+        "cellHeight": "md",
+        "footer": { "show": false },
+        "sortBy": [{ "displayName": "Device", "desc": false }]
+      }
+    },
+    {
+      "type": "row",
+      "title": "House",
+      "collapsed": false,
+      "gridPos": { "h": 1, "w": 24, "x": 0, "y": 8 }
+    },
+    {
+      "type": "stat",
+      "title": "OPNsense · .1",
+      "gridPos": { "h": 5, "w": 8, "x": 0, "y": 9 },
+      "datasource": { "type": "prometheus", "uid": "${datasource}" },
+      "targets": [
+        {
+          "refId": "A",
+          "expr": "sum(rate(ifHCInOctets{target=\"opnsense\"}[5m]) * 8) + sum(rate(ifHCOutOctets{target=\"opnsense\"}[5m]) * 8)"
+        }
+      ],
+      "fieldConfig": {
+        "defaults": {
+          "unit": "bps",
+          "color": { "mode": "fixed", "fixedColor": "blue" },
+          "noValue": "unreachable",
+          "links": [
+            {
+              "title": "Open port detail",
+              "url": "/d/snmp-switch-ports?var-device=opnsense&${__url_time_range}",
+              "targetBlank": false
+            }
+          ]
+        },
+        "overrides": []
+      },
+      "options": {
+        "colorMode": "value",
+        "graphMode": "area",
+        "textMode": "value",
+        "reduceOptions": { "calcs": ["lastNotNull"] }
+      }
+    },
+    {
+      "type": "stat",
+      "title": "Aruba S2500 · .26",
+      "gridPos": { "h": 5, "w": 8, "x": 8, "y": 9 },
+      "datasource": { "type": "prometheus", "uid": "${datasource}" },
+      "targets": [
+        {
+          "refId": "A",
+          "expr": "sum(rate(ifHCInOctets{target=\"aruba-access\"}[5m]) * 8) + sum(rate(ifHCOutOctets{target=\"aruba-access\"}[5m]) * 8)"
+        }
+      ],
+      "fieldConfig": {
+        "defaults": {
+          "unit": "bps",
+          "color": { "mode": "fixed", "fixedColor": "blue" },
+          "noValue": "unreachable",
+          "links": [
+            {
+              "title": "Open port detail",
+              "url": "/d/snmp-switch-ports?var-device=aruba-access&${__url_time_range}",
+              "targetBlank": false
+            }
+          ]
+        },
+        "overrides": []
+      },
+      "options": {
+        "colorMode": "value",
+        "graphMode": "area",
+        "textMode": "value",
+        "reduceOptions": { "calcs": ["lastNotNull"] }
+      }
+    },
+    {
+      "type": "stat",
+      "title": "NRay house · .7",
+      "gridPos": { "h": 5, "w": 8, "x": 16, "y": 9 },
+      "datasource": { "type": "prometheus", "uid": "${datasource}" },
+      "targets": [
+        {
+          "refId": "A",
+          "expr": "sum(rate(ifHCInOctets{target=\"nray-house\"}[5m]) * 8) + sum(rate(ifHCOutOctets{target=\"nray-house\"}[5m]) * 8)"
+        }
+      ],
+      "fieldConfig": {
+        "defaults": {
+          "unit": "bps",
+          "color": { "mode": "fixed", "fixedColor": "orange" },
+          "noValue": "unreachable",
+          "links": [
+            {
+              "title": "Open port detail",
+              "url": "/d/snmp-switch-ports?var-device=nray-house&${__url_time_range}",
+              "targetBlank": false
+            }
+          ]
+        },
+        "overrides": []
+      },
+      "options": {
+        "colorMode": "value",
+        "graphMode": "area",
+        "textMode": "value",
+        "reduceOptions": { "calcs": ["lastNotNull"] }
+      }
+    },
+    {
+      "type": "row",
+      "title": "Garage / Shop",
+      "collapsed": false,
+      "gridPos": { "h": 1, "w": 24, "x": 0, "y": 14 }
+    },
+    {
+      "type": "stat",
+      "title": "NRay shop · .8",
+      "gridPos": { "h": 5, "w": 6, "x": 0, "y": 15 },
+      "datasource": { "type": "prometheus", "uid": "${datasource}" },
+      "targets": [
+        {
+          "refId": "A",
+          "expr": "sum(rate(ifHCInOctets{target=\"nray-shop\"}[5m]) * 8) + sum(rate(ifHCOutOctets{target=\"nray-shop\"}[5m]) * 8)"
+        }
+      ],
+      "fieldConfig": {
+        "defaults": {
+          "unit": "bps",
+          "color": { "mode": "fixed", "fixedColor": "orange" },
+          "noValue": "unreachable",
+          "links": [
+            {
+              "title": "Open port detail",
+              "url": "/d/snmp-switch-ports?var-device=nray-shop&${__url_time_range}",
+              "targetBlank": false
+            }
+          ]
+        },
+        "overrides": []
+      },
+      "options": {
+        "colorMode": "value",
+        "graphMode": "area",
+        "textMode": "value",
+        "reduceOptions": { "calcs": ["lastNotNull"] }
+      }
+    },
+    {
+      "type": "stat",
+      "title": "CSS326 · .27",
+      "gridPos": { "h": 5, "w": 6, "x": 6, "y": 15 },
+      "datasource": { "type": "prometheus", "uid": "${datasource}" },
+      "targets": [
+        {
+          "refId": "A",
+          "expr": "sum(rate(ifHCInOctets{target=\"css326-bridge\"}[5m]) * 8) + sum(rate(ifHCOutOctets{target=\"css326-bridge\"}[5m]) * 8)"
+        }
+      ],
+      "fieldConfig": {
+        "defaults": {
+          "unit": "bps",
+          "color": { "mode": "fixed", "fixedColor": "green" },
+          "noValue": "unreachable",
+          "links": [
+            {
+              "title": "Open port detail",
+              "url": "/d/snmp-switch-ports?var-device=css326-bridge&${__url_time_range}",
+              "targetBlank": false
+            }
+          ]
+        },
+        "overrides": []
+      },
+      "options": {
+        "colorMode": "value",
+        "graphMode": "area",
+        "textMode": "value",
+        "reduceOptions": { "calcs": ["lastNotNull"] }
+      }
+    },
+    {
+      "type": "stat",
+      "title": "Brocade ICX6610 · .20 (core)",
+      "gridPos": { "h": 5, "w": 6, "x": 12, "y": 15 },
+      "datasource": { "type": "prometheus", "uid": "${datasource}" },
+      "targets": [
+        {
+          "refId": "A",
+          "expr": "sum(rate(ifHCInOctets{target=\"brocade-core\"}[5m]) * 8) + sum(rate(ifHCOutOctets{target=\"brocade-core\"}[5m]) * 8)"
+        }
+      ],
+      "fieldConfig": {
+        "defaults": {
+          "unit": "bps",
+          "color": { "mode": "fixed", "fixedColor": "green" },
+          "noValue": "unreachable",
+          "links": [
+            {
+              "title": "Open port detail",
+              "url": "/d/snmp-switch-ports?var-device=brocade-core&${__url_time_range}",
+              "targetBlank": false
+            }
+          ]
+        },
+        "overrides": []
+      },
+      "options": {
+        "colorMode": "value",
+        "graphMode": "area",
+        "textMode": "value",
+        "reduceOptions": { "calcs": ["lastNotNull"] }
+      }
+    },
+    {
+      "type": "stat",
+      "title": "Arista 7050 · .21 (dist)",
+      "gridPos": { "h": 5, "w": 6, "x": 18, "y": 15 },
+      "datasource": { "type": "prometheus", "uid": "${datasource}" },
+      "targets": [
+        {
+          "refId": "A",
+          "expr": "sum(rate(ifHCInOctets{target=\"arista-dist\"}[5m]) * 8) + sum(rate(ifHCOutOctets{target=\"arista-dist\"}[5m]) * 8)"
+        }
+      ],
+      "fieldConfig": {
+        "defaults": {
+          "unit": "bps",
+          "color": { "mode": "fixed", "fixedColor": "green" },
+          "noValue": "unreachable",
+          "links": [
+            {
+              "title": "Open port detail",
+              "url": "/d/snmp-switch-ports?var-device=arista-dist&${__url_time_range}",
+              "targetBlank": false
+            }
+          ]
+        },
+        "overrides": []
+      },
+      "options": {
+        "colorMode": "value",
+        "graphMode": "area",
+        "textMode": "value",
+        "reduceOptions": { "calcs": ["lastNotNull"] }
+      }
+    }
+  ]
+}

--- a/kubernetes/apps/observability/grafana/instance/dashboards/snmp-fabric-overview.json
+++ b/kubernetes/apps/observability/grafana/instance/dashboards/snmp-fabric-overview.json
@@ -26,7 +26,7 @@
       "type": "table",
       "title": "Fabric health — click a device to drill into its ports",
       "gridPos": { "h": 8, "w": 24, "x": 0, "y": 0 },
-      "datasource": { "type": "prometheus", "uid": "${datasource}" },
+      "datasource": { "type": "prometheus", "uid": "$${datasource}" },
       "targets": [
         {
           "refId": "A",
@@ -94,8 +94,8 @@
                 "id": "links",
                 "value": [
                   {
-                    "title": "Open ${__value.text} port detail",
-                    "url": "/d/snmp-switch-ports?var-device=${__value.text}&${__url_time_range}",
+                    "title": "Open $${__value.text} port detail",
+                    "url": "/d/snmp-switch-ports?var-device=$${__value.text}&$${__url_time_range}",
                     "targetBlank": false
                   }
                 ]
@@ -170,7 +170,7 @@
       "type": "stat",
       "title": "OPNsense · .1",
       "gridPos": { "h": 5, "w": 8, "x": 0, "y": 9 },
-      "datasource": { "type": "prometheus", "uid": "${datasource}" },
+      "datasource": { "type": "prometheus", "uid": "$${datasource}" },
       "targets": [
         {
           "refId": "A",
@@ -185,7 +185,7 @@
           "links": [
             {
               "title": "Open port detail",
-              "url": "/d/snmp-switch-ports?var-device=opnsense&${__url_time_range}",
+              "url": "/d/snmp-switch-ports?var-device=opnsense&$${__url_time_range}",
               "targetBlank": false
             }
           ]
@@ -203,7 +203,7 @@
       "type": "stat",
       "title": "Aruba S2500 · .26",
       "gridPos": { "h": 5, "w": 8, "x": 8, "y": 9 },
-      "datasource": { "type": "prometheus", "uid": "${datasource}" },
+      "datasource": { "type": "prometheus", "uid": "$${datasource}" },
       "targets": [
         {
           "refId": "A",
@@ -218,7 +218,7 @@
           "links": [
             {
               "title": "Open port detail",
-              "url": "/d/snmp-switch-ports?var-device=aruba-access&${__url_time_range}",
+              "url": "/d/snmp-switch-ports?var-device=aruba-access&$${__url_time_range}",
               "targetBlank": false
             }
           ]
@@ -236,7 +236,7 @@
       "type": "stat",
       "title": "NRay house · .7",
       "gridPos": { "h": 5, "w": 8, "x": 16, "y": 9 },
-      "datasource": { "type": "prometheus", "uid": "${datasource}" },
+      "datasource": { "type": "prometheus", "uid": "$${datasource}" },
       "targets": [
         {
           "refId": "A",
@@ -251,7 +251,7 @@
           "links": [
             {
               "title": "Open port detail",
-              "url": "/d/snmp-switch-ports?var-device=nray-house&${__url_time_range}",
+              "url": "/d/snmp-switch-ports?var-device=nray-house&$${__url_time_range}",
               "targetBlank": false
             }
           ]
@@ -275,7 +275,7 @@
       "type": "stat",
       "title": "NRay shop · .8",
       "gridPos": { "h": 5, "w": 6, "x": 0, "y": 15 },
-      "datasource": { "type": "prometheus", "uid": "${datasource}" },
+      "datasource": { "type": "prometheus", "uid": "$${datasource}" },
       "targets": [
         {
           "refId": "A",
@@ -290,7 +290,7 @@
           "links": [
             {
               "title": "Open port detail",
-              "url": "/d/snmp-switch-ports?var-device=nray-shop&${__url_time_range}",
+              "url": "/d/snmp-switch-ports?var-device=nray-shop&$${__url_time_range}",
               "targetBlank": false
             }
           ]
@@ -308,7 +308,7 @@
       "type": "stat",
       "title": "CSS326 · .27",
       "gridPos": { "h": 5, "w": 6, "x": 6, "y": 15 },
-      "datasource": { "type": "prometheus", "uid": "${datasource}" },
+      "datasource": { "type": "prometheus", "uid": "$${datasource}" },
       "targets": [
         {
           "refId": "A",
@@ -323,7 +323,7 @@
           "links": [
             {
               "title": "Open port detail",
-              "url": "/d/snmp-switch-ports?var-device=css326-bridge&${__url_time_range}",
+              "url": "/d/snmp-switch-ports?var-device=css326-bridge&$${__url_time_range}",
               "targetBlank": false
             }
           ]
@@ -341,7 +341,7 @@
       "type": "stat",
       "title": "Brocade ICX6610 · .20 (core)",
       "gridPos": { "h": 5, "w": 6, "x": 12, "y": 15 },
-      "datasource": { "type": "prometheus", "uid": "${datasource}" },
+      "datasource": { "type": "prometheus", "uid": "$${datasource}" },
       "targets": [
         {
           "refId": "A",
@@ -356,7 +356,7 @@
           "links": [
             {
               "title": "Open port detail",
-              "url": "/d/snmp-switch-ports?var-device=brocade-core&${__url_time_range}",
+              "url": "/d/snmp-switch-ports?var-device=brocade-core&$${__url_time_range}",
               "targetBlank": false
             }
           ]
@@ -374,7 +374,7 @@
       "type": "stat",
       "title": "Arista 7050 · .21 (dist)",
       "gridPos": { "h": 5, "w": 6, "x": 18, "y": 15 },
-      "datasource": { "type": "prometheus", "uid": "${datasource}" },
+      "datasource": { "type": "prometheus", "uid": "$${datasource}" },
       "targets": [
         {
           "refId": "A",
@@ -389,7 +389,7 @@
           "links": [
             {
               "title": "Open port detail",
-              "url": "/d/snmp-switch-ports?var-device=arista-dist&${__url_time_range}",
+              "url": "/d/snmp-switch-ports?var-device=arista-dist&$${__url_time_range}",
               "targetBlank": false
             }
           ]

--- a/kubernetes/apps/observability/grafana/instance/dashboards/snmp-switch-ports.json
+++ b/kubernetes/apps/observability/grafana/instance/dashboards/snmp-switch-ports.json
@@ -1,0 +1,464 @@
+{
+  "annotations": { "list": [] },
+  "editable": true,
+  "graphTooltip": 1,
+  "title": "Network / Switch Ports",
+  "uid": "snmp-switch-ports",
+  "tags": ["network", "snmp", "switch"],
+  "timezone": "",
+  "schemaVersion": 39,
+  "time": { "from": "now-3h", "to": "now" },
+  "refresh": "1m",
+  "templating": {
+    "list": [
+      {
+        "name": "datasource",
+        "type": "datasource",
+        "query": "prometheus",
+        "current": {},
+        "hide": 0,
+        "label": "Datasource"
+      },
+      {
+        "name": "device",
+        "type": "query",
+        "datasource": { "type": "prometheus", "uid": "${datasource}" },
+        "query": "label_values(ifIndex, target)",
+        "refresh": 2,
+        "includeAll": false,
+        "multi": false,
+        "current": { "text": "brocade-core", "value": "brocade-core" },
+        "label": "Device",
+        "sort": 1
+      },
+      {
+        "name": "interface",
+        "type": "query",
+        "datasource": { "type": "prometheus", "uid": "${datasource}" },
+        "query": "label_values(ifHCInOctets{target=\"$device\"}, ifName)",
+        "refresh": 2,
+        "includeAll": true,
+        "multi": true,
+        "current": { "text": "All", "value": "$__all" },
+        "label": "Interface",
+        "sort": 1
+      }
+    ]
+  },
+  "panels": [
+    {
+      "type": "stat",
+      "title": "Ports total",
+      "gridPos": { "h": 4, "w": 4, "x": 0, "y": 0 },
+      "datasource": { "type": "prometheus", "uid": "${datasource}" },
+      "targets": [{ "refId": "A", "expr": "count(ifOperStatus{target=\"$device\"}) or vector(0)" }],
+      "fieldConfig": {
+        "defaults": { "color": { "mode": "fixed", "fixedColor": "text" } },
+        "overrides": []
+      },
+      "options": { "colorMode": "value", "graphMode": "none", "textMode": "value" }
+    },
+    {
+      "type": "stat",
+      "title": "Ports up",
+      "gridPos": { "h": 4, "w": 4, "x": 4, "y": 0 },
+      "datasource": { "type": "prometheus", "uid": "${datasource}" },
+      "targets": [
+        { "refId": "A", "expr": "count(ifOperStatus{target=\"$device\"} == 1) or vector(0)" }
+      ],
+      "fieldConfig": {
+        "defaults": { "color": { "mode": "fixed", "fixedColor": "green" } },
+        "overrides": []
+      },
+      "options": { "colorMode": "value", "graphMode": "none", "textMode": "value" }
+    },
+    {
+      "type": "stat",
+      "title": "Down (admin-up)",
+      "gridPos": { "h": 4, "w": 4, "x": 8, "y": 0 },
+      "datasource": { "type": "prometheus", "uid": "${datasource}" },
+      "targets": [
+        {
+          "refId": "A",
+          "expr": "count((ifOperStatus{target=\"$device\"} == 2) and on (instance, ifIndex) (ifAdminStatus == 1)) or vector(0)"
+        }
+      ],
+      "fieldConfig": {
+        "defaults": {
+          "color": { "mode": "thresholds" },
+          "thresholds": {
+            "steps": [
+              { "color": "green", "value": null },
+              { "color": "red", "value": 1 }
+            ]
+          }
+        },
+        "overrides": []
+      },
+      "options": { "colorMode": "background", "graphMode": "none", "textMode": "value" }
+    },
+    {
+      "type": "stat",
+      "title": "Error+discard rate",
+      "gridPos": { "h": 4, "w": 4, "x": 12, "y": 0 },
+      "datasource": { "type": "prometheus", "uid": "${datasource}" },
+      "targets": [
+        {
+          "refId": "A",
+          "expr": "sum(rate(ifInErrors{target=\"$device\"}[5m]) + rate(ifOutErrors{target=\"$device\"}[5m]) + rate(ifInDiscards{target=\"$device\"}[5m]) + rate(ifOutDiscards{target=\"$device\"}[5m])) or vector(0)"
+        }
+      ],
+      "fieldConfig": {
+        "defaults": {
+          "unit": "pps",
+          "color": { "mode": "thresholds" },
+          "thresholds": {
+            "steps": [
+              { "color": "green", "value": null },
+              { "color": "yellow", "value": 0.5 },
+              { "color": "red", "value": 5 }
+            ]
+          }
+        },
+        "overrides": []
+      },
+      "options": { "colorMode": "background", "graphMode": "area", "textMode": "value" }
+    },
+    {
+      "type": "stat",
+      "title": "Aggregate inbound",
+      "gridPos": { "h": 4, "w": 4, "x": 16, "y": 0 },
+      "datasource": { "type": "prometheus", "uid": "${datasource}" },
+      "targets": [
+        { "refId": "A", "expr": "sum(rate(ifHCInOctets{target=\"$device\"}[5m]) * 8) or vector(0)" }
+      ],
+      "fieldConfig": {
+        "defaults": { "unit": "bps", "color": { "mode": "fixed", "fixedColor": "blue" } },
+        "overrides": []
+      },
+      "options": { "colorMode": "value", "graphMode": "area", "textMode": "value" }
+    },
+    {
+      "type": "stat",
+      "title": "Aggregate outbound",
+      "gridPos": { "h": 4, "w": 4, "x": 20, "y": 0 },
+      "datasource": { "type": "prometheus", "uid": "${datasource}" },
+      "targets": [
+        {
+          "refId": "A",
+          "expr": "sum(rate(ifHCOutOctets{target=\"$device\"}[5m]) * 8) or vector(0)"
+        }
+      ],
+      "fieldConfig": {
+        "defaults": { "unit": "bps", "color": { "mode": "fixed", "fixedColor": "purple" } },
+        "overrides": []
+      },
+      "options": { "colorMode": "value", "graphMode": "area", "textMode": "value" }
+    },
+    {
+      "type": "table",
+      "title": "Ports on $device",
+      "description": "Per-port status, negotiated speed, live throughput and error/discard rates. Click column headers to sort.",
+      "gridPos": { "h": 13, "w": 24, "x": 0, "y": 4 },
+      "datasource": { "type": "prometheus", "uid": "${datasource}" },
+      "targets": [
+        {
+          "refId": "A",
+          "instant": true,
+          "format": "table",
+          "expr": "label_replace(ifAdminStatus{target=\"$device\"}, \"__name__\", \"\", \"__name__\", \".*\")"
+        },
+        {
+          "refId": "B",
+          "instant": true,
+          "format": "table",
+          "expr": "label_replace(ifOperStatus{target=\"$device\"}, \"__name__\", \"\", \"__name__\", \".*\")"
+        },
+        {
+          "refId": "C",
+          "instant": true,
+          "format": "table",
+          "expr": "label_replace(ifHighSpeed{target=\"$device\"}, \"__name__\", \"\", \"__name__\", \".*\")"
+        },
+        {
+          "refId": "D",
+          "instant": true,
+          "format": "table",
+          "expr": "label_replace(rate(ifHCInOctets{target=\"$device\"}[5m]) * 8, \"__name__\", \"\", \"__name__\", \".*\")"
+        },
+        {
+          "refId": "E",
+          "instant": true,
+          "format": "table",
+          "expr": "label_replace(rate(ifHCOutOctets{target=\"$device\"}[5m]) * 8, \"__name__\", \"\", \"__name__\", \".*\")"
+        },
+        {
+          "refId": "F",
+          "instant": true,
+          "format": "table",
+          "expr": "label_replace(rate(ifInErrors{target=\"$device\"}[5m]) + rate(ifInDiscards{target=\"$device\"}[5m]), \"__name__\", \"\", \"__name__\", \".*\")"
+        },
+        {
+          "refId": "G",
+          "instant": true,
+          "format": "table",
+          "expr": "label_replace(rate(ifOutErrors{target=\"$device\"}[5m]) + rate(ifOutDiscards{target=\"$device\"}[5m]), \"__name__\", \"\", \"__name__\", \".*\")"
+        }
+      ],
+      "transformations": [
+        { "id": "merge", "options": {} },
+        {
+          "id": "organize",
+          "options": {
+            "excludeByName": {
+              "Time": true,
+              "__name__": true,
+              "instance": true,
+              "job": true,
+              "endpoint": true,
+              "container": true,
+              "namespace": true,
+              "pod": true,
+              "service": true,
+              "target": true,
+              "ifIndex": true,
+              "ifDescr": true
+            },
+            "renameByName": {
+              "ifName": "Interface",
+              "ifAlias": "Description",
+              "Value #A": "Admin",
+              "Value #B": "Status",
+              "Value #C": "Speed (Mb/s)",
+              "Value #D": "In",
+              "Value #E": "Out",
+              "Value #F": "In err+disc",
+              "Value #G": "Out err+disc"
+            },
+            "indexByName": {
+              "ifName": 0,
+              "ifAlias": 1,
+              "Value #A": 2,
+              "Value #B": 3,
+              "Value #C": 4,
+              "Value #D": 5,
+              "Value #E": 6,
+              "Value #F": 7,
+              "Value #G": 8
+            }
+          }
+        }
+      ],
+      "fieldConfig": {
+        "defaults": {},
+        "overrides": [
+          {
+            "matcher": { "id": "byName", "options": "Status" },
+            "properties": [
+              {
+                "id": "mappings",
+                "value": [
+                  {
+                    "type": "value",
+                    "options": {
+                      "1": { "text": "Up", "color": "green", "index": 0 },
+                      "2": { "text": "Down", "color": "red", "index": 1 },
+                      "3": { "text": "Testing", "index": 2 }
+                    }
+                  }
+                ]
+              },
+              { "id": "custom.cellOptions", "value": { "type": "color-text" } }
+            ]
+          },
+          {
+            "matcher": { "id": "byName", "options": "Admin" },
+            "properties": [
+              {
+                "id": "mappings",
+                "value": [
+                  {
+                    "type": "value",
+                    "options": {
+                      "1": { "text": "Up", "color": "green", "index": 0 },
+                      "2": { "text": "Down", "color": "text", "index": 1 },
+                      "3": { "text": "Testing", "index": 2 }
+                    }
+                  }
+                ]
+              },
+              { "id": "custom.cellOptions", "value": { "type": "color-text" } }
+            ]
+          },
+          {
+            "matcher": { "id": "byName", "options": "Speed (Mb/s)" },
+            "properties": [
+              { "id": "unit", "value": "locale" },
+              { "id": "decimals", "value": 0 }
+            ]
+          },
+          {
+            "matcher": { "id": "byName", "options": "In" },
+            "properties": [{ "id": "unit", "value": "bps" }]
+          },
+          {
+            "matcher": { "id": "byName", "options": "Out" },
+            "properties": [{ "id": "unit", "value": "bps" }]
+          },
+          {
+            "matcher": { "id": "byName", "options": "In err+disc" },
+            "properties": [
+              { "id": "unit", "value": "pps" },
+              {
+                "id": "custom.cellOptions",
+                "value": { "type": "color-background", "mode": "gradient" }
+              },
+              {
+                "id": "thresholds",
+                "value": {
+                  "steps": [
+                    { "color": "transparent", "value": null },
+                    { "color": "red", "value": 0.001 }
+                  ]
+                }
+              }
+            ]
+          },
+          {
+            "matcher": { "id": "byName", "options": "Out err+disc" },
+            "properties": [
+              { "id": "unit", "value": "pps" },
+              {
+                "id": "custom.cellOptions",
+                "value": { "type": "color-background", "mode": "gradient" }
+              },
+              {
+                "id": "thresholds",
+                "value": {
+                  "steps": [
+                    { "color": "transparent", "value": null },
+                    { "color": "red", "value": 0.001 }
+                  ]
+                }
+              }
+            ]
+          }
+        ]
+      },
+      "options": {
+        "showHeader": true,
+        "cellHeight": "sm",
+        "footer": { "show": false },
+        "sortBy": [{ "displayName": "Interface", "desc": false }]
+      }
+    },
+    {
+      "type": "timeseries",
+      "title": "Link utilization %  ·  $interface",
+      "description": "Throughput as a percentage of negotiated link speed (ifHighSpeed). Ports reporting 0 speed are omitted.",
+      "gridPos": { "h": 8, "w": 12, "x": 0, "y": 17 },
+      "datasource": { "type": "prometheus", "uid": "${datasource}" },
+      "targets": [
+        {
+          "refId": "A",
+          "expr": "100 * (rate(ifHCInOctets{target=\"$device\", ifName=~\"$interface\"}[5m]) * 8) / ignoring(__name__) (ifHighSpeed{target=\"$device\", ifName=~\"$interface\"} > 0) / 1e6",
+          "legendFormat": "{{ifName}} in"
+        },
+        {
+          "refId": "B",
+          "expr": "100 * (rate(ifHCOutOctets{target=\"$device\", ifName=~\"$interface\"}[5m]) * 8) / ignoring(__name__) (ifHighSpeed{target=\"$device\", ifName=~\"$interface\"} > 0) / 1e6",
+          "legendFormat": "{{ifName}} out"
+        }
+      ],
+      "fieldConfig": {
+        "defaults": {
+          "unit": "percent",
+          "min": 0,
+          "custom": { "drawStyle": "line", "fillOpacity": 10, "showPoints": "never" }
+        },
+        "overrides": []
+      },
+      "options": {
+        "legend": { "displayMode": "table", "placement": "bottom", "calcs": ["max", "mean"] },
+        "tooltip": { "mode": "multi", "sort": "desc" }
+      }
+    },
+    {
+      "type": "timeseries",
+      "title": "Errors + discards  ·  $interface",
+      "gridPos": { "h": 8, "w": 12, "x": 12, "y": 17 },
+      "datasource": { "type": "prometheus", "uid": "${datasource}" },
+      "targets": [
+        {
+          "refId": "A",
+          "expr": "rate(ifInErrors{target=\"$device\", ifName=~\"$interface\"}[5m]) + rate(ifInDiscards{target=\"$device\", ifName=~\"$interface\"}[5m])",
+          "legendFormat": "{{ifName}} in"
+        },
+        {
+          "refId": "B",
+          "expr": "rate(ifOutErrors{target=\"$device\", ifName=~\"$interface\"}[5m]) + rate(ifOutDiscards{target=\"$device\", ifName=~\"$interface\"}[5m])",
+          "legendFormat": "{{ifName}} out"
+        }
+      ],
+      "fieldConfig": {
+        "defaults": {
+          "unit": "pps",
+          "custom": { "drawStyle": "line", "fillOpacity": 10, "showPoints": "auto" }
+        },
+        "overrides": []
+      },
+      "options": {
+        "legend": { "displayMode": "table", "placement": "bottom", "calcs": ["max"] },
+        "tooltip": { "mode": "multi", "sort": "desc" }
+      }
+    },
+    {
+      "type": "timeseries",
+      "title": "Inbound throughput  ·  $interface",
+      "gridPos": { "h": 8, "w": 12, "x": 0, "y": 25 },
+      "datasource": { "type": "prometheus", "uid": "${datasource}" },
+      "targets": [
+        {
+          "refId": "A",
+          "expr": "rate(ifHCInOctets{target=\"$device\", ifName=~\"$interface\"}[5m]) * 8",
+          "legendFormat": "{{ifName}} {{ifAlias}}"
+        }
+      ],
+      "fieldConfig": {
+        "defaults": {
+          "unit": "bps",
+          "custom": { "drawStyle": "line", "fillOpacity": 10, "showPoints": "never" }
+        },
+        "overrides": []
+      },
+      "options": {
+        "legend": { "displayMode": "table", "placement": "bottom", "calcs": ["max", "mean"] },
+        "tooltip": { "mode": "multi", "sort": "desc" }
+      }
+    },
+    {
+      "type": "timeseries",
+      "title": "Outbound throughput  ·  $interface",
+      "gridPos": { "h": 8, "w": 12, "x": 12, "y": 25 },
+      "datasource": { "type": "prometheus", "uid": "${datasource}" },
+      "targets": [
+        {
+          "refId": "A",
+          "expr": "rate(ifHCOutOctets{target=\"$device\", ifName=~\"$interface\"}[5m]) * 8",
+          "legendFormat": "{{ifName}} {{ifAlias}}"
+        }
+      ],
+      "fieldConfig": {
+        "defaults": {
+          "unit": "bps",
+          "custom": { "drawStyle": "line", "fillOpacity": 10, "showPoints": "never" }
+        },
+        "overrides": []
+      },
+      "options": {
+        "legend": { "displayMode": "table", "placement": "bottom", "calcs": ["max", "mean"] },
+        "tooltip": { "mode": "multi", "sort": "desc" }
+      }
+    }
+  ]
+}

--- a/kubernetes/apps/observability/grafana/instance/dashboards/snmp-switch-ports.json
+++ b/kubernetes/apps/observability/grafana/instance/dashboards/snmp-switch-ports.json
@@ -22,7 +22,7 @@
       {
         "name": "device",
         "type": "query",
-        "datasource": { "type": "prometheus", "uid": "${datasource}" },
+        "datasource": { "type": "prometheus", "uid": "$${datasource}" },
         "query": "label_values(ifIndex, target)",
         "refresh": 2,
         "includeAll": false,
@@ -34,7 +34,7 @@
       {
         "name": "interface",
         "type": "query",
-        "datasource": { "type": "prometheus", "uid": "${datasource}" },
+        "datasource": { "type": "prometheus", "uid": "$${datasource}" },
         "query": "label_values(ifHCInOctets{target=\"$device\"}, ifName)",
         "refresh": 2,
         "includeAll": true,
@@ -50,7 +50,7 @@
       "type": "stat",
       "title": "Ports total",
       "gridPos": { "h": 4, "w": 4, "x": 0, "y": 0 },
-      "datasource": { "type": "prometheus", "uid": "${datasource}" },
+      "datasource": { "type": "prometheus", "uid": "$${datasource}" },
       "targets": [{ "refId": "A", "expr": "count(ifOperStatus{target=\"$device\"}) or vector(0)" }],
       "fieldConfig": {
         "defaults": { "color": { "mode": "fixed", "fixedColor": "text" } },
@@ -62,7 +62,7 @@
       "type": "stat",
       "title": "Ports up",
       "gridPos": { "h": 4, "w": 4, "x": 4, "y": 0 },
-      "datasource": { "type": "prometheus", "uid": "${datasource}" },
+      "datasource": { "type": "prometheus", "uid": "$${datasource}" },
       "targets": [
         { "refId": "A", "expr": "count(ifOperStatus{target=\"$device\"} == 1) or vector(0)" }
       ],
@@ -76,7 +76,7 @@
       "type": "stat",
       "title": "Down (admin-up)",
       "gridPos": { "h": 4, "w": 4, "x": 8, "y": 0 },
-      "datasource": { "type": "prometheus", "uid": "${datasource}" },
+      "datasource": { "type": "prometheus", "uid": "$${datasource}" },
       "targets": [
         {
           "refId": "A",
@@ -101,7 +101,7 @@
       "type": "stat",
       "title": "Error+discard rate",
       "gridPos": { "h": 4, "w": 4, "x": 12, "y": 0 },
-      "datasource": { "type": "prometheus", "uid": "${datasource}" },
+      "datasource": { "type": "prometheus", "uid": "$${datasource}" },
       "targets": [
         {
           "refId": "A",
@@ -128,7 +128,7 @@
       "type": "stat",
       "title": "Aggregate inbound",
       "gridPos": { "h": 4, "w": 4, "x": 16, "y": 0 },
-      "datasource": { "type": "prometheus", "uid": "${datasource}" },
+      "datasource": { "type": "prometheus", "uid": "$${datasource}" },
       "targets": [
         { "refId": "A", "expr": "sum(rate(ifHCInOctets{target=\"$device\"}[5m]) * 8) or vector(0)" }
       ],
@@ -142,7 +142,7 @@
       "type": "stat",
       "title": "Aggregate outbound",
       "gridPos": { "h": 4, "w": 4, "x": 20, "y": 0 },
-      "datasource": { "type": "prometheus", "uid": "${datasource}" },
+      "datasource": { "type": "prometheus", "uid": "$${datasource}" },
       "targets": [
         {
           "refId": "A",
@@ -160,7 +160,7 @@
       "title": "Ports on $device",
       "description": "Per-port status, negotiated speed, live throughput and error/discard rates. Click column headers to sort.",
       "gridPos": { "h": 13, "w": 24, "x": 0, "y": 4 },
-      "datasource": { "type": "prometheus", "uid": "${datasource}" },
+      "datasource": { "type": "prometheus", "uid": "$${datasource}" },
       "targets": [
         {
           "refId": "A",
@@ -357,7 +357,7 @@
       "title": "Link utilization %  ·  $interface",
       "description": "Throughput as a percentage of negotiated link speed (ifHighSpeed). Ports reporting 0 speed are omitted.",
       "gridPos": { "h": 8, "w": 12, "x": 0, "y": 17 },
-      "datasource": { "type": "prometheus", "uid": "${datasource}" },
+      "datasource": { "type": "prometheus", "uid": "$${datasource}" },
       "targets": [
         {
           "refId": "A",
@@ -387,7 +387,7 @@
       "type": "timeseries",
       "title": "Errors + discards  ·  $interface",
       "gridPos": { "h": 8, "w": 12, "x": 12, "y": 17 },
-      "datasource": { "type": "prometheus", "uid": "${datasource}" },
+      "datasource": { "type": "prometheus", "uid": "$${datasource}" },
       "targets": [
         {
           "refId": "A",
@@ -416,7 +416,7 @@
       "type": "timeseries",
       "title": "Inbound throughput  ·  $interface",
       "gridPos": { "h": 8, "w": 12, "x": 0, "y": 25 },
-      "datasource": { "type": "prometheus", "uid": "${datasource}" },
+      "datasource": { "type": "prometheus", "uid": "$${datasource}" },
       "targets": [
         {
           "refId": "A",
@@ -440,7 +440,7 @@
       "type": "timeseries",
       "title": "Outbound throughput  ·  $interface",
       "gridPos": { "h": 8, "w": 12, "x": 12, "y": 25 },
-      "datasource": { "type": "prometheus", "uid": "${datasource}" },
+      "datasource": { "type": "prometheus", "uid": "$${datasource}" },
       "targets": [
         {
           "refId": "A",

--- a/kubernetes/apps/observability/grafana/instance/grafanadashboard-configmap.yaml
+++ b/kubernetes/apps/observability/grafana/instance/grafanadashboard-configmap.yaml
@@ -89,3 +89,51 @@ spec:
   configMapRef:
     name: grafana-dashboard-snmp-network
     key: snmp-network.json
+---
+# yaml-language-server: $schema=https://kubernetes-schemas.pages.dev/grafana.integreatly.org/grafanadashboard_v1beta1.json
+apiVersion: grafana.integreatly.org/v1beta1
+kind: GrafanaDashboard
+metadata:
+  name: snmp-switch-ports
+spec:
+  allowCrossNamespaceImport: true
+  instanceSelector:
+    matchLabels:
+      dashboards: grafana
+  folder: Network
+  resyncPeriod: 1h
+  configMapRef:
+    name: grafana-dashboard-snmp-switch-ports
+    key: snmp-switch-ports.json
+---
+# yaml-language-server: $schema=https://kubernetes-schemas.pages.dev/grafana.integreatly.org/grafanadashboard_v1beta1.json
+apiVersion: grafana.integreatly.org/v1beta1
+kind: GrafanaDashboard
+metadata:
+  name: snmp-fabric-overview
+spec:
+  allowCrossNamespaceImport: true
+  instanceSelector:
+    matchLabels:
+      dashboards: grafana
+  folder: Network
+  resyncPeriod: 1h
+  configMapRef:
+    name: grafana-dashboard-snmp-fabric-overview
+    key: snmp-fabric-overview.json
+---
+# yaml-language-server: $schema=https://kubernetes-schemas.pages.dev/grafana.integreatly.org/grafanadashboard_v1beta1.json
+apiVersion: grafana.integreatly.org/v1beta1
+kind: GrafanaDashboard
+metadata:
+  name: snmp-all-switches
+spec:
+  allowCrossNamespaceImport: true
+  instanceSelector:
+    matchLabels:
+      dashboards: grafana
+  folder: Network
+  resyncPeriod: 1h
+  configMapRef:
+    name: grafana-dashboard-snmp-all-switches
+    key: snmp-all-switches.json

--- a/kubernetes/apps/observability/grafana/instance/kustomization.yaml
+++ b/kubernetes/apps/observability/grafana/instance/kustomization.yaml
@@ -41,3 +41,18 @@ configMapGenerator:
       - snmp-network.json=dashboards/snmp-network.json
     options:
       disableNameSuffixHash: true
+  - name: grafana-dashboard-snmp-switch-ports
+    files:
+      - snmp-switch-ports.json=dashboards/snmp-switch-ports.json
+    options:
+      disableNameSuffixHash: true
+  - name: grafana-dashboard-snmp-fabric-overview
+    files:
+      - snmp-fabric-overview.json=dashboards/snmp-fabric-overview.json
+    options:
+      disableNameSuffixHash: true
+  - name: grafana-dashboard-snmp-all-switches
+    files:
+      - snmp-all-switches.json=dashboards/snmp-all-switches.json
+    options:
+      disableNameSuffixHash: true


### PR DESCRIPTION
## What

Adds three drill-down Grafana dashboards to the **Network** folder, built entirely on the **existing snmp-exporter `if_mib` data** — no new polling, no new scrape targets.

| Dashboard | UID | Purpose |
|---|---|---|
| Network / Fabric Overview | `snmp-fabric-overview` | Landing page: per-switch health table (ports up/down, agg in/out, error rate) with **click-through drill-down**, plus throughput tiles laid out geographically (House / Garage). |
| Network / All Switches | `snmp-all-switches` | One section per switch (repeating rows) — whole-fabric view at a glance. |
| Network / Switch Ports | `snmp-switch-ports` | Single-device per-port table (status, negotiated speed, live throughput, error/discard) + utilization / error / throughput graphs. Interface multi-select. |

## Why

The only pre-existing SNMP dashboard (`snmp-network`) shows top-N aggregates across all devices — there was no way to pick a switch and see every port, or to get a fabric-wide overview. These fill that gap and give a glance → drill-down flow.

## Coverage

All 7 SNMP targets (Brocade core, Arista dist, Aruba access, both NRay radios, CSS326, OPNsense). Covers the fabric switching layer; end hosts (Proxmox, workstation) and PoE power draw are out of scope (PoE needs a separate MIB module).

## Notes / to verify once live

- Fabric Overview + Switch Ports tables use the Grafana **merge** transform; All Switches uses **repeating rows**. Validated structurally + `kustomize build` clean, but rendering not previewed — may need a minor column/label tweak.
- Wired via `configMapGenerator` + `GrafanaDashboard` CRs alongside the existing dashboards.