### PR TITLE
sec(auth): gate cluster OIDC apps by group + review fixes

### DIFF
--- a/kubernetes/apps/kube-system/headlamp/app/externalsecret.yaml
+++ b/kubernetes/apps/kube-system/headlamp/app/externalsecret.yaml
@@ -1,5 +1,5 @@
 ---
-# yaml-language-server: $schema=https://kubernetes-schemas.pages.dev/external-secrets.io/externalsecret_v1beta1.json
+# yaml-language-server: $schema=https://kubernetes-schemas.pages.dev/external-secrets.io/externalsecret_v1.json
 apiVersion: external-secrets.io/v1
 kind: ExternalSecret
 metadata:

--- a/kubernetes/apps/security/authentik/app/blueprints-oidc.yaml
+++ b/kubernetes/apps/security/authentik/app/blueprints-oidc.yaml
@@ -7,6 +7,13 @@
 # credentials (which already match each app's Infisical value, so logins never break). The
 # blueprint owns all non-secret config. DR caveat: re-enter the 3 client secrets once on a
 # from-scratch rebuild (or wire !Env later).
+#
+# More DR caveats:
+# - `!Find [authentik_core.user, [username, mackleyder]]` group entries fail on a
+#   from-scratch rebuild until that account exists — create the user first, then re-apply.
+# - Group `users:` lists here are AUTHORITATIVE: members added via the UI are removed on
+#   the next blueprint apply. Grant membership in git, not clickops (kubernetes-viewers
+#   deliberately has no attrs, so UI-added members there survive).
 apiVersion: v1
 kind: ConfigMap
 metadata:
@@ -136,6 +143,7 @@ data:
             - { matching_mode: strict, url: "http://localhost:18000", redirect_uri_type: authorization }
       - model: authentik_core.application
         identifiers: { slug: kubectl }
+        id: kubectl-app
         attrs: { name: Kubernetes (kubectl), group: internal, provider: !KeyOf kubectl-oidc, meta_icon: "https://cdn.jsdelivr.net/gh/selfhst/icons/svg/kubernetes.svg" }
       # kubernetes-admins → cluster-admin, kubernetes-viewers → view (bound by the
       # oidc-rbac ClusterRoleBindings). Membership here drives cluster access via
@@ -168,4 +176,38 @@ data:
             - { matching_mode: strict, url: "https://headlamp.${SECRET_DOMAIN}/oidc-callback", redirect_uri_type: authorization }
       - model: authentik_core.application
         identifiers: { slug: headlamp }
+        id: headlamp-app
         attrs: { name: Headlamp, group: internal, provider: !KeyOf headlamp-oidc, meta_icon: "https://cdn.jsdelivr.net/gh/selfhst/icons/svg/headlamp.svg", meta_launch_url: "https://headlamp.${SECRET_DOMAIN}" }
+      # Access gate: only kubernetes-admins / kubernetes-viewers members may complete
+      # OIDC against the cluster apps. Without these, ANY Authentik account (e.g. a
+      # future guest/media user) could mint a token the apiserver authenticates (RBAC
+      # would still deny real access, but token issuance should be membership-gated).
+      # Application policy_engine_mode defaults to "any" -> member of EITHER group passes.
+      - model: authentik_policies.policybinding
+        identifiers:
+          order: 0
+          target: !KeyOf kubectl-app
+        attrs:
+          group: !Find [authentik_core.group, [name, kubernetes-admins]]
+          enabled: true
+      - model: authentik_policies.policybinding
+        identifiers:
+          order: 10
+          target: !KeyOf kubectl-app
+        attrs:
+          group: !Find [authentik_core.group, [name, kubernetes-viewers]]
+          enabled: true
+      - model: authentik_policies.policybinding
+        identifiers:
+          order: 0
+          target: !KeyOf headlamp-app
+        attrs:
+          group: !Find [authentik_core.group, [name, kubernetes-admins]]
+          enabled: true
+      - model: authentik_policies.policybinding
+        identifiers:
+          order: 10
+          target: !KeyOf headlamp-app
+        attrs:
+          group: !Find [authentik_core.group, [name, kubernetes-viewers]]
+          enabled: true

--- a/kubernetes/apps/security/authentik/app/blueprints.yaml
+++ b/kubernetes/apps/security/authentik/app/blueprints.yaml
@@ -122,7 +122,7 @@ data:
         attrs: { <<: *proxy, external_host: "https://posterizarr.${SECRET_DOMAIN_MEDIA}", skip_path_regex: "^/api([/?].*)?$" }
       - model: authentik_core.application
         identifiers: { slug: posterizarr }
-        attrs: { name: Posterizarr, group: media_internal, provider: !KeyOf posterizarr-provider, meta_icon: "https://cdn.jsdelivr.net/gh/selfhst/icons/svg/posterizarr.svg", meta_launch_url: "https://posterizarr.turlteassmedia.com" }
+        attrs: { name: Posterizarr, group: media_internal, provider: !KeyOf posterizarr-provider, meta_icon: "https://cdn.jsdelivr.net/gh/selfhst/icons/svg/posterizarr.svg", meta_launch_url: "https://posterizarr.${SECRET_DOMAIN_MEDIA}" }
       # firefly
       - model: authentik_providers_proxy.proxyprovider
         identifiers: { name: Provider for Firefly }

--- a/kubernetes/bootstrap/talos/patches/controller/apiserver-oidc.yaml
+++ b/kubernetes/bootstrap/talos/patches/controller/apiserver-oidc.yaml
@@ -19,6 +19,19 @@
 #
 # Adding a new OIDC-to-apiserver app (e.g. another dashboard) = add a jwt authenticator
 # block below with that app's issuer + audience.
+#
+# TODO (fold in NEXT time the embedded config below changes — every content change
+# reboots each control-plane node, not worth a dedicated roll; the primary gate already
+# exists as Authentik policy bindings on the kubectl/headlamp applications):
+#   - claimValidationRules per authenticator, e.g.
+#       claimValidationRules:
+#         - expression: 'claims.groups.exists(g, g in ["kubernetes-admins", "kubernetes-viewers"])'
+#           message: "not a member of a kubernetes access group"
+#   - uid claim mapping (audit-stable identity; preferred_username is user-editable):
+#       uid: { claim: "sub" }
+# NOTE: never add an `anonymous:` section to the config — Talos sets
+# --anonymous-auth=false and the combination is rejected by the apiserver
+# (siderolabs/talos#11324).
 cluster:
   apiServer:
     extraArgs:


### PR DESCRIPTION
## What

Hardening PR from the full OIDC/Authentik review (two independent reviewers + live-state verification). All items are **Flux-only** — the Talos file change is comments-only, verified byte-identical rendered machineconfig, **no control-plane reboots**.

1. **Gate token issuance for the cluster apps** (the one finding both reviewers converged on): Authentik policy bindings on the `kubectl` and `headlamp` applications — only `kubernetes-admins`/`kubernetes-viewers` members can complete OIDC. Previously any Authentik account could mint a token the apiserver *authenticates* (RBAC contained it at `system:authenticated`, but issuance should be membership-gated).
2. **Fix leaked + typo'd media domain**: `posterizarr` `meta_launch_url` was hardcoded `turlteassmedia.com` in this public repo (also a broken link) — now `${SECRET_DOMAIN_MEDIA}` like its provider one line above.
3. **DR caveats documented** in the blueprint header: `!Find` user refs fail on fresh rebuild; group `users:` lists clobber UI-added members.
4. **Parked apiserver hardening as in-file TODO** (`claimValidationRules` + `uid: sub`) for the next auth-config content change — each content change reboots every control-plane node, and the IdP-side gate (item 1) covers it meanwhile. Also documents the `anonymous:`-section-vs-Talos-flag conflict so nobody trips talos#11324.
5. Cosmetic: headlamp externalsecret schema comment v1beta1 → v1.

## Review findings intentionally NOT actioned

- "Scope anonymous auth" — **rejected**: `--anonymous-auth=false` already live (verified); the suggested config block would crash the apiserver.
- Groups-less profile scope for low-trust apps (disclosure-only) — deferred, medium effort.
- Orphaned "Kubernetes API audience" mapping — manual UI delete (blueprints don't prune).

## Post-merge verification

Reconcile authentik → confirm policy bindings live → kubectl OIDC still works (member) → confirm a non-member would be denied at the Authentik authorize step.