### PR TITLE
fix(cilium): static forward-auth SecurityPolicy for hubble-ui

### DIFF
--- a/kubernetes/apps/home-automation/zigbee2mqtt-garage/app/helmrelease.yaml
+++ b/kubernetes/apps/home-automation/zigbee2mqtt-garage/app/helmrelease.yaml
@@ -93,13 +93,18 @@ spec:
             image:
               repository: ghcr.io/coder/code-server
               tag: 4.126.0@sha256:e1f03b5faaefd63ba6c7173a5290c6ec0526ac907f23acfe6bc949dd965279e4
-            args: [
-              "--auth", "none",
-              "--user-data-dir", "/app/data/.vscode",
-              "--extensions-dir", "/app/data/.vscode",
-              "--port", "12321",
-              "/app/data"
-            ]
+            args:
+              [
+                "--auth",
+                "none",
+                "--user-data-dir",
+                "/app/data/.vscode",
+                "--extensions-dir",
+                "/app/data/.vscode",
+                "--port",
+                "12321",
+                "/app/data",
+              ]
     service:
       app:
         controller: zigbee2mqtt-garage
@@ -122,6 +127,8 @@ spec:
               - identifier: app
                 port: http
       code-server:
+        annotations:
+          authentik.home.arpa/forward-auth: "true"
         hostnames: ["zigbee-garage-code.${SECRET_DOMAIN}"]
         parentRefs:
           - name: internal

--- a/kubernetes/apps/home-automation/zigbee2mqtt/app/helmrelease.yaml
+++ b/kubernetes/apps/home-automation/zigbee2mqtt/app/helmrelease.yaml
@@ -92,13 +92,18 @@ spec:
             image:
               repository: ghcr.io/coder/code-server
               tag: 4.126.0@sha256:e1f03b5faaefd63ba6c7173a5290c6ec0526ac907f23acfe6bc949dd965279e4
-            args: [
-              "--auth", "none",
-              "--user-data-dir", "/app/data/.vscode",
-              "--extensions-dir", "/app/data/.vscode",
-              "--port", "12321",
-              "/app/data"
-            ]
+            args:
+              [
+                "--auth",
+                "none",
+                "--user-data-dir",
+                "/app/data/.vscode",
+                "--extensions-dir",
+                "/app/data/.vscode",
+                "--port",
+                "12321",
+                "/app/data",
+              ]
     service:
       app:
         controller: zigbee2mqtt
@@ -121,6 +126,8 @@ spec:
               - identifier: app
                 port: http
       code-server:
+        annotations:
+          authentik.home.arpa/forward-auth: "true"
         hostnames: ["zigbee-code.${SECRET_DOMAIN}"]
         parentRefs:
           - name: internal

--- a/kubernetes/apps/kube-system/cilium/app/httproute.yaml
+++ b/kubernetes/apps/kube-system/cilium/app/httproute.yaml
@@ -5,6 +5,7 @@ metadata:
   name: hubble-ui
   namespace: kube-system
   annotations:
+    authentik.home.arpa/forward-auth: "true"
     # Dashboard discovery (Homepage) — preserved from the old cilium ui.ingress.
     gethomepage.dev/enabled: "true"
     gethomepage.dev/name: Hubble

--- a/kubernetes/apps/kube-system/cilium/app/kustomization.yaml
+++ b/kubernetes/apps/kube-system/cilium/app/kustomization.yaml
@@ -5,6 +5,7 @@ kind: Kustomization
 resources:
   - ./helmrelease.yaml
   - ./httproute.yaml
+  - ./securitypolicy.yaml
   - ./ocirepository.yaml
 configMapGenerator:
   - name: cilium-helm-values

--- a/kubernetes/apps/kube-system/cilium/app/securitypolicy.yaml
+++ b/kubernetes/apps/kube-system/cilium/app/securitypolicy.yaml
@@ -1,0 +1,38 @@
+---
+# STATIC forward-auth SecurityPolicy for hubble-ui. Everywhere else this is generated
+# by the Kyverno ClusterPolicy (httproute-authentik-forward-auth) from the route
+# annotation — but Kyverno globally excludes kube-system (resourceFilters + webhook
+# namespaceSelector), so this namespace needs the hand-written equivalent. Keep in
+# sync with the template in kyverno/policies/httproute-authentik-forward-auth.yaml.
+# The companion ReferenceGrant lives in the authentik app (security namespace).
+apiVersion: gateway.envoyproxy.io/v1alpha1
+kind: SecurityPolicy
+metadata:
+  name: hubble-ui-forward-auth
+  namespace: kube-system
+spec:
+  targetRefs:
+    - group: gateway.networking.k8s.io
+      kind: HTTPRoute
+      name: hubble-ui
+  extAuth:
+    failOpen: false
+    headersToExtAuth:
+      - host
+      - cookie
+      - x-forwarded-proto
+      - x-forwarded-host
+      - x-forwarded-for
+    http:
+      backendRefs:
+        - name: ak-outpost-authentik-embedded-outpost
+          namespace: security
+          port: 9000
+      path: /outpost.goauthentik.io/auth/envoy
+      headersToBackend:
+        - set-cookie
+        - x-authentik-username
+        - x-authentik-email
+        - x-authentik-groups
+        - x-authentik-uid
+        - x-authentik-name

--- a/kubernetes/apps/observability/blackbox-exporter/app/httproute.yaml
+++ b/kubernetes/apps/observability/blackbox-exporter/app/httproute.yaml
@@ -4,6 +4,8 @@ kind: HTTPRoute
 metadata:
   name: blackbox-exporter
   namespace: observability
+  annotations:
+    authentik.home.arpa/forward-auth: "true"
 spec:
   parentRefs:
     - name: internal

--- a/kubernetes/apps/observability/goldilocks/app/httproute.yaml
+++ b/kubernetes/apps/observability/goldilocks/app/httproute.yaml
@@ -4,6 +4,8 @@ kind: HTTPRoute
 metadata:
   name: goldilocks
   namespace: observability
+  annotations:
+    authentik.home.arpa/forward-auth: "true"
 spec:
   parentRefs:
     - name: internal

--- a/kubernetes/apps/observability/kube-prometheus-stack/app/httproute.yaml
+++ b/kubernetes/apps/observability/kube-prometheus-stack/app/httproute.yaml
@@ -4,6 +4,8 @@ kind: HTTPRoute
 metadata:
   name: alertmanager
   namespace: observability
+  annotations:
+    authentik.home.arpa/forward-auth: "true"
 spec:
   parentRefs:
     - name: internal
@@ -19,6 +21,8 @@ kind: HTTPRoute
 metadata:
   name: prometheus
   namespace: observability
+  annotations:
+    authentik.home.arpa/forward-auth: "true"
 spec:
   parentRefs:
     - name: internal

--- a/kubernetes/apps/observability/peanut/app/helmrelease.yaml
+++ b/kubernetes/apps/observability/peanut/app/helmrelease.yaml
@@ -51,6 +51,8 @@ spec:
 
     route:
       app:
+        annotations:
+          authentik.home.arpa/forward-auth: "true"
         hostnames: ["ups.${SECRET_DOMAIN}"]
         parentRefs:
           - name: internal

--- a/kubernetes/apps/security/authentik/app/blueprints.yaml
+++ b/kubernetes/apps/security/authentik/app/blueprints.yaml
@@ -131,6 +131,69 @@ data:
       - model: authentik_core.application
         identifiers: { slug: firefly }
         attrs: { name: Firefly III, group: home, provider: !KeyOf firefly-provider, meta_icon: "https://cdn.jsdelivr.net/gh/selfhst/icons/svg/firefly-iii.svg", meta_launch_url: "https://firefly.${SECRET_DOMAIN}" }
+      # peanut — UPS dashboard; app itself runs AUTH_DISABLED (no built-in auth)
+      - model: authentik_providers_proxy.proxyprovider
+        identifiers: { name: Provider for PeaNUT }
+        id: peanut-provider
+        attrs: { <<: *proxy, external_host: "https://ups.${SECRET_DOMAIN}" }
+      - model: authentik_core.application
+        identifiers: { slug: peanut }
+        attrs: { name: PeaNUT, group: internal, provider: !KeyOf peanut-provider, meta_icon: "https://cdn.jsdelivr.net/gh/selfhst/icons/svg/peanut.svg", meta_launch_url: "https://ups.${SECRET_DOMAIN}" }
+      # prometheus — no built-in auth
+      - model: authentik_providers_proxy.proxyprovider
+        identifiers: { name: Provider for Prometheus }
+        id: prometheus-provider
+        attrs: { <<: *proxy, external_host: "https://prometheus.${SECRET_DOMAIN}" }
+      - model: authentik_core.application
+        identifiers: { slug: prometheus }
+        attrs: { name: Prometheus, group: internal, provider: !KeyOf prometheus-provider, meta_icon: "https://cdn.jsdelivr.net/gh/selfhst/icons/svg/prometheus.svg", meta_launch_url: "https://prometheus.${SECRET_DOMAIN}" }
+      # alertmanager — no built-in auth (Prometheus pushes alerts in-cluster, unaffected)
+      - model: authentik_providers_proxy.proxyprovider
+        identifiers: { name: Provider for Alertmanager }
+        id: alertmanager-provider
+        attrs: { <<: *proxy, external_host: "https://alertmanager.${SECRET_DOMAIN}" }
+      - model: authentik_core.application
+        identifiers: { slug: alertmanager }
+        attrs: { name: Alertmanager, group: internal, provider: !KeyOf alertmanager-provider, meta_icon: "https://cdn.jsdelivr.net/gh/selfhst/icons/svg/prometheus.svg", meta_launch_url: "https://alertmanager.${SECRET_DOMAIN}" }
+      # hubble-ui — read-only network observability, no built-in auth
+      - model: authentik_providers_proxy.proxyprovider
+        identifiers: { name: Provider for Hubble }
+        id: hubble-provider
+        attrs: { <<: *proxy, external_host: "https://hubble.${SECRET_DOMAIN}" }
+      - model: authentik_core.application
+        identifiers: { slug: hubble }
+        attrs: { name: Hubble, group: internal, provider: !KeyOf hubble-provider, meta_icon: "https://cdn.jsdelivr.net/gh/selfhst/icons/svg/cilium.svg", meta_launch_url: "https://hubble.${SECRET_DOMAIN}" }
+      # goldilocks — VPA dashboard, no built-in auth
+      - model: authentik_providers_proxy.proxyprovider
+        identifiers: { name: Provider for Goldilocks }
+        id: goldilocks-provider
+        attrs: { <<: *proxy, external_host: "https://goldilocks.${SECRET_DOMAIN}" }
+      - model: authentik_core.application
+        identifiers: { slug: goldilocks }
+        attrs: { name: Goldilocks, group: internal, provider: !KeyOf goldilocks-provider, meta_icon: "https://cdn.jsdelivr.net/gh/selfhst/icons/svg/kubernetes.svg", meta_launch_url: "https://goldilocks.${SECRET_DOMAIN}" }
+      # blackbox-exporter — probe UI, no built-in auth (Prometheus scrapes in-cluster, unaffected)
+      - model: authentik_providers_proxy.proxyprovider
+        identifiers: { name: Provider for Blackbox Exporter }
+        id: blackbox-provider
+        attrs: { <<: *proxy, external_host: "https://blackbox-exporter.${SECRET_DOMAIN}" }
+      - model: authentik_core.application
+        identifiers: { slug: blackbox-exporter }
+        attrs: { name: Blackbox Exporter, group: internal, provider: !KeyOf blackbox-provider, meta_icon: "https://cdn.jsdelivr.net/gh/selfhst/icons/svg/prometheus.svg", meta_launch_url: "https://blackbox-exporter.${SECRET_DOMAIN}" }
+      # zigbee2mqtt code-servers — sidecars run `--auth none` (a shell into the pod)
+      - model: authentik_providers_proxy.proxyprovider
+        identifiers: { name: Provider for Zigbee Code }
+        id: zigbeecode-provider
+        attrs: { <<: *proxy, external_host: "https://zigbee-code.${SECRET_DOMAIN}" }
+      - model: authentik_core.application
+        identifiers: { slug: zigbee-code }
+        attrs: { name: Zigbee Code, group: home, provider: !KeyOf zigbeecode-provider, meta_icon: "https://cdn.jsdelivr.net/gh/selfhst/icons/svg/coder.svg", meta_launch_url: "https://zigbee-code.${SECRET_DOMAIN}" }
+      - model: authentik_providers_proxy.proxyprovider
+        identifiers: { name: Provider for Zigbee Garage Code }
+        id: zigbeegaragecode-provider
+        attrs: { <<: *proxy, external_host: "https://zigbee-garage-code.${SECRET_DOMAIN}" }
+      - model: authentik_core.application
+        identifiers: { slug: zigbee-garage-code }
+        attrs: { name: Zigbee Garage Code, group: home, provider: !KeyOf zigbeegaragecode-provider, meta_icon: "https://cdn.jsdelivr.net/gh/selfhst/icons/svg/coder.svg", meta_launch_url: "https://zigbee-garage-code.${SECRET_DOMAIN}" }
       # Embedded outpost: disables the k8s Ingress AND declaratively owns the assigned-
       # provider list. Adding an app = its 2 entries above (with id:) + one !KeyOf line here.
       - model: authentik_outposts.outpost
@@ -170,3 +233,11 @@ data:
             - !KeyOf 4kbazarr-provider
             - !KeyOf posterizarr-provider
             - !KeyOf firefly-provider
+            - !KeyOf peanut-provider
+            - !KeyOf prometheus-provider
+            - !KeyOf alertmanager-provider
+            - !KeyOf hubble-provider
+            - !KeyOf goldilocks-provider
+            - !KeyOf blackbox-provider
+            - !KeyOf zigbeecode-provider
+            - !KeyOf zigbeegaragecode-provider

--- a/kubernetes/apps/security/authentik/app/kustomization.yaml
+++ b/kubernetes/apps/security/authentik/app/kustomization.yaml
@@ -9,3 +9,4 @@ resources:
   - ./blueprints-oidc.yaml
   - ./helmrelease.yaml
   - ./httproute.yaml
+  - ./referencegrant-kube-system.yaml

--- a/kubernetes/apps/security/authentik/app/referencegrant-kube-system.yaml
+++ b/kubernetes/apps/security/authentik/app/referencegrant-kube-system.yaml
@@ -1,0 +1,20 @@
+---
+# STATIC ReferenceGrant for the hubble-ui forward-auth SecurityPolicy (kube-system).
+# Everywhere else Kyverno generates securitypolicy-to-outpost-<ns> on demand, but
+# Kyverno globally excludes kube-system, so this one is hand-written. Same shape as
+# the generated grants; lives here because it must be in the security namespace
+# (it authorizes cross-namespace refs TO the outpost Service).
+apiVersion: gateway.networking.k8s.io/v1beta1
+kind: ReferenceGrant
+metadata:
+  name: securitypolicy-to-outpost-kube-system
+  namespace: security
+spec:
+  from:
+    - group: gateway.envoyproxy.io
+      kind: SecurityPolicy
+      namespace: kube-system
+  to:
+    - group: ""
+      kind: Service
+      name: ak-outpost-authentik-embedded-outpost


### PR DESCRIPTION
Follow-up to #3522: Kyverno globally excludes kube-system, so the annotation-driven SecurityPolicy generation never fires for hubble-ui (7 of 8 policies appeared). This adds the static SecurityPolicy (kube-system) + ReferenceGrant (security ns) mirroring the Kyverno template, with comments pointing back at the template for future sync.