### PR TITLE
fix(posterizarr): mount manual/backup asset dirs where the web UI expects them

### DIFF
--- a/kubernetes/apps/media/posterizarr/app/helmrelease.yaml
+++ b/kubernetes/apps/media/posterizarr/app/helmrelease.yaml
@@ -128,3 +128,11 @@ spec:
         existingClaim: plex-posters-cephfs
         globalMounts:
           - path: /assets
+          # The web UI backend hardcodes /manualassets and /assetsbackup in
+          # container mode (it ignores config.json's ManualAssetPath/BackupPath,
+          # which only the PowerShell runner reads) and logs a WARNING every
+          # scan cycle when they're missing — expose the same share dirs there
+          - path: /manualassets
+            subPath: manualassets
+          - path: /assetsbackup
+            subPath: assetsbackup


### PR DESCRIPTION
## Summary

Posterizarr's backend was logging the same three WARNINGs every few seconds (~80k lines/day, now visible in VictoriaLogs thanks to #3530):

```
Manual assets directory does not exist: /manualassets
Backup assets directory does not exist: /assetsbackup
```

Root cause (verified in the shipped backend source): in container mode the web UI backend **hardcodes** `/manualassets` and `/assetsbackup` — it ignores `config.json`'s `ManualAssetPath`/`BackupPath` (`/assets/manualassets`, `/assets/assetsbackup`), which only the PowerShell runner reads. Both directories already exist on the `plex-posters-cephfs` share.

## Fix

Mount the share's `manualassets`/`assetsbackup` subdirectories at the hardcoded root paths via `subPath` mounts of the existing `assets` claim. Warnings stop, and the web UI's manual/backup asset browser now points at the same directories the runner is configured to use.

Passes app-template schema + kustomize build.