### PR TITLE
feat(vaultwarden): join the Gatus Pushover shortlist

### DIFF
--- a/kubernetes/apps/security/vaultwarden/app/helmrelease.yaml
+++ b/kubernetes/apps/security/vaultwarden/app/helmrelease.yaml
@@ -88,8 +88,14 @@ spec:
           external-dns.alpha.kubernetes.io/target: "external.${SECRET_DOMAIN}"
           # Probe /alive, not the first route rule (/notifications/hub/negotiate,
           # a SignalR endpoint that 404s on a plain GET).
+          # Pushover opt-in (EEMUA shortlist): password manager unreachable is
+          # act-now for the household. Added 2026-07-02 once the probe was
+          # stable (~1 blip/day vs the threshold of 5 consecutive failures).
           gatus.home-operations.com/endpoint: |-
             path: /alive
+            alerts:
+              - type: ntfy
+              - type: pushover
         hostnames: ["vault.${SECRET_DOMAIN}"]
         parentRefs:
           - name: external


### PR DESCRIPTION
Follow-up to #3554 (#3541 series): vaultwarden was deferred from the Pushover shortlist because of its flapping probe. Current data: 1 failure vs 1,436 successes in 24h — one blip a day against a debounce of 5 consecutive failures, so it can never page on noise. Route annotation now overrides the Gateway default with ntfy + pushover, same as authentik/hass.