### PR TITLE
fix(talos): apiserver auth-config to /var (not /etc/kubernetes)

### DIFF
--- a/kubernetes/bootstrap/talos/patches/controller/apiserver-oidc.yaml
+++ b/kubernetes/bootstrap/talos/patches/controller/apiserver-oidc.yaml
@@ -12,6 +12,11 @@
 # apiServer.extraVolumes mounts it read-only into the static pod; --authentication-config
 # points the apiserver at it. --authentication-config is mutually exclusive with --oidc-*.
 #
+# IMPORTANT: machine.files MUST write to a writable host path (/var/...). Writing under
+# /etc/kubernetes makes Talos overlay that dir read-only, which breaks the kubelet's own
+# PKI writes and takes the node NotReady. So the file lives at /var/lib/... on the host and
+# is mounted into the apiserver pod at /etc/kubernetes/authentication (container-only).
+#
 # Adding a new OIDC-to-apiserver app (e.g. another dashboard) = add a jwt authenticator
 # block below with that app's issuer + audience.
 cluster:
@@ -19,13 +24,13 @@ cluster:
     extraArgs:
       authentication-config: /etc/kubernetes/authentication/config.yaml
     extraVolumes:
-      - hostPath: /etc/kubernetes/authentication
-        mountPath: /etc/kubernetes/authentication
+      - hostPath: /var/lib/kubernetes/authentication # writable host path (NOT /etc/kubernetes)
+        mountPath: /etc/kubernetes/authentication # container-only mount point
         readonly: true
 machine:
   files:
     - op: create
-      path: /etc/kubernetes/authentication/config.yaml
+      path: /var/lib/kubernetes/authentication/config.yaml # writable host path
       permissions: 0o644
       content: |
         apiVersion: apiserver.config.k8s.io/v1


### PR DESCRIPTION
## Why

Follow-up to #3511. That patch wrote the structured-auth config via \`machine.files\` under **\`/etc/kubernetes\`**, which Talos overlays **read-only** — breaking the kubelet's own PKI writes and taking control-plane node **NotReady** (hit this live on control-1; recovered via config revert + reboot, cluster stayed up on 2/3 HA the whole time).

## Fix

Write the config to a **writable** host path \`/var/lib/kubernetes/authentication/config.yaml\`, mounted into the apiserver pod at \`/etc/kubernetes/authentication\` (container-only — never the host's real dir). One-line-ish change; validated with \`talhelper genconfig\`.

## ⚠️ Landmine this removes

Until merged, \`main\` still carries the bad \`/etc/kubernetes\` path from #3511 — running \`task talos:apply-cluster\` from \`main\` would apply it to **all three** control planes at once. Merging this makes \`main\` safe to apply (staged) again.

## Not yet applied

The running cluster is currently on the **legacy \`--oidc-*\`** config (control-1 reverted; control-2/3 never changed). This PR only corrects git; the staged re-apply is a separate, deliberate step.