### PR TITLE
fix(talos): multi-issuer apiserver auth (fixes Headlamp OIDC)

### DIFF
--- a/kubernetes/bootstrap/talos/patches/controller/apiserver-oidc.yaml
+++ b/kubernetes/bootstrap/talos/patches/controller/apiserver-oidc.yaml
@@ -1,0 +1,57 @@
+# kube-apiserver OIDC authentication — Structured Authentication Configuration.
+#
+# Authentik gives every application its OWN issuer URL (…/application/o/<slug>/), so the
+# legacy single-issuer --oidc-* flags can only ever trust one app. This uses the k8s
+# Structured Authentication Config (apiserver.config.k8s.io/v1, GA in 1.30) to trust
+# MULTIPLE issuers — one JWT authenticator per app, each scoped to its own audience.
+# Both map preferred_username -> user and groups -> groups with the `oidc:` prefix, so
+# the oidc-rbac ClusterRoleBindings apply identically regardless of which app issued the
+# token. x509 cert auth (talosconfig / admin kubeconfig) remains the break-glass.
+#
+# Delivery: machine.files writes the config to the control-plane nodes;
+# apiServer.extraVolumes mounts it read-only into the static pod; --authentication-config
+# points the apiserver at it. --authentication-config is mutually exclusive with --oidc-*.
+#
+# Adding a new OIDC-to-apiserver app (e.g. another dashboard) = add a jwt authenticator
+# block below with that app's issuer + audience.
+cluster:
+  apiServer:
+    extraArgs:
+      authentication-config: /etc/kubernetes/authentication/config.yaml
+    extraVolumes:
+      - hostPath: /etc/kubernetes/authentication
+        mountPath: /etc/kubernetes/authentication
+        readonly: true
+machine:
+  files:
+    - op: create
+      path: /etc/kubernetes/authentication/config.yaml
+      permissions: 0o644
+      content: |
+        apiVersion: apiserver.config.k8s.io/v1
+        kind: AuthenticationConfiguration
+        jwt:
+          # kubectl CLI (kubelogin)
+          - issuer:
+              url: "https://sso.chelonianlabs.com/application/o/kubectl/"
+              audiences:
+                - "kubectl"
+            claimMappings:
+              username:
+                claim: "preferred_username"
+                prefix: "oidc:"
+              groups:
+                claim: "groups"
+                prefix: "oidc:"
+          # Headlamp web dashboard
+          - issuer:
+              url: "https://sso.chelonianlabs.com/application/o/headlamp/"
+              audiences:
+                - "headlamp"
+            claimMappings:
+              username:
+                claim: "preferred_username"
+                prefix: "oidc:"
+              groups:
+                claim: "groups"
+                prefix: "oidc:"

--- a/kubernetes/bootstrap/talos/patches/controller/cluster.yaml
+++ b/kubernetes/bootstrap/talos/patches/controller/cluster.yaml
@@ -12,17 +12,8 @@ cluster:
       max-mutating-requests-inflight: "400"
       # Reduce watch cache memory usage
       default-watch-cache-size: "100"
-      # Authentik OIDC login (kubectl via kubelogin). Additive to x509 cert auth,
-      # which stays the untouchable break-glass. Legacy flags on purpose: the
-      # apiserver fetches JWKS lazily, so a down/unreachable Authentik never blocks
-      # apiserver startup (only OIDC token validation degrades; cert auth is intact).
-      # Issuer needs the trailing slash. sso.* uses a public LE cert -> no oidc-ca-file.
-      oidc-issuer-url: "https://sso.chelonianlabs.com/application/o/kubectl/"
-      oidc-client-id: "kubectl"
-      oidc-username-claim: "preferred_username"
-      oidc-username-prefix: "oidc:"
-      oidc-groups-claim: "groups"
-      oidc-groups-prefix: "oidc:"
+      # OIDC authentication (structured multi-issuer) lives in its own patch:
+      # ./patches/controller/apiserver-oidc.yaml
     resources:
       requests:
         cpu: 500m

--- a/kubernetes/bootstrap/talos/talconfig.yaml
+++ b/kubernetes/bootstrap/talos/talconfig.yaml
@@ -287,6 +287,7 @@ controlPlane:
   patches:
     - "@./patches/controller/admission-controller-patch.yaml"
     - "@./patches/controller/cluster.yaml"
+    - "@./patches/controller/apiserver-oidc.yaml"
     - "@./patches/controller/machine-gh-actions.yaml"
     - "@./patches/global/machine-talos-api.yaml"
 


### PR DESCRIPTION
## Problem

Headlamp logs in via Authentik fine, but the apiserver **401s its forwarded token**, bouncing the user back to login. Root cause: Authentik gives every application its **own issuer** (`…/application/o/<slug>/`), so Headlamp's tokens carry `iss=…/o/headlamp/` while the apiserver's legacy `--oidc-issuer-url` only trusts `…/o/kubectl/`. Single-issuer legacy flags can't cover both.

## Fix

Replace the legacy `--oidc-*` flags with **Structured Authentication Configuration** (`apiserver.config.k8s.io/v1`, GA since 1.30): one `jwt` authenticator per issuer, each scoped to its own audience, both mapping `preferred_username`/`groups` with the `oidc:` prefix — so the `oidc-rbac` bindings apply unchanged to logins from either app.

Delivered on Talos via `machine.files` (writes the config to control-plane nodes) + `apiServer.extraVolumes` (mounts it) + `--authentication-config`. All isolated in a dedicated **`patches/controller/apiserver-oidc.yaml`**; adding a future OIDC-to-apiserver app is just another `jwt` block.

## Safety

- Validated locally with `talhelper genconfig` (Talos schema OK, control-plane only, workers unaffected).
- **Staged apply**: control-1 first — if its apiserver rejects the config, control-2/3 keep the old config and serve the API (HA). Verify, then roll the rest.
- **x509 cert auth (talosconfig / admin kubeconfig) is untouched** and remains break-glass throughout.
- Bonus: makes the earlier `kubernetes-audience` scope-mapping hack unnecessary (each issuer has its own audience) — cleanup to follow.