### PR TITLE
feat(gatus): Pushover opt-in for the act-now shortlist (authentik, hass)

### DIFF
--- a/kubernetes/apps/home-automation/home-assistant/app/helmrelease.yaml
+++ b/kubernetes/apps/home-automation/home-assistant/app/helmrelease.yaml
@@ -98,6 +98,13 @@ spec:
       app:
         annotations:
           external-dns.alpha.kubernetes.io/target: "external.${SECRET_DOMAIN}"
+          # Pushover opt-in (EEMUA shortlist): HA down = automations, alarm
+          # panel, and companion apps dead — household-impacting, act-now.
+          # Overrides the Gateway's ntfy-only default.
+          gatus.home-operations.com/endpoint: |-
+            alerts:
+              - type: ntfy
+              - type: pushover
         hostnames: ["hass.${SECRET_DOMAIN}"]
         parentRefs:
           - name: external

--- a/kubernetes/apps/security/authentik/app/httproute.yaml
+++ b/kubernetes/apps/security/authentik/app/httproute.yaml
@@ -10,6 +10,12 @@ metadata:
     # DNS via the Cloudflare tunnel; LAN clients still reach it locally because
     # k8s-gateway resolves it to the external VIP (10.100.0.22), no Cloudflare hairpin.
     external-dns.alpha.kubernetes.io/target: "external.${SECRET_DOMAIN}"
+    # Pushover opt-in (EEMUA shortlist): the IdP down = every SSO-gated app
+    # unusable, act-now. Overrides the Gateway's ntfy-only default.
+    gatus.home-operations.com/endpoint: |-
+      alerts:
+        - type: ntfy
+        - type: pushover
 spec:
   parentRefs:
     - name: external


### PR DESCRIPTION
Phase 2.2 of #3541.

The ntfy-only default for auto-discovered Gatus endpoints was already in place via the Gateway `gatus.home-operations.com/endpoint` annotations — this adds the opt-in side: route-level annotations that override `alerts:` with ntfy + Pushover for the two apps whose outage is genuinely act-now:

- **Authentik** — the IdP; down means every SSO-gated UI is unusable and OIDC logins fail everywhere.
- **Home Assistant** — automations, alarm handling, and companion apps all stop.

Debounce is the provider default (`failure-threshold: 5` / `success-threshold: 3` — ~5 minutes of hard failure before anything pages).

**Deliberately excluded:** Vaultwarden — its probe has a flapping history; wiring a flapper to Pushover is how the paging channel dies. It joins the shortlist once the probe is stable. Clients also cache vault data, so a brief outage is not act-now.