### PR TITLE
fix(emqx): raise retainer payload and delivery limits for MQTT discovery

### DIFF
--- a/kubernetes/apps/database/emqx/cluster/cluster.yaml
+++ b/kubernetes/apps/database/emqx/cluster/cluster.yaml
@@ -31,6 +31,18 @@ spec:
         max_packet_size = 100MB
         retain_available = true
       }
+      # zigbee2mqtt's retained bridge/devices payload is >1MB and Home Assistant
+      # fetches thousands of retained discovery messages at once on reconnect;
+      # the 1MB / 1000-per-second defaults silently drop both.
+      retainer {
+        max_payload_size = "5MB"
+        delivery_rate = "infinity"
+        max_publish_rate = "infinity"
+        flow_control {
+          batch_read_number = 0
+          batch_deliver_limiter = "infinity"
+        }
+      }
   coreTemplate:
     spec:
       # Single core node: EMQX 6.x is Enterprise; the built-in free Developer


### PR DESCRIPTION
## Problem
The smarthome stack was degraded: Home Assistant entities (`light.master_bedroom`, `light.upstairs_chandelier`, etc.) intermittently unavailable and Node-RED automations erroring on missing entities.

Root cause in EMQX (post 6.2.1 migration, defaults changed vs 5.8):
- `retainer.max_payload_size` default 1MB rejected zigbee2mqtt's retained `bridge/devices` payload (1.23MB): `retain_failed_for_payload_size_exceeded_limit`
- Retained-delivery limiters at 1000/s dropped most of the `homeassistant/#` retained discovery fetch on client reconnect (125 of 1000 delivered): `retained_fetch_rate_limit_exceeded`

## Fix
Raise `max_payload_size` to 5MB and disable retained-delivery rate limiting (single-node home broker, ~3.3k retained messages).

Config was validated by hot-loading on the live broker with `emqx ctl conf load` (accepted, persisted); this PR makes it durable in the CR.

