### PR TITLE
fix(ntfy): sqlite WAL mode + in-cluster rate-limit exemption

### DIFF
--- a/kubernetes/apps/network/ntfy/app/helmrelease.yaml
+++ b/kubernetes/apps/network/ntfy/app/helmrelease.yaml
@@ -48,6 +48,24 @@ spec:
               NTFY_AUTH_DEFAULT_ACCESS: deny-all
               NTFY_CACHE_FILE: /var/lib/ntfy/cache.db
               NTFY_CACHE_DURATION: 12h
+              # sqlite contention fix: default journal mode serializes writers, and
+              # background jobs (delayed sends, token expiry) were locking the DBs
+              # long enough that Alertmanager webhook posts got 5xx "database is
+              # locked" (~25% of sends failing). WAL + busy_timeout lets readers and
+              # writers coexist and makes brief lock waits invisible.
+              NTFY_CACHE_STARTUP_QUERIES: |
+                pragma journal_mode = WAL;
+                pragma synchronous = normal;
+                pragma temp_store = memory;
+                pragma busy_timeout = 15000;
+              NTFY_AUTH_STARTUP_QUERIES: |
+                pragma journal_mode = WAL;
+                pragma synchronous = normal;
+                pragma busy_timeout = 15000;
+              # In-cluster senders (alertmanager-ntfy bridge, gatus) connect with
+              # their pod IP (no proxy in that path) — exempt the pod CIDR so an
+              # alert flood can never rate-limit the alerting pipeline itself.
+              NTFY_VISITOR_REQUEST_LIMIT_EXEMPT_HOSTS: 10.69.0.0/16
               NTFY_ENABLE_LOGIN: "true"
             envFrom:
               - secretRef:


### PR DESCRIPTION
Phase 1.1 of #3541.

Alertmanager's webhook integration to the ntfy bridge was failing ~25% of sends (144/582 lifetime, ~128 in the last 24h) with `reason=serverError`, firing both `AlertmanagerFailedToSendAlerts` and `AlertmanagerClusterFailedToSendAlerts`. ntfy's logs show zero 429s — the failures line up with recurring `error=database is locked` warnings from sqlite on both `cache.db` (delayed sends) and `user.db` (token expiry, user cleanup).

- Enable WAL journal mode + `busy_timeout=15000` on the cache and auth DBs via `NTFY_CACHE_STARTUP_QUERIES` / `NTFY_AUTH_STARTUP_QUERIES` (auth variant is in `server/config.go` even though the docs only list the cache one).
- Exempt the pod CIDR (`10.69.0.0/16`) from visitor request limits — in-cluster senders (alertmanager-ntfy bridge, gatus) hit ntfy directly with their pod IP, so an alert flood could otherwise rate-limit the alerting pipeline itself (429 → Alertmanager retry ×20 → amplification). CIDR prefixes are supported (`VisitorRequestExemptPrefixes []netip.Prefix`).

Verification after merge: `rate(alertmanager_notifications_failed_total{integration="webhook"}[1h])` drops to 0 and both FailedToSend alerts resolve; `database is locked` disappears from ntfy logs.