### PR TITLE
feat(alertmanager): inhibition rules for symptom cascades

### DIFF
--- a/kubernetes/apps/observability/kube-prometheus-stack/app/alertmanagerconfig.yaml
+++ b/kubernetes/apps/observability/kube-prometheus-stack/app/alertmanagerconfig.yaml
@@ -103,6 +103,31 @@ spec:
         - name: severity
           value: warning
           matchType: =
+    # Symptom-cascade suppression (EEMUA: one incident = one notification).
+    # When pods in a namespace aren't ready, the replica mismatches, stuck
+    # rollouts, and the Flux healthcheck failure are the same incident
+    # restated — the 2026-07-02 gpu-node wedge produced 6 alert groups for
+    # one cause. Namespace-scoped, so an unrelated same-ns workload alert
+    # can be masked in theory; acceptable at homelab scale.
+    - equal: ["namespace"]
+      sourceMatch:
+        - name: alertname
+          value: KubePodNotReady
+          matchType: =
+      targetMatch:
+        - name: alertname
+          value: "KubeDeploymentReplicasMismatch|KubeStatefulSetReplicasMismatch|KubeDeploymentRolloutStuck|KubeDaemonSetRolloutStuck|FluxKustomizationHealthcheckfailed"
+          matchType: =~
+    # Crashloop is the cause; not-ready is its symptom (same pod).
+    - equal: ["namespace", "pod"]
+      sourceMatch:
+        - name: alertname
+          value: KubePodCrashLooping
+          matchType: =
+      targetMatch:
+        - name: alertname
+          value: KubePodNotReady
+          matchType: =
   receivers:
     - name: "null"
     - name: pushover


### PR DESCRIPTION
Phase 2.3 (inhibition) of #3541.

Yesterday's `talos-node-gpu-1` wedge produced six concurrent alert groups for one root cause (2× KubePodNotReady, 2× ReplicasMismatch/RolloutStuck, FluxKustomizationHealthcheckfailed, plus TargetDown). Two inhibition rules collapse that class of cascade:

- `KubePodNotReady` (source) inhibits `KubeDeploymentReplicasMismatch` / `KubeStatefulSetReplicasMismatch` / `KubeDeploymentRolloutStuck` / `KubeDaemonSetRolloutStuck` / `FluxKustomizationHealthcheckfailed` on `equal: [namespace]` — pods not coming up *is* the mismatch, the stuck rollout, and the failed healthcheck.
- `KubePodCrashLooping` inhibits `KubePodNotReady` on `equal: [namespace, pod]` — the crashloop message names the cause; not-ready restates it.

Known trade-off (noted in the file): namespace-scoped inhibition can mask an unrelated same-namespace workload's mismatch alert while any pod there is not-ready. At single-operator homelab scale the dedup wins; the alerts remain visible in the Alertmanager UI either way (inhibited ≠ dropped).