### PR TITLE
fix(alerts): de-flap BlackboxProbeFailed + restore duplicate-timestamps route

### DIFF
--- a/kubernetes/apps/observability/blackbox-exporter/app/helmrelease.yaml
+++ b/kubernetes/apps/observability/blackbox-exporter/app/helmrelease.yaml
@@ -64,11 +64,19 @@ spec:
       enabled: true
       rules:
         - alert: BlackboxProbeFailed
-          expr: probe_success == 0
-          for: 15m
+          # max_over_time absorbs single-scrape blips: the garage hosts
+          # (proxmox-0x, firewall, zigbee-controller) sit behind the 60GHz
+          # bridge and each flapped 400-600 pending-episodes/7d on the old
+          # `probe_success == 0` — a probe now has to fail every scrape for
+          # 5 minutes straight before the alert even goes pending.
+          expr: max_over_time(probe_success[5m]) == 0
+          for: 10m
           labels:
-            severity: critical
+            # Warning, not critical: an unreachable LAN host at 3am is a
+            # morning task (and when it's the bridge, there's nothing to do
+            # remotely anyway). Cluster impact has its own alerts.
+            severity: warning
           annotations:
             summary: The host {{ $labels.target }} is currently unreachable
             description: |-
-              Blackbox probe to {{ $labels.target }} has failed for more than 15 minutes. The host may be down or network connectivity issues exist.
+              Blackbox probe to {{ $labels.target }} has failed every scrape for 15+ minutes. The host may be down or network connectivity issues exist (check the 60GHz bridge first for garage hosts).

--- a/kubernetes/apps/observability/kube-prometheus-stack/app/alertmanagerconfig.yaml
+++ b/kubernetes/apps/observability/kube-prometheus-stack/app/alertmanagerconfig.yaml
@@ -18,11 +18,10 @@ spec:
           - name: alertname
             value: InfoInhibitor
             matchType: =
-      - receiver: "null"
-        matchers:
-          - name: alertname
-            value: PrometheusDuplicateTimestamps
-            matchType: =
+      # PrometheusDuplicateTimestamps was null-routed while a target emitted a
+      # steady 120 dup/h (started 2026-06-25, stopped 2026-07-02 ~14:00 with
+      # that day's pod restarts). Route restored so a recurrence notifies —
+      # hunt the offender while it's fresh instead of shelving it again.
       # Dead man's switch: Watchdog fires ALWAYS by design — it exists to be a
       # heartbeat consumed OUTSIDE the cluster. Forward it to healthchecks.io,
       # which alerts via its own channels when the heartbeat STOPS. End-to-end


### PR DESCRIPTION
Follow-ups from #3541.

**BlackboxProbeFailed** — two defects:
- It was an **8th custom critical** that escaped the Phase-2 audit (defined inline in the blackbox-exporter helmrelease, not a `prometheusrule.yaml`). An unreachable LAN host at 3am is a morning task; when it's the 60GHz bridge there's nothing to do remotely anyway → warning.
- `probe_success == 0` goes pending on a single failed scrape: the garage hosts behind the bridge (proxmox-01..04, firewall.manor, zigbee-controller.manor) each logged 400–624 flap-episodes/7d. New expr `max_over_time(probe_success[5m]) == 0` + `for: 10m` requires ~15 minutes of hard-down before firing, identical detection for real outages, zero pending-churn from blips.

**PrometheusDuplicateTimestamps** — the 7d rate history shows a clean story: 0 → steady 120 dup/h starting 2026-06-25 ~14:00 → 0 again 2026-07-02 ~14:00 (stopped with that day's pod restarts; exactly one duplicated series on a 1m-scrape target). It's resolved, so the null-route comes out — if it recurs, we want the warning so the offender can be hunted while fresh, not shelved for another week.