### PR TITLE
feat(grafana): Plex Logs dashboard (VictoriaLogs)

### DIFF
--- a/kubernetes/apps/observability/grafana/instance/dashboards/plex-logs.json
+++ b/kubernetes/apps/observability/grafana/instance/dashboards/plex-logs.json
@@ -1,0 +1,229 @@
+{
+  "title": "Plex Logs",
+  "uid": "plex-logs",
+  "description": "Plex Media Server file logs (tail sidecar -> fluent-bit -> VictoriaLogs). Events belong on a dashboard, not in notifications (#3541 Phase 3).",
+  "tags": ["media", "plex", "logs", "victorialogs"],
+  "schemaVersion": 39,
+  "editable": true,
+  "graphTooltip": 1,
+  "time": {
+    "from": "now-24h",
+    "to": "now"
+  },
+  "refresh": "5m",
+  "timezone": "browser",
+  "templating": {
+    "list": []
+  },
+  "panels": [
+    {
+      "id": 1,
+      "type": "timeseries",
+      "title": "Plex ERROR lines per hour",
+      "datasource": {
+        "type": "victoriametrics-logs-datasource",
+        "uid": "victoria-logs"
+      },
+      "gridPos": {
+        "h": 8,
+        "w": 12,
+        "x": 0,
+        "y": 0
+      },
+      "targets": [
+        {
+          "datasource": {
+            "type": "victoriametrics-logs-datasource",
+            "uid": "victoria-logs"
+          },
+          "refId": "A",
+          "queryType": "statsRange",
+          "step": "1h",
+          "expr": "k_pod_name:plex* k_container_name:logs \"ERROR\" | stats by (_time:1h) count() as errors"
+        }
+      ],
+      "fieldConfig": {
+        "defaults": {
+          "unit": "short",
+          "color": {
+            "mode": "palette-classic"
+          },
+          "custom": {
+            "drawStyle": "line",
+            "lineWidth": 2,
+            "fillOpacity": 8,
+            "showPoints": "never"
+          }
+        },
+        "overrides": []
+      },
+      "options": {
+        "legend": {
+          "showLegend": false
+        },
+        "tooltip": {
+          "mode": "multi"
+        }
+      }
+    },
+    {
+      "id": 2,
+      "type": "timeseries",
+      "title": "Plex WARN lines per hour",
+      "datasource": {
+        "type": "victoriametrics-logs-datasource",
+        "uid": "victoria-logs"
+      },
+      "gridPos": {
+        "h": 8,
+        "w": 12,
+        "x": 12,
+        "y": 0
+      },
+      "targets": [
+        {
+          "datasource": {
+            "type": "victoriametrics-logs-datasource",
+            "uid": "victoria-logs"
+          },
+          "refId": "A",
+          "queryType": "statsRange",
+          "step": "1h",
+          "expr": "k_pod_name:plex* k_container_name:logs \"WARN\" | stats by (_time:1h) count() as warns"
+        }
+      ],
+      "fieldConfig": {
+        "defaults": {
+          "unit": "short",
+          "color": {
+            "mode": "palette-classic"
+          },
+          "custom": {
+            "drawStyle": "line",
+            "lineWidth": 2,
+            "fillOpacity": 8,
+            "showPoints": "never"
+          }
+        },
+        "overrides": []
+      },
+      "options": {
+        "legend": {
+          "showLegend": false
+        },
+        "tooltip": {
+          "mode": "multi"
+        }
+      }
+    },
+    {
+      "id": 3,
+      "type": "logs",
+      "title": "Database health signatures",
+      "description": "Sqlite contention & corruption strings from Plex Media Server.log. 'Held transaction for too long' = DB contention; 'malformed' = restore from backup time.",
+      "datasource": {
+        "type": "victoriametrics-logs-datasource",
+        "uid": "victoria-logs"
+      },
+      "gridPos": {
+        "h": 8,
+        "w": 24,
+        "x": 0,
+        "y": 8
+      },
+      "targets": [
+        {
+          "datasource": {
+            "type": "victoriametrics-logs-datasource",
+            "uid": "victoria-logs"
+          },
+          "refId": "A",
+          "expr": "k_pod_name:plex* k_container_name:logs (\"database is locked\" OR \"database disk image is malformed\" OR \"corrupt\" OR \"Held transaction for too long\")",
+          "queryType": "logs",
+          "maxLines": 200
+        }
+      ],
+      "options": {
+        "showTime": true,
+        "wrapLogMessage": true,
+        "sortOrder": "Descending",
+        "enableLogDetails": true,
+        "dedupStrategy": "none"
+      }
+    },
+    {
+      "id": 4,
+      "type": "logs",
+      "title": "Transcode failures",
+      "description": "Transcoder-related errors \u2014 codec/HW-accel issues show up here long before users file reports.",
+      "datasource": {
+        "type": "victoriametrics-logs-datasource",
+        "uid": "victoria-logs"
+      },
+      "gridPos": {
+        "h": 8,
+        "w": 24,
+        "x": 0,
+        "y": 16
+      },
+      "targets": [
+        {
+          "datasource": {
+            "type": "victoriametrics-logs-datasource",
+            "uid": "victoria-logs"
+          },
+          "refId": "A",
+          "expr": "k_pod_name:plex* k_container_name:logs \"transcode\" (\"failed\" OR \"error\" OR \"died\")",
+          "queryType": "logs",
+          "maxLines": 200
+        }
+      ],
+      "options": {
+        "showTime": true,
+        "wrapLogMessage": true,
+        "sortOrder": "Descending",
+        "enableLogDetails": true,
+        "dedupStrategy": "none"
+      }
+    },
+    {
+      "id": 5,
+      "type": "logs",
+      "title": "All recent ERROR lines",
+      "description": "",
+      "datasource": {
+        "type": "victoriametrics-logs-datasource",
+        "uid": "victoria-logs"
+      },
+      "gridPos": {
+        "h": 10,
+        "w": 24,
+        "x": 0,
+        "y": 24
+      },
+      "targets": [
+        {
+          "datasource": {
+            "type": "victoriametrics-logs-datasource",
+            "uid": "victoria-logs"
+          },
+          "refId": "A",
+          "expr": "k_pod_name:plex* k_container_name:logs \"ERROR\"",
+          "queryType": "logs",
+          "maxLines": 200
+        }
+      ],
+      "options": {
+        "showTime": true,
+        "wrapLogMessage": true,
+        "sortOrder": "Descending",
+        "enableLogDetails": true,
+        "dedupStrategy": "none"
+      }
+    }
+  ],
+  "annotations": {
+    "list": []
+  },
+  "links": []
+}

--- a/kubernetes/apps/observability/grafana/instance/grafanadashboard-configmap.yaml
+++ b/kubernetes/apps/observability/grafana/instance/grafanadashboard-configmap.yaml
@@ -152,3 +152,18 @@ spec:
   configMapRef:
     name: grafana-dashboard-alerting-health
     key: alerting-health.json
+---
+# yaml-language-server: $schema=https://kubernetes-schemas.pages.dev/grafana.integreatly.org/grafanadashboard_v1beta1.json
+apiVersion: grafana.integreatly.org/v1beta1
+kind: GrafanaDashboard
+metadata:
+  name: plex-logs
+spec:
+  allowCrossNamespaceImport: true
+  instanceSelector:
+    matchLabels:
+      dashboards: grafana
+  resyncPeriod: 1h
+  configMapRef:
+    name: grafana-dashboard-plex-logs
+    key: plex-logs.json

--- a/kubernetes/apps/observability/grafana/instance/kustomization.yaml
+++ b/kubernetes/apps/observability/grafana/instance/kustomization.yaml
@@ -41,6 +41,11 @@ configMapGenerator:
       - alerting-health.json=dashboards/alerting-health.json
     options:
       disableNameSuffixHash: true
+  - name: grafana-dashboard-plex-logs
+    files:
+      - plex-logs.json=dashboards/plex-logs.json
+    options:
+      disableNameSuffixHash: true
   - name: grafana-dashboard-snmp-network
     files:
       - snmp-network.json=dashboards/snmp-network.json


### PR DESCRIPTION
Last #3541 Phase-3 follow-up: Plex file-log **dashboard** (uid `plex-logs`) — the gate ruled these are events, not alerts.

The `logs` sidecar already tails `Plex Media Server.log` into fluent-bit → VictoriaLogs (~130k lines/day, verified live). Panels, all on the `victoria-logs` datasource:

- ERROR and WARN lines per hour (statsRange timeseries) — trend/regression spotting.
- **Database health signatures** logs panel: `database is locked`, `database disk image is malformed`, `corrupt`, `Held transaction for too long` (contention showed up in today's live sample).
- **Transcode failures** logs panel.
- Raw recent-ERROR tail.

Same configMapRef wiring as alert-history/alerting-health.