### PR TITLE
feat(paperless): native OIDC login via Authentik

### DIFF
--- a/kubernetes/apps/home-automation/zigbee2mqtt-garage/app/helmrelease.yaml
+++ b/kubernetes/apps/home-automation/zigbee2mqtt-garage/app/helmrelease.yaml
@@ -93,13 +93,18 @@ spec:
             image:
               repository: ghcr.io/coder/code-server
               tag: 4.126.0@sha256:e1f03b5faaefd63ba6c7173a5290c6ec0526ac907f23acfe6bc949dd965279e4
-            args: [
-              "--auth", "none",
-              "--user-data-dir", "/app/data/.vscode",
-              "--extensions-dir", "/app/data/.vscode",
-              "--port", "12321",
-              "/app/data"
-            ]
+            args:
+              [
+                "--auth",
+                "none",
+                "--user-data-dir",
+                "/app/data/.vscode",
+                "--extensions-dir",
+                "/app/data/.vscode",
+                "--port",
+                "12321",
+                "/app/data",
+              ]
     service:
       app:
         controller: zigbee2mqtt-garage
@@ -122,6 +127,8 @@ spec:
               - identifier: app
                 port: http
       code-server:
+        annotations:
+          authentik.home.arpa/forward-auth: "true"
         hostnames: ["zigbee-garage-code.${SECRET_DOMAIN}"]
         parentRefs:
           - name: internal

--- a/kubernetes/apps/home-automation/zigbee2mqtt/app/helmrelease.yaml
+++ b/kubernetes/apps/home-automation/zigbee2mqtt/app/helmrelease.yaml
@@ -92,13 +92,18 @@ spec:
             image:
               repository: ghcr.io/coder/code-server
               tag: 4.126.0@sha256:e1f03b5faaefd63ba6c7173a5290c6ec0526ac907f23acfe6bc949dd965279e4
-            args: [
-              "--auth", "none",
-              "--user-data-dir", "/app/data/.vscode",
-              "--extensions-dir", "/app/data/.vscode",
-              "--port", "12321",
-              "/app/data"
-            ]
+            args:
+              [
+                "--auth",
+                "none",
+                "--user-data-dir",
+                "/app/data/.vscode",
+                "--extensions-dir",
+                "/app/data/.vscode",
+                "--port",
+                "12321",
+                "/app/data",
+              ]
     service:
       app:
         controller: zigbee2mqtt
@@ -121,6 +126,8 @@ spec:
               - identifier: app
                 port: http
       code-server:
+        annotations:
+          authentik.home.arpa/forward-auth: "true"
         hostnames: ["zigbee-code.${SECRET_DOMAIN}"]
         parentRefs:
           - name: internal

--- a/kubernetes/apps/kube-system/cilium/app/httproute.yaml
+++ b/kubernetes/apps/kube-system/cilium/app/httproute.yaml
@@ -5,6 +5,7 @@ metadata:
   name: hubble-ui
   namespace: kube-system
   annotations:
+    authentik.home.arpa/forward-auth: "true"
     # Dashboard discovery (Homepage) — preserved from the old cilium ui.ingress.
     gethomepage.dev/enabled: "true"
     gethomepage.dev/name: Hubble

--- a/kubernetes/apps/kube-system/cilium/app/kustomization.yaml
+++ b/kubernetes/apps/kube-system/cilium/app/kustomization.yaml
@@ -5,6 +5,7 @@ kind: Kustomization
 resources:
   - ./helmrelease.yaml
   - ./httproute.yaml
+  - ./securitypolicy.yaml
   - ./ocirepository.yaml
 configMapGenerator:
   - name: cilium-helm-values

--- a/kubernetes/apps/kube-system/cilium/app/securitypolicy.yaml
+++ b/kubernetes/apps/kube-system/cilium/app/securitypolicy.yaml
@@ -1,0 +1,38 @@
+---
+# STATIC forward-auth SecurityPolicy for hubble-ui. Everywhere else this is generated
+# by the Kyverno ClusterPolicy (httproute-authentik-forward-auth) from the route
+# annotation — but Kyverno globally excludes kube-system (resourceFilters + webhook
+# namespaceSelector), so this namespace needs the hand-written equivalent. Keep in
+# sync with the template in kyverno/policies/httproute-authentik-forward-auth.yaml.
+# The companion ReferenceGrant lives in the authentik app (security namespace).
+apiVersion: gateway.envoyproxy.io/v1alpha1
+kind: SecurityPolicy
+metadata:
+  name: hubble-ui-forward-auth
+  namespace: kube-system
+spec:
+  targetRefs:
+    - group: gateway.networking.k8s.io
+      kind: HTTPRoute
+      name: hubble-ui
+  extAuth:
+    failOpen: false
+    headersToExtAuth:
+      - host
+      - cookie
+      - x-forwarded-proto
+      - x-forwarded-host
+      - x-forwarded-for
+    http:
+      backendRefs:
+        - name: ak-outpost-authentik-embedded-outpost
+          namespace: security
+          port: 9000
+      path: /outpost.goauthentik.io/auth/envoy
+      headersToBackend:
+        - set-cookie
+        - x-authentik-username
+        - x-authentik-email
+        - x-authentik-groups
+        - x-authentik-uid
+        - x-authentik-name

--- a/kubernetes/apps/observability/blackbox-exporter/app/httproute.yaml
+++ b/kubernetes/apps/observability/blackbox-exporter/app/httproute.yaml
@@ -4,6 +4,8 @@ kind: HTTPRoute
 metadata:
   name: blackbox-exporter
   namespace: observability
+  annotations:
+    authentik.home.arpa/forward-auth: "true"
 spec:
   parentRefs:
     - name: internal

--- a/kubernetes/apps/observability/goldilocks/app/httproute.yaml
+++ b/kubernetes/apps/observability/goldilocks/app/httproute.yaml
@@ -4,6 +4,8 @@ kind: HTTPRoute
 metadata:
   name: goldilocks
   namespace: observability
+  annotations:
+    authentik.home.arpa/forward-auth: "true"
 spec:
   parentRefs:
     - name: internal

--- a/kubernetes/apps/observability/kube-prometheus-stack/app/httproute.yaml
+++ b/kubernetes/apps/observability/kube-prometheus-stack/app/httproute.yaml
@@ -4,6 +4,8 @@ kind: HTTPRoute
 metadata:
   name: alertmanager
   namespace: observability
+  annotations:
+    authentik.home.arpa/forward-auth: "true"
 spec:
   parentRefs:
     - name: internal
@@ -19,6 +21,8 @@ kind: HTTPRoute
 metadata:
   name: prometheus
   namespace: observability
+  annotations:
+    authentik.home.arpa/forward-auth: "true"
 spec:
   parentRefs:
     - name: internal

--- a/kubernetes/apps/observability/peanut/app/helmrelease.yaml
+++ b/kubernetes/apps/observability/peanut/app/helmrelease.yaml
@@ -51,6 +51,8 @@ spec:
 
     route:
       app:
+        annotations:
+          authentik.home.arpa/forward-auth: "true"
         hostnames: ["ups.${SECRET_DOMAIN}"]
         parentRefs:
           - name: internal

--- a/kubernetes/apps/security/authentik/app/blueprints-oidc.yaml
+++ b/kubernetes/apps/security/authentik/app/blueprints-oidc.yaml
@@ -211,3 +211,19 @@ data:
         attrs:
           group: !Find [authentik_core.group, [name, kubernetes-viewers]]
           enabled: true
+      # paperless-ngx — native OIDC via django-allauth (paperless >= 2.5). Pinned
+      # client_id (headlamp pattern); Authentik generates the client_secret on first
+      # apply -> copy into Infisical as PAPERLESS_OIDC_CLIENT_SECRET. The redirect
+      # path embeds allauth's provider_id ("authentik", set in
+      # PAPERLESS_SOCIALACCOUNT_PROVIDERS on the app side).
+      - model: authentik_providers_oauth2.oauth2provider
+        identifiers: { name: Paperless OIDC }
+        id: paperless-oidc
+        attrs:
+          <<: *oidc
+          client_id: paperless
+          redirect_uris:
+            - { matching_mode: strict, url: "https://docs.${SECRET_DOMAIN}/accounts/oidc/authentik/login/callback/", redirect_uri_type: authorization }
+      - model: authentik_core.application
+        identifiers: { slug: paperless }
+        attrs: { name: Paperless-ngx, group: home, provider: !KeyOf paperless-oidc, meta_icon: "https://cdn.jsdelivr.net/gh/selfhst/icons/svg/paperless-ngx.svg", meta_launch_url: "https://docs.${SECRET_DOMAIN}" }

--- a/kubernetes/apps/security/authentik/app/blueprints.yaml
+++ b/kubernetes/apps/security/authentik/app/blueprints.yaml
@@ -131,6 +131,69 @@ data:
       - model: authentik_core.application
         identifiers: { slug: firefly }
         attrs: { name: Firefly III, group: home, provider: !KeyOf firefly-provider, meta_icon: "https://cdn.jsdelivr.net/gh/selfhst/icons/svg/firefly-iii.svg", meta_launch_url: "https://firefly.${SECRET_DOMAIN}" }
+      # peanut — UPS dashboard; app itself runs AUTH_DISABLED (no built-in auth)
+      - model: authentik_providers_proxy.proxyprovider
+        identifiers: { name: Provider for PeaNUT }
+        id: peanut-provider
+        attrs: { <<: *proxy, external_host: "https://ups.${SECRET_DOMAIN}" }
+      - model: authentik_core.application
+        identifiers: { slug: peanut }
+        attrs: { name: PeaNUT, group: internal, provider: !KeyOf peanut-provider, meta_icon: "https://cdn.jsdelivr.net/gh/selfhst/icons/svg/peanut.svg", meta_launch_url: "https://ups.${SECRET_DOMAIN}" }
+      # prometheus — no built-in auth
+      - model: authentik_providers_proxy.proxyprovider
+        identifiers: { name: Provider for Prometheus }
+        id: prometheus-provider
+        attrs: { <<: *proxy, external_host: "https://prometheus.${SECRET_DOMAIN}" }
+      - model: authentik_core.application
+        identifiers: { slug: prometheus }
+        attrs: { name: Prometheus, group: internal, provider: !KeyOf prometheus-provider, meta_icon: "https://cdn.jsdelivr.net/gh/selfhst/icons/svg/prometheus.svg", meta_launch_url: "https://prometheus.${SECRET_DOMAIN}" }
+      # alertmanager — no built-in auth (Prometheus pushes alerts in-cluster, unaffected)
+      - model: authentik_providers_proxy.proxyprovider
+        identifiers: { name: Provider for Alertmanager }
+        id: alertmanager-provider
+        attrs: { <<: *proxy, external_host: "https://alertmanager.${SECRET_DOMAIN}" }
+      - model: authentik_core.application
+        identifiers: { slug: alertmanager }
+        attrs: { name: Alertmanager, group: internal, provider: !KeyOf alertmanager-provider, meta_icon: "https://cdn.jsdelivr.net/gh/selfhst/icons/svg/prometheus.svg", meta_launch_url: "https://alertmanager.${SECRET_DOMAIN}" }
+      # hubble-ui — read-only network observability, no built-in auth
+      - model: authentik_providers_proxy.proxyprovider
+        identifiers: { name: Provider for Hubble }
+        id: hubble-provider
+        attrs: { <<: *proxy, external_host: "https://hubble.${SECRET_DOMAIN}" }
+      - model: authentik_core.application
+        identifiers: { slug: hubble }
+        attrs: { name: Hubble, group: internal, provider: !KeyOf hubble-provider, meta_icon: "https://cdn.jsdelivr.net/gh/selfhst/icons/svg/cilium.svg", meta_launch_url: "https://hubble.${SECRET_DOMAIN}" }
+      # goldilocks — VPA dashboard, no built-in auth
+      - model: authentik_providers_proxy.proxyprovider
+        identifiers: { name: Provider for Goldilocks }
+        id: goldilocks-provider
+        attrs: { <<: *proxy, external_host: "https://goldilocks.${SECRET_DOMAIN}" }
+      - model: authentik_core.application
+        identifiers: { slug: goldilocks }
+        attrs: { name: Goldilocks, group: internal, provider: !KeyOf goldilocks-provider, meta_icon: "https://cdn.jsdelivr.net/gh/selfhst/icons/svg/kubernetes.svg", meta_launch_url: "https://goldilocks.${SECRET_DOMAIN}" }
+      # blackbox-exporter — probe UI, no built-in auth (Prometheus scrapes in-cluster, unaffected)
+      - model: authentik_providers_proxy.proxyprovider
+        identifiers: { name: Provider for Blackbox Exporter }
+        id: blackbox-provider
+        attrs: { <<: *proxy, external_host: "https://blackbox-exporter.${SECRET_DOMAIN}" }
+      - model: authentik_core.application
+        identifiers: { slug: blackbox-exporter }
+        attrs: { name: Blackbox Exporter, group: internal, provider: !KeyOf blackbox-provider, meta_icon: "https://cdn.jsdelivr.net/gh/selfhst/icons/svg/prometheus.svg", meta_launch_url: "https://blackbox-exporter.${SECRET_DOMAIN}" }
+      # zigbee2mqtt code-servers — sidecars run `--auth none` (a shell into the pod)
+      - model: authentik_providers_proxy.proxyprovider
+        identifiers: { name: Provider for Zigbee Code }
+        id: zigbeecode-provider
+        attrs: { <<: *proxy, external_host: "https://zigbee-code.${SECRET_DOMAIN}" }
+      - model: authentik_core.application
+        identifiers: { slug: zigbee-code }
+        attrs: { name: Zigbee Code, group: home, provider: !KeyOf zigbeecode-provider, meta_icon: "https://cdn.jsdelivr.net/gh/selfhst/icons/svg/coder.svg", meta_launch_url: "https://zigbee-code.${SECRET_DOMAIN}" }
+      - model: authentik_providers_proxy.proxyprovider
+        identifiers: { name: Provider for Zigbee Garage Code }
+        id: zigbeegaragecode-provider
+        attrs: { <<: *proxy, external_host: "https://zigbee-garage-code.${SECRET_DOMAIN}" }
+      - model: authentik_core.application
+        identifiers: { slug: zigbee-garage-code }
+        attrs: { name: Zigbee Garage Code, group: home, provider: !KeyOf zigbeegaragecode-provider, meta_icon: "https://cdn.jsdelivr.net/gh/selfhst/icons/svg/coder.svg", meta_launch_url: "https://zigbee-garage-code.${SECRET_DOMAIN}" }
       # Embedded outpost: disables the k8s Ingress AND declaratively owns the assigned-
       # provider list. Adding an app = its 2 entries above (with id:) + one !KeyOf line here.
       - model: authentik_outposts.outpost
@@ -170,3 +233,11 @@ data:
             - !KeyOf 4kbazarr-provider
             - !KeyOf posterizarr-provider
             - !KeyOf firefly-provider
+            - !KeyOf peanut-provider
+            - !KeyOf prometheus-provider
+            - !KeyOf alertmanager-provider
+            - !KeyOf hubble-provider
+            - !KeyOf goldilocks-provider
+            - !KeyOf blackbox-provider
+            - !KeyOf zigbeecode-provider
+            - !KeyOf zigbeegaragecode-provider

--- a/kubernetes/apps/security/authentik/app/kustomization.yaml
+++ b/kubernetes/apps/security/authentik/app/kustomization.yaml
@@ -9,3 +9,4 @@ resources:
   - ./blueprints-oidc.yaml
   - ./helmrelease.yaml
   - ./httproute.yaml
+  - ./referencegrant-kube-system.yaml

--- a/kubernetes/apps/security/authentik/app/referencegrant-kube-system.yaml
+++ b/kubernetes/apps/security/authentik/app/referencegrant-kube-system.yaml
@@ -1,0 +1,20 @@
+---
+# STATIC ReferenceGrant for the hubble-ui forward-auth SecurityPolicy (kube-system).
+# Everywhere else Kyverno generates securitypolicy-to-outpost-<ns> on demand, but
+# Kyverno globally excludes kube-system, so this one is hand-written. Same shape as
+# the generated grants; lives here because it must be in the security namespace
+# (it authorizes cross-namespace refs TO the outpost Service).
+apiVersion: gateway.networking.k8s.io/v1beta1
+kind: ReferenceGrant
+metadata:
+  name: securitypolicy-to-outpost-kube-system
+  namespace: security
+spec:
+  from:
+    - group: gateway.envoyproxy.io
+      kind: SecurityPolicy
+      namespace: kube-system
+  to:
+    - group: ""
+      kind: Service
+      name: ak-outpost-authentik-embedded-outpost

--- a/kubernetes/apps/selfhosted/paperless-ngx/app/externalsecret.yaml
+++ b/kubernetes/apps/selfhosted/paperless-ngx/app/externalsecret.yaml
@@ -26,6 +26,15 @@ spec:
         PAPERLESS_ADMIN_PASSWORD: "{{ .PAPERLESS_ADMIN_PASSWORD }}"
         PAPERLESS_OUTLOOK_OAUTH_CLIENT_ID: "{{ .PAPERLESS_OUTLOOK_OAUTH_CLIENT_ID }}"
         PAPERLESS_OUTLOOK_OAUTH_CLIENT_SECRET: "{{ .PAPERLESS_OUTLOOK_OAUTH_CLIENT_SECRET }}"
+        # Authentik OIDC (django-allauth). provider_id "authentik" determines the
+        # callback path (/accounts/oidc/authentik/login/callback/) registered on the
+        # Authentik provider. Secret = PAPERLESS_OIDC_CLIENT_SECRET in Infisical
+        # (copy from the Authentik-generated provider secret).
+        PAPERLESS_SOCIALACCOUNT_PROVIDERS: >-
+          {"openid_connect": {"SCOPE": ["openid", "profile", "email"], "OAUTH_PKCE_ENABLED": true,
+          "APPS": [{"provider_id": "authentik", "name": "Authentik", "client_id": "paperless",
+          "secret": "{{ .PAPERLESS_OIDC_CLIENT_SECRET }}",
+          "settings": {"server_url": "https://sso.chelonianlabs.com/application/o/paperless/.well-known/openid-configuration"}}]}}
   dataFrom:
     - find:
         name:

--- a/kubernetes/apps/selfhosted/paperless-ngx/app/helmrelease.yaml
+++ b/kubernetes/apps/selfhosted/paperless-ngx/app/helmrelease.yaml
@@ -44,7 +44,7 @@ spec:
               TZ: "${TIME_ZONE}"
 
               # Optional services
-              PAPERLESS_TIKA_ENABLED: 'true'
+              PAPERLESS_TIKA_ENABLED: "true"
               PAPERLESS_TIKA_GOTENBERG_ENDPOINT: http://gotenberg.selfhosted.svc.cluster.local:3000
               PAPERLESS_TIKA_ENDPOINT: http://127.0.0.1:9998
 
@@ -53,34 +53,39 @@ spec:
               PAPERLESS_DATA_DIR: /data/local
               PAPERLESS_MEDIA_ROOT: /media/paperless
               PAPERLESS_FILENAME_FORMAT: "{created_year}/{correspondent}/{title}"
-              PAPERLESS_FILENAME_FORMAT_REMOVE_NONE: 'true'
+              PAPERLESS_FILENAME_FORMAT_REMOVE_NONE: "true"
 
               # Logging
-              PAPERLESS_LOGROTATE_MAX_BACKUPS: '20'
+              PAPERLESS_LOGROTATE_MAX_BACKUPS: "20"
 
               # Hosting and security
               PAPERLESS_URL: "https://docs.${SECRET_DOMAIN}"
+              # Authentik OIDC (django-allauth). Provider config JSON (contains the
+              # client_secret) comes from the ExternalSecret as
+              # PAPERLESS_SOCIALACCOUNT_PROVIDERS. Local admin login stays enabled
+              # as fallback; link SSO via Profile -> Connect social account.
+              PAPERLESS_APPS: allauth.socialaccount.providers.openid_connect
 
               # OCR settings
               PAPERLESS_OCR_LANGUAGE: eng
               PAPERLESS_OCR_SKIP_ARCHIVE_FILE: with_text
-              PAPERLESS_OCR_DESKEW: 'false'
-              PAPERLESS_OCR_ROTATE_PAGES: 'false'
+              PAPERLESS_OCR_DESKEW: "false"
+              PAPERLESS_OCR_ROTATE_PAGES: "false"
 
               # Software tweaks
-              PAPERLESS_TASK_WORKERS: '2'
-              PAPERLESS_THREADS_PER_WORKER: '2'
+              PAPERLESS_TASK_WORKERS: "2"
+              PAPERLESS_THREADS_PER_WORKER: "2"
               PAPERLESS_TIME_ZONE: "${TIME_ZONE}"
 
               # Document consumption
-              PAPERLESS_CONSUMER_POLLING: '30'
-              PAPERLESS_CONSUMER_DELETE_DUPLICATES: 'true'
-              PAPERLESS_CONSUMER_RECURSIVE: 'true'
-              PAPERLESS_CONSUMER_SUBDIRS_AS_TAGS: 'true'
+              PAPERLESS_CONSUMER_POLLING: "30"
+              PAPERLESS_CONSUMER_DELETE_DUPLICATES: "true"
+              PAPERLESS_CONSUMER_RECURSIVE: "true"
+              PAPERLESS_CONSUMER_SUBDIRS_AS_TAGS: "true"
               PAPERLESS_FILENAME_DATE_ORDER: YMD
 
               # Docker-specific options
-              PAPERLESS_PORT: '8000'
+              PAPERLESS_PORT: "8000"
             envFrom:
               - secretRef:
                   name: paperless-ngx-secret


### PR DESCRIPTION
## What

**PR 2 of the SSO-coverage work**: paperless-ngx native OIDC (django-allauth, ≥2.5) — the flagship native-OIDC upgrade from the survey.

- **Authentik**: `Paperless OIDC` provider (confidential, pinned `client_id: paperless`, PKCE) + application. Redirect = `https://docs.*/accounts/oidc/authentik/login/callback/` (path embeds allauth's `provider_id: authentik`).
- **Paperless**: `PAPERLESS_APPS: allauth.socialaccount.providers.openid_connect` + `PAPERLESS_SOCIALACCOUNT_PROVIDERS` JSON templated in the ExternalSecret (validated as JSON post-template).
- **Local admin login stays enabled** as fallback — no lockout risk.

## Post-merge steps

1. Reconcile authentik → force blueprint apply → copy the generated client secret into **Infisical as `PAPERLESS_OIDC_CLIENT_SECRET`** (existing `^PAPERLESS.*` find picks it up; ES retains the old secret until then, paperless keeps running).
2. Force ES resync → restart paperless.
3. First login: sign in locally → Profile → **Connect social account** → Authentik. After that, the login page shows an Authentik button.