### PR TITLE
sec(talos): apiserver claim validation + audit-stable uid

### DIFF
--- a/kubernetes/bootstrap/talos/patches/controller/apiserver-oidc.yaml
+++ b/kubernetes/bootstrap/talos/patches/controller/apiserver-oidc.yaml
@@ -20,15 +20,14 @@
 # Adding a new OIDC-to-apiserver app (e.g. another dashboard) = add a jwt authenticator
 # block below with that app's issuer + audience.
 #
-# TODO (fold in NEXT time the embedded config below changes — every content change
-# reboots each control-plane node, not worth a dedicated roll; the primary gate already
-# exists as Authentik policy bindings on the kubectl/headlamp applications):
-#   - claimValidationRules per authenticator, e.g.
-#       claimValidationRules:
-#         - expression: 'claims.groups.exists(g, g in ["kubernetes-admins", "kubernetes-viewers"])'
-#           message: "not a member of a kubernetes access group"
-#   - uid claim mapping (audit-stable identity; preferred_username is user-editable):
-#       uid: { claim: "sub" }
+# Hardening (both authenticators):
+#   - claimValidationRules: the apiserver itself rejects tokens whose groups claim has
+#     no kubernetes-* access group — a second gate independent of the Authentik policy
+#     bindings on the kubectl/headlamp applications. CEL errors fail CLOSED (a token
+#     with no groups claim at all is rejected, which is the desired direction).
+#   - uid <- sub: audit-stable identity. preferred_username is user-editable in
+#     Authentik; sub (sub_mode: hashed_user_id) is immutable. Never bind kind: User
+#     RBAC to oidc: usernames.
 # NOTE: never add an `anonymous:` section to the config — Talos sets
 # --anonymous-auth=false and the combination is rejected by the apiserver
 # (siderolabs/talos#11324).
@@ -61,6 +60,11 @@ machine:
               groups:
                 claim: "groups"
                 prefix: "oidc:"
+              uid:
+                claim: "sub"
+            claimValidationRules:
+              - expression: 'claims.groups.exists(g, g in ["kubernetes-admins", "kubernetes-viewers"])'
+                message: "not a member of a kubernetes access group"
           # Headlamp web dashboard
           - issuer:
               url: "https://sso.chelonianlabs.com/application/o/headlamp/"
@@ -73,3 +77,8 @@ machine:
               groups:
                 claim: "groups"
                 prefix: "oidc:"
+              uid:
+                claim: "sub"
+            claimValidationRules:
+              - expression: 'claims.groups.exists(g, g in ["kubernetes-admins", "kubernetes-viewers"])'
+                message: "not a member of a kubernetes access group"


### PR DESCRIPTION
Closes the parked hardening TODO from the OIDC security review (#3515 follow-up):

- **claimValidationRules** on both jwt authenticators — the apiserver itself rejects tokens whose `groups` claim lacks `kubernetes-admins`/`kubernetes-viewers`. Second gate, independent of the Authentik policy bindings; survives any IdP misconfig. CEL errors fail **closed** (a token with no groups claim is rejected).
- **`uid: sub` claim mapping** — audit-stable identity. `preferred_username` is user-editable in Authentik; `sub` (`sub_mode: hashed_user_id`) is immutable. Retires the mutable-username caveat.

**Rollout**: machine.files content change → per-node reboot. Staged: control-1 → verify (apiserver up, member OIDC login passes CEL) → control-2 → control-3. Same battle-tested procedure as the multi-issuer rollout; x509 break-glass unaffected throughout.

Validated: rendered machineconfig carries both rules + uid mappings; embedded AuthenticationConfiguration parses; expression matches the upstream k8s docs pattern.