### PR TITLE
fix(alertmanager): route channel-failure alerts cross-channel

### DIFF
--- a/kubernetes/apps/observability/kube-prometheus-stack/app/alertmanagerconfig.yaml
+++ b/kubernetes/apps/observability/kube-prometheus-stack/app/alertmanagerconfig.yaml
@@ -62,10 +62,20 @@ spec:
           - name: alertname
             value: "KnightMetricsAbsent|RoundtablePodRestarting"
             matchType: =~
-      # Break the pushover self-notify loop: when a pushover send fails it raises
-      # Alertmanager(Cluster)FailedToSendAlerts (severity=critical), which would
-      # otherwise route back to the failing pushover channel and amplify. Send these
-      # to ntfy only. MUST precede the critical->pushover route (first match wins).
+      # Channel-failure alerts must cross channels: a broken channel can't report
+      # its own death (EEMUA alarm-system health). The FailedToSendAlerts alerts
+      # carry an `integration` label, so split on it — webhook(=ntfy-bridge)
+      # failures page via pushover, pushover failures notify via ntfy. This also
+      # breaks the self-notify amplification loop in both directions. MUST precede
+      # the critical->pushover route (first match wins).
+      - receiver: pushover
+        matchers:
+          - name: alertname
+            value: "Alertmanager(Cluster)?FailedToSendAlerts"
+            matchType: =~
+          - name: integration
+            value: webhook
+            matchType: =
       - receiver: ntfy
         matchers:
           - name: alertname


### PR DESCRIPTION
Phase 1.2 of #3541.

A notification channel cannot report its own failure — the old loop-breaker route sent `Alertmanager(Cluster)?FailedToSendAlerts` to ntfy unconditionally, including when the failing integration *was* the ntfy webhook (exactly what happened this week: ~25% webhook send failures, visible only in metrics). The alerts carry an `integration` label, so:

- `integration=webhook` (ntfy bridge path broken) → **pushover**
- everything else, including `integration=pushover` → **ntfy** (unchanged catch-all)

Both routes stay ahead of the generic `severity=critical → pushover` route, preserving the anti-amplification behavior in both directions. Complements #3543 (which fixes this week's actual failure cause) and the upcoming healthchecks.io dead-man's switch (which covers both-channels-dead).