### PR TITLE
chore(claude): symlink gitignored creds into worktrees via SessionStart hook

### DIFF
--- a/.claude/hooks/link-worktree-creds.sh
+++ b/.claude/hooks/link-worktree-creds.sh
@@ -1,0 +1,28 @@
+#!/usr/bin/env bash
+# SessionStart hook: git worktrees only contain tracked files, but the
+# Taskfile pins these gitignored credentials to ROOT_DIR (kubeconfig,
+# age.key, talosconfig). Symlink them in from the main checkout so
+# `task kubernetes:*`, `task talos:*`, and sops decryption work in
+# worktree sessions without manual setup.
+set -euo pipefail
+
+cd "${CLAUDE_PROJECT_DIR:-.}"
+
+gitdir="$(git rev-parse --absolute-git-dir 2>/dev/null)" || exit 0
+common="$(git rev-parse --path-format=absolute --git-common-dir 2>/dev/null)" || exit 0
+
+# Main checkout (git-dir == common-dir): nothing to link.
+[ "$gitdir" = "$common" ] && exit 0
+
+main_root="$(dirname "$common")"
+
+for f in \
+  kubeconfig \
+  age.key \
+  kubernetes/bootstrap/talos/clusterconfig/talosconfig; do
+  if [ -e "$main_root/$f" ] && [ ! -e "$f" ]; then
+    mkdir -p "$(dirname "$f")"
+    ln -s "$main_root/$f" "$f"
+  fi
+done
+exit 0

--- a/.claude/settings.json
+++ b/.claude/settings.json
@@ -14,6 +14,16 @@
     ]
   },
   "hooks": {
+    "SessionStart": [
+      {
+        "hooks": [
+          {
+            "type": "command",
+            "command": "$CLAUDE_PROJECT_DIR/.claude/hooks/link-worktree-creds.sh"
+          }
+        ]
+      }
+    ],
     "PreToolUse": [
       {
         "matcher": "Bash",


### PR DESCRIPTION
## Problem

Claude Code sessions run in git worktrees, which only contain **tracked** files. But `Taskfile.yaml` pins three gitignored credentials to `ROOT_DIR`:

- `kubeconfig` → breaks every `task kubernetes:*`
- `age.key` (`SOPS_AGE_KEY_FILE`) → breaks sops decryption
- `kubernetes/bootstrap/talos/clusterconfig/talosconfig` → breaks `task talos:*`

Every worktree session hit this and had to hand-symlink `kubeconfig` before task commands worked.

## Fix

A `SessionStart` hook (`.claude/hooks/link-worktree-creds.sh`) that runs once per session: if the session is in a worktree (git-dir ≠ common-dir), it symlinks each of the three files from the main checkout root, skipping any that already exist. No-op in the main checkout, idempotent, silent.

Verified in three live worktrees: `kubectl get nodes` via the linked kubeconfig and a sops decrypt via the linked age.key both work.