### PR TITLE
chore(headlamp): drop audience hack, add offline_access, update SSO docs

### DIFF
--- a/docs/src/operations/sso-cluster-access.md
+++ b/docs/src/operations/sso-cluster-access.md
@@ -14,15 +14,27 @@ admin kubeconfig, which remains the untouchable **break-glass** path.
 
 The kube-apiserver runs multiple authenticators at once — OIDC is _additive_. The
 apiserver validates the x509 admin cert entirely locally against the cluster CA, so
-it works even if Authentik is completely down. The OIDC flags use the legacy
-`--oidc-*` form, which fetches JWKS lazily: an unreachable Authentik degrades only
-OIDC token validation, it never blocks apiserver startup.
+it works even if Authentik is completely down. OIDC uses the **structured
+Authentication Configuration** (`apiserver.config.k8s.io/v1`): one `jwt` authenticator
+per Authentik issuer — Authentik gives every application its own issuer URL, so the
+kubectl CLI and Headlamp each get their own entry. JWKS is fetched lazily, so an
+unreachable Authentik degrades only OIDC token validation, never apiserver startup.
 
-- **Provider**: Authentik `Kubernetes OIDC`, public/PKCE client, `client_id: kubectl`.
-- **Issuer**: `https://sso.chelonianlabs.com/application/o/kubectl/` (trailing slash required).
-- **apiserver flags**: `kubernetes/bootstrap/talos/patches/controller/cluster.yaml`.
+- **Providers**: Authentik `Kubernetes OIDC` (public/PKCE, `client_id: kubectl`) and
+  `Headlamp OIDC` (confidential, `client_id: headlamp`).
+- **Issuers**: `https://sso.chelonianlabs.com/application/o/kubectl/` and
+  `…/o/headlamp/` (trailing slash required).
+- **apiserver config**: `kubernetes/bootstrap/talos/patches/controller/apiserver-oidc.yaml`
+  — the auth config is written via `machine.files` to `/var/lib/kubernetes/authentication/`
+  (must be a writable `/var` path — a `machine.files` entry under `/etc/kubernetes` makes
+  Talos overlay that dir read-only and breaks the kubelet's PKI writes) and mounted into
+  the apiserver pod. Adding another OIDC app = one more `jwt:` block. Applying this patch
+  requires a per-node reboot (`machine.files` changes are not immediate-mode).
 - **RBAC**: `kubernetes/apps/kube-system/oidc-rbac/` binds
-  `oidc:kubernetes-admins` → `cluster-admin` and `oidc:kubernetes-viewers` → `view`.
+  `oidc:kubernetes-admins` → `cluster-admin` and `oidc:kubernetes-viewers` → `view`;
+  both issuers map claims with the same `oidc:` prefix, so bindings apply to both.
+- **Headlamp**: `https://headlamp.chelonianlabs.com` — same login, per-user RBAC via
+  token pass-through.
 
 ## Access tiers
 

--- a/kubernetes/apps/kube-system/headlamp/app/externalsecret.yaml
+++ b/kubernetes/apps/kube-system/headlamp/app/externalsecret.yaml
@@ -18,7 +18,7 @@ spec:
         OIDC_CLIENT_ID: "headlamp"
         OIDC_CLIENT_SECRET: "{{ .HEADLAMP_OIDC_CLIENT_SECRET }}"
         OIDC_ISSUER_URL: "https://sso.${SECRET_DOMAIN}/application/o/headlamp/"
-        OIDC_SCOPES: "openid profile email kubernetes-audience"
+        OIDC_SCOPES: "openid profile email offline_access"
   dataFrom:
     - find:
         name:

--- a/kubernetes/apps/security/authentik/app/blueprints-oidc.yaml
+++ b/kubernetes/apps/security/authentik/app/blueprints-oidc.yaml
@@ -148,30 +148,22 @@ data:
       - model: authentik_core.group
         identifiers: { name: kubernetes-viewers }
       # Headlamp (web k8s dashboard) — confidential OIDC client, per-user RBAC via
-      # token pass-through (Headlamp forwards the user's id_token to the apiserver).
-      # The apiserver runs --oidc-client-id=kubectl, so the token's aud MUST contain
-      # `kubectl`; Headlamp's own verifier needs `headlamp`. This scope mapping sets
-      # aud to BOTH (apiserver does array-contains matching). Requested via the
-      # `kubernetes-audience` scope in Headlamp's OIDC_SCOPES.
-      - model: authentik_providers_oauth2.scopemapping
-        identifiers: { name: Kubernetes API audience }
-        id: k8s-audience
-        attrs:
-          scope_name: kubernetes-audience
-          description: "Sets token aud to [headlamp, kubectl] so kube-apiserver (oidc-client-id=kubectl) accepts Headlamp-forwarded tokens"
-          expression: |
-            return {"aud": ["headlamp", "kubectl"]}
+      # token pass-through (Headlamp forwards the user's id_token to the apiserver;
+      # the apiserver trusts this issuer directly via the structured multi-issuer auth
+      # config, see talos patches/controller/apiserver-oidc.yaml — no audience tricks
+      # needed). offline_access gives Headlamp a refresh token so sessions renew
+      # silently instead of bouncing to Sign In at every token expiry.
       - model: authentik_providers_oauth2.oauth2provider
         identifiers: { name: Headlamp OIDC }
         id: headlamp-oidc
         attrs:
           <<: *oidc
           client_id: headlamp   # pinned; Authentik still generates the client_secret (→ Infisical HEADLAMP_OIDC_CLIENT_SECRET)
-          property_mappings:     # re-list the anchor's 3 + the audience mapping (override replaces the whole list)
+          property_mappings:     # re-list the anchor's 3 + offline_access (override replaces the whole list)
             - !Find [authentik_providers_oauth2.scopemapping, [managed, goauthentik.io/providers/oauth2/scope-openid]]
             - !Find [authentik_providers_oauth2.scopemapping, [managed, goauthentik.io/providers/oauth2/scope-email]]
             - !Find [authentik_providers_oauth2.scopemapping, [managed, goauthentik.io/providers/oauth2/scope-profile]]
-            - !KeyOf k8s-audience
+            - !Find [authentik_providers_oauth2.scopemapping, [managed, goauthentik.io/providers/oauth2/scope-offline_access]]
           redirect_uris:
             - { matching_mode: strict, url: "https://headlamp.${SECRET_DOMAIN}/oidc-callback", redirect_uri_type: authorization }
       - model: authentik_core.application


### PR DESCRIPTION
## What

Post-victory tidy-up now that Headlamp SSO is working end-to-end on structured multi-issuer auth:

1. **Drop the \`kubernetes-audience\` scope-mapping hack** — it stamped \`aud=[headlamp, kubectl]\` to satisfy the old single-issuer apiserver. Redundant since #3511/#3512: the apiserver trusts the headlamp issuer directly with its own audience.
2. **Add \`offline_access\`** to the Headlamp provider + \`OIDC_SCOPES\` — Headlamp had no refresh token (\`token expired and refresh token is not set\` in its logs), so every token expiry bounced users back to Sign In. Now sessions renew silently.
3. **Docs** — \`sso-cluster-access.md\` now describes the structured auth config (incl. the \`machine.files\` must-be-\`/var\` gotcha and the per-node reboot requirement) instead of the removed legacy flags.

## Post-merge

- Restart Headlamp once so it picks up the new \`OIDC_SCOPES\` (secret change alone doesn't roll the pod).
- Optional: delete the now-unreferenced **"Kubernetes API audience"** scope mapping in the Authentik UI (blueprints don't prune removed entries).