### PR TITLE
fix(zigbee2mqtt-garage): give the garage its own Zigbee network identity

### DIFF
--- a/kubernetes/apps/home-automation/zigbee2mqtt-garage/app/externalsecret.yaml
+++ b/kubernetes/apps/home-automation/zigbee2mqtt-garage/app/externalsecret.yaml
@@ -15,9 +15,12 @@ spec:
       data:
         ZIGBEE2MQTT_CONFIG_MQTT_USER: "{{ .EMQX_MQTT_HOME_USERNAME }}"
         ZIGBEE2MQTT_CONFIG_MQTT_PASSWORD: "{{ .EMQX_MQTT_HOME_PASSWORD }}"
-        ZIGBEE2MQTT_CONFIG_ADVANCED_PAN_ID: "{{ .ZIGBEE_PAN_ID }} "
-        ZIGBEE2MQTT_CONFIG_ADVANCED_EXT_PAN_ID: "{{ .ZIGBEE_EXT_PAN_ID }}"
-        ZIGBEE2MQTT_CONFIG_ADVANCED_NETWORK_KEY: "{{ .ZIGBEE_NETWORK_KEY }}"
+        # The garage runs its OWN Zigbee network — never reuse the house
+        # ZIGBEE_* identity here. Sharing PAN/key/coordinator identity let the
+        # two coordinators hijack each other's devices (fixed 2026-07-01).
+        ZIGBEE2MQTT_CONFIG_ADVANCED_PAN_ID: "{{ .ZIGBEE_GARAGE_PAN_ID }}"
+        ZIGBEE2MQTT_CONFIG_ADVANCED_EXT_PAN_ID: "{{ .ZIGBEE_GARAGE_EXT_PAN_ID }}"
+        ZIGBEE2MQTT_CONFIG_ADVANCED_NETWORK_KEY: "{{ .ZIGBEE_GARAGE_NETWORK_KEY }}"
   # One folder-scoped recursive find (these keys live in /Infrastructure) instead
   # of 5 separate root-level finds — one ListSecrets call against that folder.
   dataFrom:


### PR DESCRIPTION
## Problem
The garage z2m instance's ExternalSecret templated the **same** Infisical keys (`ZIGBEE_PAN_ID`, `ZIGBEE_EXT_PAN_ID`, `ZIGBEE_NETWORK_KEY`) as the house instance. Combined with the garage adapter having been restored with the house coordinator's IEEE address, both coordinators ran one logical network — the garage DB accumulated 26 phantom house devices and its HA discovery publishes clobbered house device names to IEEE addresses (the smarthome breakage fixed earlier today).

## Fix
Point the garage at new `ZIGBEE_GARAGE_PAN_ID` / `ZIGBEE_GARAGE_EXT_PAN_ID` / `ZIGBEE_GARAGE_NETWORK_KEY` (already created in Infisical /Infrastructure with freshly generated values). Also drops the stray trailing space in the PAN_ID template.

## Post-merge (operational)
- Wipe garage coordinator state (`coordinator_backup.json`, `database.db`) so zstack forms the new network
- Workshop Door + Workshop Lights must be physically re-paired