### PR TITLE
fix(kube-prometheus-stack): disable unactionable stock rules at the source

### DIFF
--- a/kubernetes/apps/observability/kube-prometheus-stack/app/alertmanagerconfig.yaml
+++ b/kubernetes/apps/observability/kube-prometheus-stack/app/alertmanagerconfig.yaml
@@ -28,21 +28,9 @@ spec:
           - name: alertname
             value: Watchdog
             matchType: =
-      # CPUThrottlingHigh (info severity) is unactionable noise here. The throttled
-      # workloads are upstream operators/controllers (emqx-operator, infisical,
-      # intel-device-plugin, silence-operator, flux controllers, roundtable-operator)
-      # carrying small chart-default CPU limits. CFS throttling does NOT restart them
-      # — observed restarts are synchronized leader-election exits tied to etcd
-      # instability, not CPU starvation. Right-sizing is advisory only (Goldilocks
-      # VPAs run updateMode:Off and recommend requests, not the limits that cause
-      # throttling), so this alert has no action. Dropped from notifications; still
-      # visible in the Alertmanager UI. Was previously scoped to the skill-filter
-      # sidecar only; broadened to the whole alertname (1400+ fire/resolve cycles/7d).
-      - receiver: "null"
-        matchers:
-          - name: alertname
-            value: CPUThrottlingHigh
-            matchType: =
+      # CPUThrottlingHigh was null-routed here 2026-06-29..2026-07-02; it is now
+      # disabled at the source (defaultRules.disabled in helmrelease.yaml) so it
+      # no longer evaluates at all.
       # Silence roundtable agent-sandbox churn: pods are ephemeral and restart/
       # crashloop/not-ready constantly by design, so warning/info pod-lifecycle alerts
       # there are expected noise. Drop all non-critical roundtable alerts; critical

--- a/kubernetes/apps/observability/kube-prometheus-stack/app/helmrelease.yaml
+++ b/kubernetes/apps/observability/kube-prometheus-stack/app/helmrelease.yaml
@@ -41,6 +41,21 @@ spec:
         # etcdDatabaseQuotaLowSpace already cover the real "approaching quota"
         # risk, so disabling this loses no safety. See project_etcd_flapping.
         etcdDatabaseHighFragmentationRatio: true
+        # Unactionable here (EEMUA gate: no response exists). The throttled
+        # workloads are upstream operators/controllers carrying small
+        # chart-default CPU limits; CFS throttling doesn't restart or break
+        # them, and right-sizing is advisory-only (Goldilocks updateMode:Off).
+        # Was null-routed in alertmanagerconfig since 2026-06-29, but kept
+        # firing 10k+ flap-episodes/7d, polluting ALERTS metrics, inhibition
+        # processing, and the bad-actor dashboard. Kill the evaluation, not
+        # just the delivery.
+        CPUThrottlingHigh: true
+        # Known etcd-mixin false positive: grpc_code!="OK" counts normal
+        # client cancellations (kube-apiserver watch streams are cancelled
+        # constantly), so it flaps forever (~1.4k episodes/7d) with nothing
+        # to fix. Real etcd failures surface via etcdMembersDown /
+        # etcdInsufficientMembers / apiserver latency rules.
+        etcdHighNumberOfFailedGRPCRequests: true
     alertmanager:
       alertmanagerSpec:
         # External hostname so notification "View in Alertmanager" links resolve


### PR DESCRIPTION
Phase 1.4 of #3541 (kill noise at the source, not the router).

The 7-day flap-episode ranking (`changes(ALERTS_FOR_STATE[7d])`) puts these two at #1 and #4 of all alerts:

- **CPUThrottlingHigh** (10,562 episodes/7d): already null-routed with a full no-action rationale in `alertmanagerconfig.yaml`, but null-routing only stops delivery — the rule kept evaluating, polluting `ALERTS`, inhibition processing, and the upcoming bad-actor dashboard (Phase 4). Trade-off vs. the null-route: it disappears from the Alertmanager UI too. The EEMUA gate says an alert with no response shouldn't exist at all.
- **etcdHighNumberOfFailedGRPCRequests** (1,444 episodes/7d): well-known etcd-mixin false positive — `grpc_code!="OK"` counts normal client cancellations, and kube-apiserver cancels watch streams constantly. Real etcd failure modes remain covered by `etcdMembersDown`, `etcdInsufficientMembers`, and apiserver latency rules.

Left alone deliberately:
- roundtable/Knight rules — evaluated-but-null-routed by design (Night Watch's watchman reads `ALERTS{namespace="roundtable"}` as its query menu).
- `PrometheusDuplicateTimestamps` — stays null-routed; finding the duplicate-scrape source is a separate follow-up.
- Flux `Alert` CR — verified already `eventSeverity: error` with exclusions; no Progressing-event noise exists.