### PR TITLE
fix(home-assistant): roll back 2026.7.0 again — websocket API broken

### DIFF
--- a/.renovate/allowedVersions.json5
+++ b/.renovate/allowedVersions.json5
@@ -7,6 +7,16 @@
       allowedVersions: "<1",
     },
     {
+      // 2026.7.0 ships a broken websocket API (WebSocketResponse decode_text
+      // TypeError with the bundled aiohttp) — kills the UI and companion apps.
+      // Rolled back twice (#3527, and again 2026-07-02 after renovate
+      // auto-merged it). Allow 2026.7.1+ where the fix should land; drop this
+      // rule once a working 2026.7.x is verified.
+      matchDatasources: ["docker"],
+      matchPackageNames: ["ghcr.io/home-operations/home-assistant"],
+      allowedVersions: "!/^2026\\.7\\.0$/",
+    },
+    {
       // Pin Ceph images to v18.x to match external Ceph cluster version (18.2.7)
       // Prevents automatic upgrades to v19+ which would be incompatible
       // Applies to: toolbox and CephCluster cephVersion.image
@@ -14,7 +24,7 @@
       matchPackageNames: ["quay.io/ceph/ceph"],
       matchFileNames: [
         "kubernetes/apps/rook-ceph/rook-ceph-cluster/app/toolbox.yaml",
-        "kubernetes/apps/rook-ceph/rook-ceph-cluster/app/cluster-external.yaml"
+        "kubernetes/apps/rook-ceph/rook-ceph-cluster/app/cluster-external.yaml",
       ],
       allowedVersions: "/^v18\\./",
     },

--- a/kubernetes/apps/home-automation/home-assistant/app/helmrelease.yaml
+++ b/kubernetes/apps/home-automation/home-assistant/app/helmrelease.yaml
@@ -32,7 +32,7 @@ spec:
           app:
             image:
               repository: ghcr.io/home-operations/home-assistant
-              tag: 2026.7.0@sha256:dba81097ecdee59dda9adaed94e146398a241efaa74a836567c64f5a3f29ca67
+              tag: 2026.6.4@sha256:29d953e7be59a0c3cceefad839138d3a57c7b9efb81c800a51d8453d5913cc12
             env:
               TZ: ${TIME_ZONE}
               UV_SYSTEM_PYTHON: true
@@ -59,13 +59,18 @@ spec:
             image:
               repository: ghcr.io/coder/code-server
               tag: 4.126.0@sha256:e1f03b5faaefd63ba6c7173a5290c6ec0526ac907f23acfe6bc949dd965279e4
-            args: [
-              "--auth", "none",
-              "--user-data-dir", "/config/.vscode",
-              "--extensions-dir", "/config/.vscode",
-              "--port", "12321",
-              "/config"
-            ]
+            args:
+              [
+                "--auth",
+                "none",
+                "--user-data-dir",
+                "/config/.vscode",
+                "--extensions-dir",
+                "/config/.vscode",
+                "--port",
+                "12321",
+                "/config",
+              ]
             env:
               HASS_SERVER: http://localhost:8123
               HASS_TOKEN:


### PR DESCRIPTION
Renovate auto-merged #3529 (2026.6.4 → 2026.7.0) ~30 minutes ago — the exact version already rolled back in #3527. Confirmed broken live: the pod is on 2026.7.0 and every websocket connection dies with

```
TypeError: WebSocketResponse.__init__() got an unexpected keyword argument 'decode_text'
```

so the UI and companion apps can't connect.

- Revert image to `2026.6.4` (previous digest).
- Add a `.renovate/allowedVersions.json5` rule excluding exactly `2026.7.0` for `ghcr.io/home-operations/home-assistant` — without it, Renovate would immediately re-open and auto-merge the same bump. `2026.7.1+` (where the aiohttp fix should land) flows normally; drop the rule once a working 2026.7.x is verified.