### PR TITLE
feat(media): ship plex and posterizarr file logs to victorialogs

### DIFF
--- a/kubernetes/apps/media/plex/app/helmrelease.yaml
+++ b/kubernetes/apps/media/plex/app/helmrelease.yaml
@@ -96,6 +96,26 @@ spec:
                 memory: 512Mi
               limits:
                 memory: 2Gi
+          # Plex only logs to files, never stdout — tail the main log so
+          # Fluent Bit ships it to VictoriaLogs like every other app
+          logs:
+            image:
+              repository: mirror.gcr.io/library/busybox
+              tag: "1.37"
+            command:
+              - /bin/sh
+              - -c
+              - tail -n0 -F "/config/Library/Application Support/Plex Media Server/Logs/Plex Media Server.log"
+            securityContext:
+              allowPrivilegeEscalation: false
+              readOnlyRootFilesystem: true
+              capabilities: { drop: ["ALL"] }
+            resources:
+              requests:
+                cpu: 10m
+                memory: 10Mi
+              limits:
+                memory: 64Mi
     defaultPodOptions:
       securityContext:
         runAsNonRoot: true

--- a/kubernetes/apps/media/posterizarr/app/helmrelease.yaml
+++ b/kubernetes/apps/media/posterizarr/app/helmrelease.yaml
@@ -32,8 +32,8 @@ spec:
             args:
               - "/app/config-file/init-config.sh"
             envFrom:
-            - secretRef:
-                name: posterizarr-secret
+              - secretRef:
+                  name: posterizarr-secret
             resources:
               requests:
                 cpu: 10m
@@ -58,7 +58,29 @@ spec:
               readOnlyRootFilesystem: false
               capabilities:
                 drop:
-                - ALL
+                  - ALL
+          # Posterizarr only logs to files, never stdout — tail the backend log
+          # (FrontendUI.log is a duplicate of it) for Fluent Bit → VictoriaLogs
+          logs:
+            image:
+              repository: mirror.gcr.io/library/busybox
+              tag: "1.37"
+            command:
+              - /bin/sh
+              - -c
+              - tail -n0 -F /config/UILogs/BackendServer.log
+            securityContext:
+              allowPrivilegeEscalation: false
+              readOnlyRootFilesystem: true
+              capabilities:
+                drop:
+                  - ALL
+            resources:
+              requests:
+                cpu: 10m
+                memory: 10Mi
+              limits:
+                memory: 64Mi
     service:
       app:
         controller: posterizarr


### PR DESCRIPTION
## Summary

Plex and Posterizarr are the only user-facing apps whose logs never reach VictoriaLogs — they write to files instead of stdout, so the fluent-bit DaemonSet (which tails CRI container logs) never sees them. Verified by sweeping 24h stdout volume vs freshly-written log files across all ~45 workloads in media/selfhosted/home-automation/ai/security; everything else already logs to stdout (Overseerr, all *arr apps, HA, etc.).

## Changes

Add a `mirror.gcr.io/library/busybox:1.37` tail sidecar (same convention as gatus) to each:

- **plex**: tails `Plex Media Server.log` from the existing `logs` emptyDir — Plex's stdout is only s6 init noise
- **posterizarr**: tails `/config/UILogs/BackendServer.log` — stdout is completely silent, and `FrontendUI.log` is a byte-for-byte duplicate of the backend log

`tail -F` follows Plex's log rotation; `-n0` avoids re-shipping backlog on container restart. Logs land in VictoriaLogs queryable as `k_pod_name:plex* AND k_container_name:logs`.

Both files pass the app-template HelmRelease schema and kustomize-build cleanly; log paths confirmed against the live pods.