### PR TITLE
fix(home-assistant): roll back 2026.7.0 → 2026.6.4, websocket API broken

### DIFF
--- a/kubernetes/apps/home-automation/home-assistant/app/helmrelease.yaml
+++ b/kubernetes/apps/home-automation/home-assistant/app/helmrelease.yaml
@@ -32,7 +32,7 @@ spec:
           app:
             image:
               repository: ghcr.io/home-operations/home-assistant
-              tag: 2026.7.0@sha256:dba81097ecdee59dda9adaed94e146398a241efaa74a836567c64f5a3f29ca67
+              tag: 2026.6.4@sha256:29d953e7be59a0c3cceefad839138d3a57c7b9efb81c800a51d8453d5913cc12
             env:
               TZ: ${TIME_ZONE}
               UV_SYSTEM_PYTHON: true


### PR DESCRIPTION
2026.7.0 (`dba81097`) returns HTTP 500 on every `/api/websocket` handshake:

```
TypeError: WebSocketResponse.__init__() got an unexpected keyword argument 'decode_text'
```

HA core vs bundled aiohttp 3.14.1 mismatch in the image — frontend UI and all websocket clients (Node-RED, mobile apps) are dead; REST API unaffected. Verified the live `2026.7.0` tag digest matches the pinned one, so no fixed rebuild exists yet. Revert to 2026.6.4 until upstream ships a fix; Renovate will re-PR the bump — hold it until the websocket issue is confirmed fixed.