### PR TITLE
fix(posterizarr): move unrotated web UI logs to emptyDir

### DIFF
--- a/kubernetes/apps/media/posterizarr/app/helmrelease.yaml
+++ b/kubernetes/apps/media/posterizarr/app/helmrelease.yaml
@@ -107,6 +107,13 @@ spec:
     persistence:
       config:
         existingClaim: *app
+      # Posterizarr's web UI logs have no rotation and grow ~12MB/day, but the
+      # app wipes them on every startup anyway — keep them off the config PVC
+      # (and out of VolSync backups); durable history lives in VictoriaLogs
+      ui-logs:
+        type: emptyDir
+        globalMounts:
+          - path: /config/UILogs
       posterizarr-watcher:
         existingClaim: posterizarr-watcher
         globalMounts:


### PR DESCRIPTION
## Summary

Follow-up to #3530. Posterizarr's web UI logs (`/config/UILogs/BackendServer.log` + `FrontendUI.log`) use a plain Python `logging.FileHandler` — **no rotation exists and none is configurable** (verified in the shipped backend source). They had grown to 263MB + 278MB on the config PVC (~12MB/day each) and churn VolSync backups.

The app deletes and recreates these files on every startup, so nothing in that directory needs to survive a restart. Mount an emptyDir over `/config/UILogs` — logs stay off the PVC and out of backups, and durable history lives in VictoriaLogs via the tail sidecar from #3530.

Already removed the existing oversized files from the PVC (the app recreates them; space frees on rollout).

Tradeoff: `webui_settings.json` (the web UI's log-level preference, 79 bytes) lives in the same dir and resets to INFO on pod restart.