### PR TITLE
feat(alerts): VL explore links on log alerts + review reminder on drill

### DIFF
--- a/kubernetes/apps/observability/kube-prometheus-stack/app/paging-drill.yaml
+++ b/kubernetes/apps/observability/kube-prometheus-stack/app/paging-drill.yaml
@@ -51,7 +51,7 @@ spec:
                       },
                       "annotations": {
                         "summary": "Monthly paging-path drill — no action needed if received",
-                        "description": "Synthetic critical exercising the full paging path. Expect BOTH a Pushover page and an ntfy urgent push. If either is missing the pipeline is broken: check alertmanager_notifications_failed_total."
+                        "description": "Synthetic critical exercising the full paging path. Expect BOTH a Pushover page and an ntfy urgent push. If either is missing the pipeline is broken: check alertmanager_notifications_failed_total. While you are here: monthly bad-actor review — open https://grafana.${SECRET_DOMAIN}/d/alerting-health and fix anything firing >5x/week."
                       }
                     }]' \
                     http://alertmanager-operated.observability.svc.cluster.local:9093/api/v2/alerts

--- a/kubernetes/apps/observability/vmalert/app/helmrelease.yaml
+++ b/kubernetes/apps/observability/vmalert/app/helmrelease.yaml
@@ -61,6 +61,7 @@ spec:
                       (normal ~180k). Log collection is broken and evidence is
                       being lost. Check fluent-bit DaemonSet health and the
                       victoria-logs ingestion endpoint.
+                      Logs: https://grafana.${SECRET_DOMAIN}/explore?schemaVersion=1&panes=%7B%22vl%22%3A%7B%22datasource%22%3A%22victoria-logs%22%2C%22queries%22%3A%5B%7B%22refId%22%3A%22A%22%2C%22expr%22%3A%22%2A%22%2C%22datasource%22%3A%7B%22type%22%3A%22victoriametrics-logs-datasource%22%2C%22uid%22%3A%22victoria-logs%22%7D%7D%5D%2C%22range%22%3A%7B%22from%22%3A%22now-30m%22%2C%22to%22%3A%22now%22%7D%7D%7D
                 # 10 hits cluster-wide in the last 7d — >3 per namespace in 10m
                 # is a real crash pattern, not background noise.
                 - alert: PanicLogPatternDetected
@@ -75,6 +76,7 @@ spec:
                       crash-looping at the process level (may not surface as
                       pod restarts if a supervisor swallows it). Inspect the
                       namespace's pod logs in VictoriaLogs.
+                      Logs: https://grafana.${SECRET_DOMAIN}/explore?schemaVersion=1&panes=%7B%22vl%22%3A%7B%22datasource%22%3A%22victoria-logs%22%2C%22queries%22%3A%5B%7B%22refId%22%3A%22A%22%2C%22expr%22%3A%22%28%5C%22panic%3A%5C%22%20OR%20%5C%22segfault%5C%22%20OR%20%5C%22SIGSEGV%5C%22%29%22%2C%22datasource%22%3A%7B%22type%22%3A%22victoriametrics-logs-datasource%22%2C%22uid%22%3A%22victoria-logs%22%7D%7D%5D%2C%22range%22%3A%7B%22from%22%3A%22now-30m%22%2C%22to%22%3A%22now%22%7D%7D%7D
                 # Baseline is ~5 failed logins per WEEK — >20 in 15m is a
                 # credential-stuffing/brute-force signature, not fat fingers.
                 - alert: AuthentikLoginFailureSpike
@@ -87,3 +89,4 @@ spec:
                       {{ $labels.failures }} failed logins in 15m (baseline ~5/week).
                       Check Authentik events for the source IP/username, and
                       Cloudflare for the client; consider blocking at the edge.
+                      Logs: https://grafana.${SECRET_DOMAIN}/explore?schemaVersion=1&panes=%7B%22vl%22%3A%7B%22datasource%22%3A%22victoria-logs%22%2C%22queries%22%3A%5B%7B%22refId%22%3A%22A%22%2C%22expr%22%3A%22k_namespace_name%3Asecurity%20%5C%22login_failed%5C%22%22%2C%22datasource%22%3A%7B%22type%22%3A%22victoriametrics-logs-datasource%22%2C%22uid%22%3A%22victoria-logs%22%7D%7D%5D%2C%22range%22%3A%7B%22from%22%3A%22now-1h%22%2C%22to%22%3A%22now%22%7D%7D%7D


### PR DESCRIPTION
Two remaining #3541 follow-ups:

- **VL explore links (Phase 3 leftover):** each of the three vmalert LogsQL rules gets a `Logs:` deep-link in its description — Grafana explore pre-loaded with the victoria-logs datasource and the rule's own filter query (pipeline: `*` last 30m; panic: the pattern match; authentik: `k_namespace_name:security "login_failed"`). ntfy renders the URL clickable, so the notification is one tap from the evidence.
- **Monthly bad-actor review cadence (Phase 4 leftover):** rather than a new notification (which would fail the gate — a reminder push for a routine chore), the existing monthly paging-drill alert now carries the review prompt and a link to the `alerting-health` dashboard. Same monthly touchpoint, zero added notification load.