### PR TITLE
fix(kube-prometheus-stack): alertmanager ExternalSecret find:path -> name regexp

### DIFF
--- a/kubernetes/apps/observability/kube-prometheus-stack/app/externalsecret.yaml
+++ b/kubernetes/apps/observability/kube-prometheus-stack/app/externalsecret.yaml
@@ -17,10 +17,9 @@ spec:
         PUSHOVER_USER_KEY: "{{ .PUSHOVER_USER_KEY }}"
         HEALTHCHECK_HEARTBEAT_URL: "{{ .HEALTHCHECK_HEARTBEAT_URL }}"
   dataFrom:
-    - find:
-        path: PUSHOVER_USER_KEY
-    - find:
-        path: ALERTMANAGER_PUSHOVER_TOKEN
+    # find.name.regexp, NOT find.path — path lookups broke after the Infisical
+    # folder reorg and were silently returning nothing (secret coasted on its
+    # last good sync until the template gained a new key and hard-failed).
     - find:
         name:
-          regexp: ^HEALTHCHECK_HEARTBEAT_URL$
+          regexp: ^(PUSHOVER_USER_KEY|ALERTMANAGER_PUSHOVER_TOKEN|HEALTHCHECK_HEARTBEAT_URL)$


### PR DESCRIPTION
Unblocks #3548's dead-man's switch (follow-up in the #3541 series).

The `alertmanager` ExternalSecret was still on the broken `find: path:` pattern — both lookups return nothing since the Infisical folder reorg, so the ES had been silently coasting on its last good sync. Adding `HEALTHCHECK_HEARTBEAT_URL` to the template turned that latent breakage into a hard `SecretSyncedError` (template references a key the finds never fetch).

Verified against live Infisical with a throwaway probe ES: `find.name.regexp` returns all three keys (`PUSHOVER_USER_KEY`, `ALERTMANAGER_PUSHOVER_TOKEN`, `HEALTHCHECK_HEARTBEAT_URL`); `find.path` returns none of them. This is the same migration already applied to the volsync component and the postgres apps.

Verification after merge: ES goes `SecretSynced=True`, `alertmanager-secret` gains `HEALTHCHECK_HEARTBEAT_URL`, and healthchecks.io starts receiving Watchdog pings every ~5m.