### PR TITLE
feat(vmalert): log-based alerting on VictoriaLogs (LogsQL rules)

### DIFF
--- a/kubernetes/apps/observability/kustomization.yaml
+++ b/kubernetes/apps/observability/kustomization.yaml
@@ -21,3 +21,4 @@ resources:
   - ./fluent-bit/ks.yaml
   - ./silence-operator/ks.yaml
   - ./victoria-logs/ks.yaml
+  - ./vmalert/ks.yaml

--- a/kubernetes/apps/observability/vmalert/app/helmrelease.yaml
+++ b/kubernetes/apps/observability/vmalert/app/helmrelease.yaml
@@ -1,0 +1,89 @@
+---
+# yaml-language-server: $schema=https://kubernetes-schemas.pages.dev/helm.toolkit.fluxcd.io/helmrelease_v2.json
+# vmalert evaluating LogsQL rules against VictoriaLogs (log-based alerting).
+# Fires into the existing Alertmanager — same routing, inhibition, and
+# channels as every other alert; no new delivery path. Every rule here has
+# passed the notification-design gate (cause/consequence/response and a
+# threshold tuned against live log volumes, see rule comments).
+apiVersion: helm.toolkit.fluxcd.io/v2
+kind: HelmRelease
+metadata:
+  name: vmalert
+spec:
+  interval: 30m
+  chartRef:
+    kind: OCIRepository
+    name: vmalert
+  install:
+    remediation:
+      retries: 3
+  upgrade:
+    cleanupOnFail: true
+    remediation:
+      strategy: rollback
+      retries: 3
+  dependsOn:
+    - name: victoria-logs
+      namespace: observability
+  values:
+    fullnameOverride: vmalert
+    serviceMonitor:
+      enabled: true
+    server:
+      datasource:
+        url: http://victoria-logs-server.observability.svc.cluster.local:9428
+      notifier:
+        url: http://alertmanager-operated.observability.svc.cluster.local:9093
+      resources:
+        requests:
+          cpu: 10m
+          memory: 64Mi
+        limits:
+          memory: 128Mi
+      config:
+        alerts:
+          groups:
+            - name: victorialogs.rules
+              type: vlogs
+              interval: 5m
+              rules:
+                # Pipeline deadman: normal volume is ~180k lines/15m, so <100
+                # means collection is dead (fluent-bit or ingestion), not quiet.
+                # If VictoriaLogs itself is down, stock kube alerts cover it.
+                - alert: LoggingPipelineDead
+                  expr: "_time:15m * | stats count() as ingested | filter ingested:<100"
+                  labels:
+                    severity: warning
+                  annotations:
+                    summary: "Log pipeline dead — almost no logs ingested in 15m"
+                    description: >-
+                      VictoriaLogs received {{ $labels.ingested }} lines in 15m
+                      (normal ~180k). Log collection is broken and evidence is
+                      being lost. Check fluent-bit DaemonSet health and the
+                      victoria-logs ingestion endpoint.
+                # 10 hits cluster-wide in the last 7d — >3 per namespace in 10m
+                # is a real crash pattern, not background noise.
+                - alert: PanicLogPatternDetected
+                  expr: '_time:10m ("panic:" OR "segfault" OR "SIGSEGV") | stats by (k_namespace_name) count() as hits | filter hits:>3'
+                  labels:
+                    severity: warning
+                  annotations:
+                    summary: "Repeated panic/segfault logs in {{ $labels.k_namespace_name }}"
+                    description: >-
+                      {{ $labels.hits }} panic/segfault log lines in 10m in
+                      namespace {{ $labels.k_namespace_name }} — something is
+                      crash-looping at the process level (may not surface as
+                      pod restarts if a supervisor swallows it). Inspect the
+                      namespace's pod logs in VictoriaLogs.
+                # Baseline is ~5 failed logins per WEEK — >20 in 15m is a
+                # credential-stuffing/brute-force signature, not fat fingers.
+                - alert: AuthentikLoginFailureSpike
+                  expr: '_time:15m k_namespace_name:security "login_failed" | stats count() as failures | filter failures:>20'
+                  labels:
+                    severity: warning
+                  annotations:
+                    summary: "Authentik login-failure spike — possible brute force"
+                    description: >-
+                      {{ $labels.failures }} failed logins in 15m (baseline ~5/week).
+                      Check Authentik events for the source IP/username, and
+                      Cloudflare for the client; consider blocking at the edge.

--- a/kubernetes/apps/observability/vmalert/app/kustomization.yaml
+++ b/kubernetes/apps/observability/vmalert/app/kustomization.yaml
@@ -1,0 +1,7 @@
+---
+# yaml-language-server: $schema=https://json.schemastore.org/kustomization
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+resources:
+  - ./helmrelease.yaml
+  - ./ocirepository.yaml

--- a/kubernetes/apps/observability/vmalert/app/ocirepository.yaml
+++ b/kubernetes/apps/observability/vmalert/app/ocirepository.yaml
@@ -1,0 +1,14 @@
+---
+# yaml-language-server: $schema=https://kubernetes-schemas.pages.dev/source.toolkit.fluxcd.io/ocirepository_v1.json
+apiVersion: source.toolkit.fluxcd.io/v1
+kind: OCIRepository
+metadata:
+  name: vmalert
+spec:
+  interval: 5m
+  layerSelector:
+    mediaType: application/vnd.cncf.helm.chart.content.v1.tar+gzip
+    operation: copy
+  ref:
+    tag: 0.43.0
+  url: oci://ghcr.io/victoriametrics/helm-charts/victoria-metrics-alert

--- a/kubernetes/apps/observability/vmalert/ks.yaml
+++ b/kubernetes/apps/observability/vmalert/ks.yaml
@@ -1,0 +1,29 @@
+---
+# yaml-language-server: $schema=https://kubernetes-schemas.pages.dev/kustomize.toolkit.fluxcd.io/kustomization_v1.json
+apiVersion: kustomize.toolkit.fluxcd.io/v1
+kind: Kustomization
+metadata:
+  name: &app vmalert
+  namespace: &namespace observability
+spec:
+  targetNamespace: *namespace
+  commonMetadata:
+    labels:
+      app.kubernetes.io/name: *app
+  dependsOn:
+    - name: victoria-logs
+      namespace: observability
+  path: ./kubernetes/apps/observability/vmalert/app
+  prune: true
+  sourceRef:
+    kind: GitRepository
+    name: flux-system
+    namespace: flux-system
+  healthChecks:
+    - apiVersion: helm.toolkit.fluxcd.io/v2
+      kind: HelmRelease
+      name: *app
+      namespace: *namespace
+  interval: 1h
+  retryInterval: 2m
+  timeout: 5m


### PR DESCRIPTION
Phase 3 of #3541 — VictoriaLogs finally alerts on what it sees.

New app `observability/vmalert` (victoria-metrics-alert 0.43.0, OCI like victoria-logs): `datasource.url` → `victoria-logs-server:9428`, `notifier.url` → `alertmanager-operated:9093`. Alerts flow through the existing Alertmanager — same routing tree, inhibition, ntfy/Pushover channels, and severity discipline; no new delivery path. ServiceMonitor enabled so rule-evaluation errors are visible in Prometheus.

Three first rules (group `type: vlogs`), each with thresholds tuned against **live** log data rather than guesses:

| Rule | Threshold | Live baseline |
|---|---|---|
| `LoggingPipelineDead` | <100 lines/15m | ~184k lines/15m normal |
| `PanicLogPatternDetected` | >3 panic/segfault per ns/10m | 10 hits cluster-wide in 7d |
| `AuthentikLoginFailureSpike` | >20 `login_failed`/15m | ~5/week |

All `severity: warning` (act-today, ntfy). Deliberately **not** shipped after gating: VolSync/restic and CNPG WAL log rules (outcome already covered by `VolSyncVolumeOutOfSync` / `LastFailedArchiveTime` — a log twin would violate the existing-coverage kill criterion), and Plex file-log errors (events → dashboard, not alerts).

Verification: vmalert pod Ready, `/vmalert/groups` shows the group, `vmalert_alerting_rules_error == 0` in Prometheus.