### PR TITLE
fix(kyverno): stop webhook outages from blocking the cluster; cilium-operator HA

### DIFF
--- a/kubernetes/apps/kube-system/cilium/app/helm-values.yaml
+++ b/kubernetes/apps/kube-system/cilium/app/helm-values.yaml
@@ -45,7 +45,7 @@ loadBalancer:
   mode: "dsr"
 localRedirectPolicy: true
 operator:
-  replicas: 1
+  replicas: 2
   rollOutPods: true
   prometheus:
     enabled: true

--- a/kubernetes/apps/kyverno/kyverno/policies/helmrelease-maxhistory.yaml
+++ b/kubernetes/apps/kyverno/kyverno/policies/helmrelease-maxhistory.yaml
@@ -14,6 +14,8 @@ metadata:
       declare maxHistory explicitly are left untouched via the +() add-if-absent
       anchor, so an individual app can override up (e.g. 10) or down (e.g. 1).
 spec:
+  webhookConfiguration:
+    failurePolicy: Ignore
   rules:
     - name: default-maxhistory
       match:

--- a/kubernetes/apps/kyverno/kyverno/policies/httproute-authentik-forward-auth.yaml
+++ b/kubernetes/apps/kyverno/kyverno/policies/httproute-authentik-forward-auth.yaml
@@ -15,6 +15,8 @@ metadata:
       by Host. The generated SecurityPolicy is kept in sync and removed when the
       HTTPRoute is deleted or the annotation is cleared (synchronize: true).
 spec:
+  webhookConfiguration:
+    failurePolicy: Ignore
   # Generate for HTTPRoutes that already exist (not just on create/update).
   generateExisting: true
   rules:

--- a/kubernetes/apps/kyverno/kyverno/policies/nfs-health-checks.yaml
+++ b/kubernetes/apps/kyverno/kyverno/policies/nfs-health-checks.yaml
@@ -16,6 +16,8 @@ metadata:
       is automatically restarted, providing self-healing for storage layer issues. This centralized
       approach ensures consistent NFS monitoring across all media applications.
 spec:
+  webhookConfiguration:
+    failurePolicy: Ignore
   rules:
     # Add NFS health monitoring liveness probe to ALL containers
     # This is the single source of truth for health checks in media namespace
@@ -109,6 +111,6 @@ spec:
 
                             exit $ERROR
                       initialDelaySeconds: 60
-                      periodSeconds: 600      # Check every 10 minutes
-                      timeoutSeconds: 30      # Allow 30 seconds for check
-                      failureThreshold: 3     # Restart after 30 minutes of failures (3 * 10min)
+                      periodSeconds: 600 # Check every 10 minutes
+                      timeoutSeconds: 30 # Allow 30 seconds for check
+                      failureThreshold: 3 # Restart after 30 minutes of failures (3 * 10min)

--- a/kubernetes/apps/kyverno/kyverno/policies/pod-security/default-security-context.yaml
+++ b/kubernetes/apps/kyverno/kyverno/policies/pod-security/default-security-context.yaml
@@ -15,6 +15,8 @@ metadata:
       drop ALL capabilities. Audit mode — reports violations without
       blocking deployments. Workloads should be hardened incrementally.
 spec:
+  webhookConfiguration:
+    failurePolicy: Ignore
   validationFailureAction: Audit
   background: true
   rules:

--- a/kubernetes/apps/kyverno/kyverno/policies/pod-security/disable-automount-sa-token.yaml
+++ b/kubernetes/apps/kyverno/kyverno/policies/pod-security/disable-automount-sa-token.yaml
@@ -15,6 +15,8 @@ metadata:
       leaving it mounted expands the blast radius of container compromise.
       Audit mode — reports violations without blocking deployments.
 spec:
+  webhookConfiguration:
+    failurePolicy: Ignore
   validationFailureAction: Audit
   background: true
   rules:

--- a/kubernetes/apps/kyverno/kyverno/policies/pod-security/require-probes.yaml
+++ b/kubernetes/apps/kyverno/kyverno/policies/pod-security/require-probes.yaml
@@ -14,6 +14,8 @@ metadata:
       Health probes enable Kubernetes to properly manage traffic routing
       and rolling updates. Audit mode — reports violations without blocking.
 spec:
+  webhookConfiguration:
+    failurePolicy: Ignore
   validationFailureAction: Audit
   background: true
   rules:

--- a/kubernetes/apps/kyverno/kyverno/policies/pod-security/restrict-latest-tag.yaml
+++ b/kubernetes/apps/kyverno/kyverno/policies/pod-security/restrict-latest-tag.yaml
@@ -15,6 +15,8 @@ metadata:
       silently introduce breaking changes or vulnerabilities.
       Set to Audit mode initially to surface violations without blocking.
 spec:
+  webhookConfiguration:
+    failurePolicy: Ignore
   validationFailureAction: Audit
   background: true
   rules:

--- a/kubernetes/apps/kyverno/kyverno/policies/postgres-init/clusterpolicy-container.yaml
+++ b/kubernetes/apps/kyverno/kyverno/policies/postgres-init/clusterpolicy-container.yaml
@@ -14,6 +14,8 @@ metadata:
       with the controller name defaulting to the release name unless overridden
       via the postgres-init.home.arpa/controller annotation.
 spec:
+  webhookConfiguration:
+    failurePolicy: Ignore
   rules:
     - name: inject-postgres-init-container
       match:
@@ -32,12 +34,12 @@ spec:
           spec:
             values:
               controllers:
-                "{{ request.object.metadata.annotations.\"postgres-init.home.arpa/controller\" || request.object.metadata.name }}":
+                '{{ request.object.metadata.annotations."postgres-init.home.arpa/controller" || request.object.metadata.name }}':
                   initContainers:
                     init-db:
                       image:
-                        repository: "{{ pgInitConfig.\"image-repository\" }}"
-                        tag: "{{ pgInitConfig.\"image-tag\" }}"
+                        repository: '{{ pgInitConfig."image-repository" }}'
+                        tag: '{{ pgInitConfig."image-tag" }}'
                       envFrom:
                         - secretRef:
                             name: "{{ request.object.metadata.name }}-postgres-init"

--- a/kubernetes/apps/kyverno/kyverno/policies/postgres-init/clusterpolicy-externalsecret.yaml
+++ b/kubernetes/apps/kyverno/kyverno/policies/postgres-init/clusterpolicy-externalsecret.yaml
@@ -15,6 +15,8 @@ metadata:
       container. The generated ExternalSecret is automatically cleaned up when
       the source HelmRelease is deleted.
 spec:
+  webhookConfiguration:
+    failurePolicy: Ignore
   rules:
     - name: generate-postgres-init-externalsecret
       match:
@@ -26,10 +28,10 @@ spec:
       # Ensure required annotations are present
       preconditions:
         all:
-          - key: "{{ request.object.metadata.annotations.\"postgres-init.home.arpa/user-key\" || '' }}"
+          - key: '{{ request.object.metadata.annotations."postgres-init.home.arpa/user-key" || '''' }}'
             operator: NotEquals
             value: ""
-          - key: "{{ request.object.metadata.annotations.\"postgres-init.home.arpa/pass-key\" || '' }}"
+          - key: '{{ request.object.metadata.annotations."postgres-init.home.arpa/pass-key" || '''' }}'
             operator: NotEquals
             value: ""
       generate:
@@ -42,7 +44,7 @@ spec:
           spec:
             secretStoreRef:
               kind: ClusterSecretStore
-              name: "{{ request.object.metadata.annotations.\"postgres-init.home.arpa/secret-store\" || 'infisical' }}"
+              name: '{{ request.object.metadata.annotations."postgres-init.home.arpa/secret-store" || ''infisical'' }}'
             target:
               name: "{{ request.object.metadata.name }}-postgres-init"
               template:
@@ -52,7 +54,7 @@ spec:
                   INIT_POSTGRES_SUPER_USER: '\{{ .POSTGRES_SUPER_USER }}'
                   INIT_POSTGRES_SUPER_PASS: '\{{ .POSTGRES_SUPER_PASS }}'
                   INIT_POSTGRES_PORT: "5432"
-                  INIT_POSTGRES_DBNAME: "{{ request.object.metadata.annotations.\"postgres-init.home.arpa/dbname\" || request.object.metadata.name }}"
+                  INIT_POSTGRES_DBNAME: '{{ request.object.metadata.annotations."postgres-init.home.arpa/dbname" || request.object.metadata.name }}'
                   INIT_POSTGRES_USER: '\{{ .{{ request.object.metadata.annotations."postgres-init.home.arpa/user-key" }} }}'
                   INIT_POSTGRES_PASS: '\{{ .{{ request.object.metadata.annotations."postgres-init.home.arpa/pass-key" }} }}'
             # Static superuser + per-app postgres creds — rarely rotate, so a long
@@ -66,4 +68,4 @@ spec:
               # which is what triggered the HTTP 429 storm on this store.
               - find:
                   name:
-                    regexp: "^(POSTGRES_SUPER_USER|POSTGRES_SUPER_PASS|{{ request.object.metadata.annotations.\"postgres-init.home.arpa/user-key\" }}|{{ request.object.metadata.annotations.\"postgres-init.home.arpa/pass-key\" }})$"
+                    regexp: '^(POSTGRES_SUPER_USER|POSTGRES_SUPER_PASS|{{ request.object.metadata.annotations."postgres-init.home.arpa/user-key" }}|{{ request.object.metadata.annotations."postgres-init.home.arpa/pass-key" }})$'


### PR DESCRIPTION
## What

- Set `spec.webhookConfiguration.failurePolicy: Ignore` on all 9 ClusterPolicies
- Bump `operator.replicas` 1 → 2 for Cilium (upstream chart default)

## Why

During yesterday's etcd latency incident (slow Ceph OSDs on proxmox-01 → 0.5–1.6s etcd applies), Kyverno's admission webhooks were registered with `failurePolicy: Fail`, meaning an unresponsive Kyverno blocks all matching resource operations cluster-wide for up to 10s each, and outright fails them when it's down.

None of our policies justify that blast radius:
- All 4 validate policies are **Audit-only** — `Fail` provided zero enforcement, only risk
- The mutate/generate policies (postgres-init, forward-auth, maxhistory, security-context defaults) are conveniences; a resource admitted during Kyverno downtime just misses its mutation, and generate policies self-heal via background scans

With every policy set to `Ignore`, Kyverno aggregates the resource webhooks into the `-ignore` variants and its downtime becomes a non-event for the rest of the cluster.

The cilium-operator bump is the same incident's other lesson: with `replicas: 1` a single control-plane reboot leaves the cluster with no operator (delayed IPAM for new pods) until reschedule. Two replicas run active/standby via leader election with node anti-affinity — the upstream default.

## Verification

- All 8 live ClusterPolicies validated with `kubectl apply --dry-run=server`