### PR TITLE
fix(alerts): EEMUA re-triage — demote 10 criticals to warning (17 → 7)

### DIFF
--- a/kubernetes/apps/media/plex/app/prometheusrule.yaml
+++ b/kubernetes/apps/media/plex/app/prometheusrule.yaml
@@ -20,7 +20,7 @@ spec:
             kube_pod_status_phase{namespace="media", pod=~"plex-.*", phase!~"Succeeded|Failed"} == 1
           for: 5m
           labels:
-            severity: critical
+            severity: warning
             category: availability
 
         - alert: PlexPodCrashLooping
@@ -33,7 +33,7 @@ spec:
             increase(kube_pod_container_status_restarts_total{namespace="media", pod=~"plex-.*"}[15m]) > 0
           for: 5m
           labels:
-            severity: critical
+            severity: warning
             category: stability
 
         - alert: PlexContainerOOMKilled
@@ -46,7 +46,7 @@ spec:
             kube_pod_container_status_last_terminated_reason{namespace="media", pod=~"plex-.*", reason="OOMKilled"} == 1
           for: 1m
           labels:
-            severity: critical
+            severity: warning
             category: resources
 
         - alert: PlexHighMemoryUsage
@@ -106,7 +106,7 @@ spec:
             kube_pod_status_phase{namespace="media", pod=~"plex-.*", phase="Failed"} == 1
           for: 1m
           labels:
-            severity: critical
+            severity: warning
             category: availability
 
         - alert: PlexPersistentVolumeIssue
@@ -119,7 +119,7 @@ spec:
             kube_persistentvolumeclaim_status_phase{namespace="media", persistentvolumeclaim="plex", phase!="Bound"} == 1
           for: 5m
           labels:
-            severity: critical
+            severity: warning
             category: storage
 
         - alert: PlexServiceDown
@@ -132,7 +132,7 @@ spec:
             kube_endpoint_address_available{namespace="media", endpoint="plex"} == 0
           for: 3m
           labels:
-            severity: critical
+            severity: warning
             category: availability
 
         - alert: PlexHighRestartRate

--- a/kubernetes/apps/observability/exporters/nut-exporter/app/prometheusrule.yaml
+++ b/kubernetes/apps/observability/exporters/nut-exporter/app/prometheusrule.yaml
@@ -16,7 +16,8 @@ spec:
             absent(up{job=~".*nut-exporter.*"} == 1)
           for: 5m
           labels:
-            severity: critical
+            # A monitoring gap, not a power event — fix same-day, don't wake up.
+            severity: warning
         - alert: UpsOnBattery
           annotations:
             description: UPS {{ $labels.ups }} has lost power and is running on battery.
@@ -43,4 +44,5 @@ spec:
             network_ups_tools_ups_status{flag="RB"} == 1
           for: 10s
           labels:
-            severity: critical
+            # Order a battery — an act-today task, not a 3am page.
+            severity: warning

--- a/kubernetes/apps/roundtable/infrastructure/app/prometheusrule.yaml
+++ b/kubernetes/apps/roundtable/infrastructure/app/prometheusrule.yaml
@@ -47,7 +47,9 @@ spec:
             sum(increase(pi_knight_llm_cost_dollars_total[24h])) > 15
           for: 15m
           labels:
-            severity: critical
+            # Spend overshoot is an act-today problem (review/suspend knights),
+            # not a wake-up; hard budget enforcement belongs in Night Watch itself.
+            severity: warning
     - name: roundtable.pods
       rules:
         - alert: RoundtablePodRestarting

--- a/kubernetes/apps/storage/volsync/app/prometheusrule.yaml
+++ b/kubernetes/apps/storage/volsync/app/prometheusrule.yaml
@@ -15,7 +15,7 @@ spec:
             absent(up{job="volsync-metrics"})
           for: 15m
           labels:
-            severity: critical
+            severity: warning
         - alert: VolSyncVolumeOutOfSync
           annotations:
             summary: >-
@@ -25,4 +25,4 @@ spec:
             volsync_volume_out_of_sync == 1
           for: 15m
           labels:
-            severity: critical
+            severity: warning


### PR DESCRIPTION
Phase 2.1 of #3541 — every custom critical walked through the notification-design gate's 3am test.

**Stay critical (7):** `UpsOnBattery`, `UpsLowBattery` (nut), `UPSOnBattery` (snmp — different UPS, the ZPM/APC via SNMP card, not a duplicate), `PostgresWALVolumeCritical`, `FluxInstanceAbsent`, `FluxInstanceNotReady`.

**Demoted to warning (10):**
- Plex ×6 (`PlexPodNotReady`, `PlexPodCrashLooping`, `PlexContainerOOMKilled`, `PlexPodFailed`, `PlexPersistentVolumeIssue`, `PlexServiceDown`) — media down at 3am costs nothing; handled at breakfast.
- `VolSyncVolumeOutOfSync`, `VolSyncComponentAbsent` — a missed sync window is act-today, not data loss in progress (yesterday's kometa-r2 case: stale restic lock, zero urgency).
- `NutExporterAbsent` — monitoring gap, not a power event.
- `UpsBatteryReplace` — order a battery; day task.
- `KnightLLMCostSpike` — review/suspend knights at breakfast; hard budget enforcement belongs in Night Watch itself. (No namespace label, so as a warning it still reaches ntfy — the roundtable null-route matches on the namespace label it doesn't have.)

Distribution moves from 45% critical toward the EEMUA ~5/15/80 shape. Pushover page budget (~0/week) becomes achievable: only power, imminent-DB-death, and dead-GitOps page now.