### PR TITLE
feat(alertmanager): Watchdog dead man's switch via healthchecks.io heartbeat

### DIFF
--- a/kubernetes/apps/observability/kube-prometheus-stack/app/alertmanagerconfig.yaml
+++ b/kubernetes/apps/observability/kube-prometheus-stack/app/alertmanagerconfig.yaml
@@ -24,11 +24,11 @@ spec:
             value: PrometheusDuplicateTimestamps
             matchType: =
       # Dead man's switch: Watchdog fires ALWAYS by design — it exists to be a
-      # heartbeat consumed OUTSIDE the cluster. Forward it to healthchecks.io,
-      # which pages via its own channels when the heartbeat STOPS. End-to-end
-      # pipeline death (Prometheus, Alertmanager, or egress down) is the one
-      # failure this stack cannot report about itself. hc.io check: period 10m,
-      # grace 5m.
+      # heartbeat consumed OUTSIDE the cluster. Forward it to an UptimeRobot
+      # heartbeat monitor, which alerts via its own channels when the heartbeat
+      # STOPS. End-to-end pipeline death (Prometheus, Alertmanager, or egress
+      # down) is the one failure this stack cannot report about itself.
+      # UptimeRobot heartbeat interval: 15m (tolerates one missed 5m ping).
       - receiver: heartbeat
         groupWait: 0s
         groupInterval: 5m
@@ -153,4 +153,4 @@ spec:
         - sendResolved: false
           urlSecret:
             name: *secret
-            key: HEALTHCHECKS_PING_URL
+            key: UPTIMEROBOT_HEARTBEAT_URL

--- a/kubernetes/apps/observability/kube-prometheus-stack/app/alertmanagerconfig.yaml
+++ b/kubernetes/apps/observability/kube-prometheus-stack/app/alertmanagerconfig.yaml
@@ -23,7 +23,16 @@ spec:
           - name: alertname
             value: PrometheusDuplicateTimestamps
             matchType: =
-      - receiver: "null"
+      # Dead man's switch: Watchdog fires ALWAYS by design — it exists to be a
+      # heartbeat consumed OUTSIDE the cluster. Forward it to healthchecks.io,
+      # which pages via its own channels when the heartbeat STOPS. End-to-end
+      # pipeline death (Prometheus, Alertmanager, or egress down) is the one
+      # failure this stack cannot report about itself. hc.io check: period 10m,
+      # grace 5m.
+      - receiver: heartbeat
+        groupWait: 0s
+        groupInterval: 5m
+        repeatInterval: 5m
         matchers:
           - name: alertname
             value: Watchdog
@@ -139,3 +148,9 @@ spec:
       webhookConfigs:
         - sendResolved: true
           url: http://alertmanager-ntfy.observability.svc.cluster.local:8000/hook
+    - name: heartbeat
+      webhookConfigs:
+        - sendResolved: false
+          urlSecret:
+            name: *secret
+            key: HEALTHCHECKS_PING_URL

--- a/kubernetes/apps/observability/kube-prometheus-stack/app/alertmanagerconfig.yaml
+++ b/kubernetes/apps/observability/kube-prometheus-stack/app/alertmanagerconfig.yaml
@@ -24,11 +24,11 @@ spec:
             value: PrometheusDuplicateTimestamps
             matchType: =
       # Dead man's switch: Watchdog fires ALWAYS by design — it exists to be a
-      # heartbeat consumed OUTSIDE the cluster. Forward it to an UptimeRobot
-      # heartbeat monitor, which alerts via its own channels when the heartbeat
-      # STOPS. End-to-end pipeline death (Prometheus, Alertmanager, or egress
-      # down) is the one failure this stack cannot report about itself.
-      # UptimeRobot heartbeat interval: 15m (tolerates one missed 5m ping).
+      # heartbeat consumed OUTSIDE the cluster. Forward it to healthchecks.io,
+      # which alerts via its own channels when the heartbeat STOPS. End-to-end
+      # pipeline death (Prometheus, Alertmanager, or egress down) is the one
+      # failure this stack cannot report about itself. Check: period 10m,
+      # grace 5m (tolerates one missed 5m ping).
       - receiver: heartbeat
         groupWait: 0s
         groupInterval: 5m
@@ -153,4 +153,4 @@ spec:
         - sendResolved: false
           urlSecret:
             name: *secret
-            key: UPTIMEROBOT_HEARTBEAT_URL
+            key: HEALTHCHECK_HEARTBEAT_URL

--- a/kubernetes/apps/observability/kube-prometheus-stack/app/externalsecret.yaml
+++ b/kubernetes/apps/observability/kube-prometheus-stack/app/externalsecret.yaml
@@ -15,8 +15,12 @@ spec:
       data:
         ALERTMANAGER_PUSHOVER_TOKEN: "{{ .ALERTMANAGER_PUSHOVER_TOKEN }}"
         PUSHOVER_USER_KEY: "{{ .PUSHOVER_USER_KEY }}"
+        HEALTHCHECKS_PING_URL: "{{ .HEALTHCHECKS_PING_URL }}"
   dataFrom:
     - find:
         path: PUSHOVER_USER_KEY
     - find:
         path: ALERTMANAGER_PUSHOVER_TOKEN
+    - find:
+        name:
+          regexp: ^HEALTHCHECKS_PING_URL$

--- a/kubernetes/apps/observability/kube-prometheus-stack/app/externalsecret.yaml
+++ b/kubernetes/apps/observability/kube-prometheus-stack/app/externalsecret.yaml
@@ -15,7 +15,7 @@ spec:
       data:
         ALERTMANAGER_PUSHOVER_TOKEN: "{{ .ALERTMANAGER_PUSHOVER_TOKEN }}"
         PUSHOVER_USER_KEY: "{{ .PUSHOVER_USER_KEY }}"
-        UPTIMEROBOT_HEARTBEAT_URL: "{{ .UPTIMEROBOT_HEARTBEAT_URL }}"
+        HEALTHCHECK_HEARTBEAT_URL: "{{ .HEALTHCHECK_HEARTBEAT_URL }}"
   dataFrom:
     - find:
         path: PUSHOVER_USER_KEY
@@ -23,4 +23,4 @@ spec:
         path: ALERTMANAGER_PUSHOVER_TOKEN
     - find:
         name:
-          regexp: ^UPTIMEROBOT_HEARTBEAT_URL$
+          regexp: ^HEALTHCHECK_HEARTBEAT_URL$

--- a/kubernetes/apps/observability/kube-prometheus-stack/app/externalsecret.yaml
+++ b/kubernetes/apps/observability/kube-prometheus-stack/app/externalsecret.yaml
@@ -15,7 +15,7 @@ spec:
       data:
         ALERTMANAGER_PUSHOVER_TOKEN: "{{ .ALERTMANAGER_PUSHOVER_TOKEN }}"
         PUSHOVER_USER_KEY: "{{ .PUSHOVER_USER_KEY }}"
-        HEALTHCHECKS_PING_URL: "{{ .HEALTHCHECKS_PING_URL }}"
+        UPTIMEROBOT_HEARTBEAT_URL: "{{ .UPTIMEROBOT_HEARTBEAT_URL }}"
   dataFrom:
     - find:
         path: PUSHOVER_USER_KEY
@@ -23,4 +23,4 @@ spec:
         path: ALERTMANAGER_PUSHOVER_TOKEN
     - find:
         name:
-          regexp: ^HEALTHCHECKS_PING_URL$
+          regexp: ^UPTIMEROBOT_HEARTBEAT_URL$


### PR DESCRIPTION
Phase 1.3 of #3541.

The stock `Watchdog` alert exists to be an always-firing heartbeat consumed by something OUTSIDE the cluster; null-routing it (the previous state) means total pipeline death is indistinguishable from all-healthy. This routes it to a new `heartbeat` receiver — a webhook to a healthchecks.io ping URL (free tier; UptimeRobot heartbeats are paywalled, and UptimeRobot keeps its existing external-uptime role) — with `groupWait: 0s` / `repeatInterval: 5m`, so healthchecks.io gets a ping every ~5 minutes and alerts via its own delivery (independent of Pushover *and* ntfy) when pings stop.

The check and the Infisical key **`HEALTHCHECK_HEARTBEAT_URL`** already exist — ready to merge. Suggested check settings: period 10m, grace 5m (tolerates one missed 5m ping).

Verification: healthchecks.io shows pings arriving every ~5m after merge; then confirm the down-alert by pausing the check or silencing Watchdog briefly.