### PR TITLE
fix(tautulli): sync JBOPS into config PVC so script notifiers can execute

### DIFF
--- a/kubernetes/apps/media/tautulli/app/helmrelease.yaml
+++ b/kubernetes/apps/media/tautulli/app/helmrelease.yaml
@@ -100,8 +100,18 @@ spec:
     persistence:
       config:
         existingClaim: tautulli
+      # JBOPS must live inside Tautulli's data dir (/config): Tautulli >=2.15
+      # refuses to execute scripts from mounted paths outside it
+      # ("Script folder is on a mounted path which is not allowed").
+      # git-sync writes to a subPath of the config PVC, which the app
+      # container sees at /config/add-ons via its existing /config mount.
       add-ons:
-        type: emptyDir
+        existingClaim: tautulli
+        advancedMounts:
+          tautulli:
+            jbops:
+              - path: /add-ons
+                subPath: add-ons
       cache:
         existingClaim: tautulli-cache
         globalMounts:


### PR DESCRIPTION
## Problem

Tautulli's "Kill streams paused for 60 min" notifier (JBOPS `kill_stream.py`) has been silently broken since **2026-05-04**. Every pause event logs:

```
Tautulli Notifiers :: Script folder is on a mounted path which is not allowed.
```

Tautulli >=2.15 refuses to execute scripts from mounted filesystems unless they're inside its data dir (`/config`) or `allow_mounted_folders` is enabled. The JBOPS git-sync sidecar was writing to an `emptyDir` mounted at `/add-ons`, which trips the check. 28 blocked kill attempts in the current log alone (e.g. a stream left paused ~20h on 2026-06-30).

## Fix

Point git-sync at the `add-ons` subPath of the existing tautulli config PVC (mounted only in the `jbops` container). The app container already mounts the whole PVC at `/config`, so scripts appear at `/config/add-ons/JBOPS` — inside the data dir and exempt from the check, keeping the security default (`allow_mounted_folders = 0`) intact.

`/config/add-ons` was pre-created on the PVC as uid 1000 so the subPath mount doesn't get root-owned. Notifier script paths (IDs 2/4/5) will be repointed to `/config/add-ons/JBOPS/killstream` after rollout (runtime config, not GitOps-managed).