### PR TITLE
feat(skills): smart-home working skills (node-red-flows, hass-api, zigbee-mqtt, smart-home-map)

### DIFF
--- a/.claude/skills/hass-api/SKILL.md
+++ b/.claude/skills/hass-api/SKILL.md
@@ -1,0 +1,62 @@
+---
+name: hass-api
+description: Query and control Home Assistant from the CLI — entity states, service calls, templates, history. Use when verifying what an automation reads/writes, checking whether an entity exists or is stale, firing a test service call, or debugging "why didn't X trigger". Works via the HA REST API with a token borrowed from Node-RED.
+allowed-tools: Bash, Read
+---
+
+# Home Assistant API
+
+HA runs at <https://hass.chelonianlabs.com> (`home-automation` namespace). Its config
+lives on the PVC (VolSync-backed), **not in this repo** — the repo only has the
+HelmRelease (`kubernetes/apps/home-automation/home-assistant/`).
+
+## The helper script
+
+`scripts/ha.sh` wraps the REST API and auto-extracts a long-lived token from
+Node-RED's project credentials (plaintext on the pod). Export `HASS_TOKEN` to skip
+the kubectl round-trip when making several calls.
+
+```bash
+HA=./.claude/skills/hass-api/scripts/ha.sh
+
+$HA states washer                 # list entity_ids matching a pattern (+ state)
+$HA state sensor.washer_power_minute_average    # one entity, full JSON
+$HA template '{{ states("input_select.washer_state") }}'   # evaluate a Jinja template
+$HA services notify               # what services exist in a domain
+$HA history sensor.dryer_power_minute_average 6 # last 6h of states
+$HA call input_select select_option '{"entity_id":"input_select.washer_state","option":"Idle"}'
+```
+
+`call` CHANGES real state in the house — use for deliberate tests only, and prefer
+reversible targets (input_selects, notify to your own phone) over lights/locks.
+
+Cache the token for a session:
+
+```bash
+export HASS_TOKEN=$($HA token)
+```
+
+## Conventions worth knowing
+
+- Appliance state machines: `input_select.{washer,dryer,dishwasher}_state`
+  (options `Idle/Running/Clean[/Dirty]`) — owned by Node-RED flows, see the
+  smart-home-map skill.
+- Power sensing: `sensor.{washer,dryer}_power_minute_average` (smoothed
+  statistics sensors over the raw plug power).
+- Notifications: `notify.everyone` fans out to all phones; per-device
+  `notify.mobile_app_*` also exist. Anything new that notifies must pass the
+  notification-design skill first.
+- HA version is pinned/rolled back at times (2026.7.0 broke the websocket API that
+  Node-RED depends on — PR #3553). Before blaming a flow, check
+  `kubectl logs -n home-automation deploy/node-red` for websocket reconnect loops.
+
+## Raw API (when the script doesn't cover it)
+
+```bash
+curl -s -H "Authorization: Bearer $HASS_TOKEN" https://hass.chelonianlabs.com/api/states | jq length
+# Docs: https://developers.home-assistant.io/docs/api/rest/
+```
+
+WebSocket API (entity registry, device registry, traces) isn't covered by ha.sh;
+for registry-level questions, exec into the HA pod and read
+`/config/.storage/core.entity_registry` (read-only!) or ask the user to check the UI.

--- a/.claude/skills/hass-api/scripts/ha.sh
+++ b/.claude/skills/hass-api/scripts/ha.sh
@@ -1,0 +1,83 @@
+#!/usr/bin/env bash
+# Home Assistant REST helper for the dapper-cluster smart home.
+# Token comes from $HASS_TOKEN if set, else extracted from Node-RED's project creds.
+#
+# Usage:
+#   ha.sh token                        print a usable long-lived token
+#   ha.sh states [pattern]             entity_id + state, optionally filtered (grep -iE)
+#   ha.sh state <entity_id>            full JSON for one entity
+#   ha.sh template '<jinja>'           evaluate a template
+#   ha.sh services [domain]            list services (all domains or one)
+#   ha.sh history <entity_id> [hours]  state history (default 12h)
+#   ha.sh call <domain> <service> '<json-payload>'   fire a service (MUTATES!)
+set -euo pipefail
+export KUBECONFIG="${KUBECONFIG:-$HOME/projects/dapper-cluster/kubeconfig}"
+HASS_URL="${HASS_URL:-https://hass.chelonianlabs.com}"
+
+get_token() {
+  if [ -n "${HASS_TOKEN:-}" ]; then echo "$HASS_TOKEN"; return; fi
+  kubectl exec -n home-automation deploy/node-red -- \
+    cat /data/projects/Turtleassmanor-automations/flows_cred.json |
+    python3 -c "import json,sys; print(json.load(sys.stdin)['4a296574.4626bc']['access_token'])"
+}
+
+pretty() { python3 -m json.tool 2>/dev/null || cat; }
+
+cmd="${1:?usage: ha.sh token|states|state|template|services|history|call ...}"
+shift || true
+[ "$cmd" = token ] && { get_token; exit 0; }
+
+TOKEN="$(get_token)"
+api() {
+  curl -sS -m 20 -H "Authorization: Bearer $TOKEN" -H "Content-Type: application/json" "$@"
+}
+
+case "$cmd" in
+  states)
+    pattern="${1:-.}"
+    api "$HASS_URL/api/states" | python3 -c "
+import json, re, sys
+pat = re.compile(sys.argv[1], re.I)
+for e in json.load(sys.stdin):
+    line = f\"{e['entity_id']:55s} {e['state']}\"
+    if pat.search(line):
+        print(line)
+" "$pattern"
+    ;;
+  state)
+    api "$HASS_URL/api/states/${1:?entity_id required}" | pretty
+    ;;
+  template)
+    api -X POST "$HASS_URL/api/template" \
+      --data-binary "$(python3 -c 'import json,sys; print(json.dumps({"template": sys.argv[1]}))' "${1:?template required}")"
+    echo
+    ;;
+  services)
+    api "$HASS_URL/api/services" | python3 -c "
+import json, sys
+domain = sys.argv[1] if len(sys.argv) > 1 else None
+for d in json.load(sys.stdin):
+    if domain and d['domain'] != domain: continue
+    for s in sorted(d['services']):
+        print(f\"{d['domain']}.{s}\")
+" ${1:+"$1"}
+    ;;
+  history)
+    entity="${1:?entity_id required}"; hours="${2:-12}"
+    start=$(python3 -c "import datetime as d; print((d.datetime.now(d.timezone.utc)-d.timedelta(hours=$hours)).isoformat())")
+    api "$HASS_URL/api/history/period/$start?filter_entity_id=$entity&minimal_response" | python3 -c "
+import json, sys
+for series in json.load(sys.stdin):
+    for p in series:
+        print(p.get('last_changed', p.get('lu', '?')), p.get('state', p.get('s')))
+"
+    ;;
+  call)
+    domain="${1:?domain}"; service="${2:?service}"; payload="${3:-{\}}"
+    echo ">> calling $domain.$service with $payload" >&2
+    api -X POST "$HASS_URL/api/services/$domain/$service" --data-binary "$payload" | pretty
+    ;;
+  *)
+    echo "unknown command: $cmd" >&2; exit 1
+    ;;
+esac

--- a/.claude/skills/node-red-flows/SKILL.md
+++ b/.claude/skills/node-red-flows/SKILL.md
@@ -1,0 +1,100 @@
+---
+name: node-red-flows
+description: Read, analyze, edit, and deploy Node-RED automation flows for the smart home. Use when checking on an automation, debugging why a flow didn't fire, adding/modifying flows, or answering "what does Node-RED do when X". The flows are NOT in this repo — they live in the Node-RED pod's git project.
+allowed-tools: Bash, Read, Grep, Glob
+---
+
+# Node-RED Flows
+
+Node-RED (`home-automation` namespace) holds most of the smart-home automation logic.
+It runs in **projects mode** — this is the #1 trap:
+
+> **The live flows file is `/data/projects/Turtleassmanor-automations/flows.json`.**
+> `/data/flows.json` also exists but is a STALE pre-projects leftover. Never read or edit it.
+
+The project is a git repo (`git@github.com:DapperDivers/Turtleassmanor-automations.git`),
+but **the pod cannot push** (no SSH key) — history lives on the PVC, protected by hourly
+VolSync backups (`node-red` ReplicationSource) plus daily R2 offsite.
+
+## Fast start
+
+```bash
+# Pull the live flows to a scratch file
+./.claude/skills/node-red-flows/scripts/fetch-flows.sh > /tmp/flows-live.json
+
+# Explore: tabs → nodes on a tab → one node's full config + wiring
+./.claude/skills/node-red-flows/scripts/flowdump.py /tmp/flows-live.json
+./.claude/skills/node-red-flows/scripts/flowdump.py /tmp/flows-live.json --tab Appliances
+./.claude/skills/node-red-flows/scripts/flowdump.py /tmp/flows-live.json --grep washer
+./.claude/skills/node-red-flows/scripts/flowdump.py /tmp/flows-live.json --node <node-id>
+```
+
+`flowdump.py --node` shows a node's full JSON plus **incoming and outgoing wires by
+name** — use it to trace trigger → gate → action chains without hand-parsing JSON.
+
+## Checking recent work / history
+
+The project repo's git log is the change history for all automations:
+
+```bash
+kubectl exec -n home-automation deploy/node-red -- \
+  sh -c 'cd /data/projects/Turtleassmanor-automations && git log --oneline -15'
+```
+
+## Runtime checks
+
+```bash
+kubectl logs -n home-automation deploy/node-red --since=2h   # HA/MQTT connects, call-service errors
+```
+
+A healthy log shows `Connected to https://hass.chelonianlabs.com` and
+`Connected to broker: mqtt://emqx-listeners.database.svc.cluster.local`.
+To verify the Home Assistant entities a flow reads/writes, use the `hass-api` skill.
+
+## Editing and deploying
+
+Preferred for anything non-trivial: the editor at <https://node-red.chelonianlabs.com>
+(user does it interactively). For programmatic changes, the admin API has **no auth
+in-cluster** (adminAuth commented out in settings.js):
+
+```bash
+./.claude/skills/node-red-flows/scripts/deploy-flows.sh /tmp/flows-edited.json
+```
+
+The script backs up the current flows, POSTs a **full deploy** via the admin API
+(port-forward to 1880), and reminds you to commit. Deploys write the project
+`flows.json` on the PVC but do NOT git-commit; commit afterwards:
+
+```bash
+kubectl exec -n home-automation deploy/node-red -- sh -c \
+  'cd /data/projects/Turtleassmanor-automations && git add flows.json && git commit -m "<msg>"'
+```
+
+Always run the notification-design skill first if the change adds/modifies anything
+that notifies (push, TTS, LED bar).
+
+## Known gotchas (hard-won — read before editing)
+
+See [references/node-gotchas.md](references/node-gotchas.md) for the full list with
+examples. Headlines:
+
+- **`api-current-state` gate outputs**: output 1 (wires[0]) = condition TRUE,
+  output 2 = false. 14 gates were once wired backwards (commit d4ed0be).
+- **`server-state-changed` with "for X hours" is fragile** — any state flap resets the
+  timer silently. The laundry flows replaced it with a 1-minute poll + counter
+  function (commit 1b2b74a). Prefer that pattern for "low for N minutes" logic.
+- **Function-node `context` is in-memory** (`contextStorage` default) — counters and
+  latches reset on pod restart. Design so a reset is safe (gate on an
+  `input_select` state, as the appliance flows do).
+- **Disabled nodes** have `"d": true`. A trigger wired to an enabled action does
+  nothing if the trigger itself is disabled — check both ends.
+- **`outputInitially: true` on trigger/watch nodes replays on every reconnect** —
+  caused light/notification spam on each restart (commit b226955). Leave it false.
+- **Durable appliance state lives in HA `input_select` helpers**
+  (`input_select.washer_state` etc.), not in Node-RED context — see the
+  smart-home-map skill for the architecture.
+
+Config-node IDs (referenced by most nodes): HA server = `4a296574.4626bc`,
+MQTT broker (EMQX) = `329c148fa7c93659`. Credentials for both are in the project's
+`flows_cred.json` on the pod (plaintext — "Using unencrypted credentials" in log).
+Never copy credential VALUES into this repo.

--- a/.claude/skills/node-red-flows/references/node-gotchas.md
+++ b/.claude/skills/node-red-flows/references/node-gotchas.md
@@ -1,0 +1,69 @@
+# node-red-contrib-home-assistant-websocket gotchas
+
+Hard-won lessons from the Turtleassmanor-automations project (commit refs are in that
+repo, on the pod — `git log` there for context).
+
+## api-current-state as an if-gate
+
+With "If State" set and 2 outputs: **wires[0] fires when the condition is TRUE,
+wires[1] when false.** The editor labels can mislead; 14 gates were wired backwards
+until commit d4ed0be. When adding a gate, always test both branches with an inject.
+
+Useful pattern (appliance completion):
+
+```
+counter fires once -> api-current-state "If State == Running" on input_select.X_state
+    out0 (true)  -> set input_select to Clean
+    out1 (false) -> nothing (was Idle/Clean already — stale fire, drop it)
+```
+
+## server-state-changed "for: N hours" is fragile
+
+The `for` timer restarts on ANY state change of the watched entity, including
+unavailable-flaps and attribute-driven re-fires. Long "has been X for hours" logic
+silently never fires. Replaced in the laundry flows (commit 1b2b74a) by:
+
+```
+inject (repeat 60s) -> api-current-state (read sensor into payload)
+  -> function: parseFloat; NaN => return null (skip flap, keep count);
+     below-threshold => count++; above => count=0 + re-arm latch;
+     count >= N && !fired => fired=true, return msg (fire once)
+```
+
+Properties that make this robust: NaN skip (sensor unavailable doesn't reset),
+`>=` latch (survives missed polls), re-arm only on genuinely-high power,
+`node.status()` so the counter is visible in the editor.
+
+## trigger-state constraint pitfalls
+
+- Every constraint's `propertyValue: new_state.state` compares against the SAME
+  watched entity — two constraints on `new_state.state` with different values can
+  never both be true. To cross-check ANOTHER entity, set `targetType: entity_id`.
+- `comparatorType: "is"` with a number is exact equality — a power reading almost
+  never equals exactly 50. Use `<=` / `>=`.
+- The old (pre-redesign) washer/dryer completion triggers had both bugs; the
+  stale `/data/flows.json` still contains them. Don't resurrect it.
+
+## Context & restarts
+
+- Function-node `context` uses the default in-memory store — pod restart zeroes
+  counters and latches. Any latch must be safe to lose (gate on durable HA state).
+- Durable state belongs in HA `input_select` helpers, set via
+  `input_select.select_option` with `entityId` targeting, `data: {"option": "..."}`.
+- `homeassistant.update_entity` does NOT set state — it only asks HA to poll the
+  entity. An earlier design misused it as a state-setter; nothing happened.
+
+## Replay on reconnect
+
+`outputInitially: true` (a.k.a. "output on connect") on watch nodes replays the
+current state every time Node-RED reconnects to HA — after every deploy, HA
+restart, or pod restart. Commit b226955 fixed light/notification spam caused by
+this. Only enable it when a replay is genuinely idempotent.
+
+## Editor/JSON trivia
+
+- Disabled node: `"d": true`. Disabled tab: `"disabled": true` on the tab node.
+- `z` = owning tab id; `g` = owning group id; nodes without `z` are global config
+  nodes (servers, brokers).
+- MQTT out with `retain: true` keeps the last state on the broker — remember to
+  clear the retained message (publish empty payload) if a topic is decommissioned.

--- a/.claude/skills/node-red-flows/scripts/deploy-flows.sh
+++ b/.claude/skills/node-red-flows/scripts/deploy-flows.sh
@@ -1,0 +1,30 @@
+#!/usr/bin/env bash
+# Deploy an edited flows.json to the LIVE Node-RED via the admin API (full deploy).
+# Backs up the current flows first. Does NOT git-commit — do that afterwards (see SKILL.md).
+#
+# Usage: deploy-flows.sh /path/to/flows-edited.json
+set -euo pipefail
+export KUBECONFIG="${KUBECONFIG:-$HOME/projects/dapper-cluster/kubeconfig}"
+
+FLOWS_FILE="${1:?usage: deploy-flows.sh <flows.json>}"
+python3 -c "import json,sys; f=json.load(open(sys.argv[1])); assert isinstance(f,list) and any(n.get('type')=='tab' for n in f), 'not a flows array'" "$FLOWS_FILE"
+
+BACKUP="/tmp/flows-backup-$(date +%Y%m%d-%H%M%S).json"
+kubectl exec -n home-automation deploy/node-red -- \
+  cat /data/projects/Turtleassmanor-automations/flows.json > "$BACKUP"
+echo "backed up current flows -> $BACKUP"
+
+kubectl port-forward -n home-automation deploy/node-red 18800:1880 >/dev/null 2>&1 &
+PF=$!
+trap 'kill $PF 2>/dev/null' EXIT
+for _ in $(seq 1 20); do curl -sf -m 2 http://127.0.0.1:18800/flows >/dev/null 2>&1 && break; sleep 0.5; done
+
+HTTP=$(curl -s -o /tmp/deploy-resp.json -w '%{http_code}' -X POST http://127.0.0.1:18800/flows \
+  -H 'Content-Type: application/json' \
+  -H 'Node-RED-Deployment-Type: full' \
+  --data-binary @"$FLOWS_FILE")
+if [ "$HTTP" != "204" ] && [ "$HTTP" != "200" ]; then
+  echo "DEPLOY FAILED (HTTP $HTTP):"; cat /tmp/deploy-resp.json; exit 1
+fi
+echo "deployed OK (HTTP $HTTP). Watch: kubectl logs -n home-automation deploy/node-red --since=2m"
+echo "REMEMBER to commit in the project repo (see node-red-flows SKILL.md)."

--- a/.claude/skills/node-red-flows/scripts/fetch-flows.sh
+++ b/.claude/skills/node-red-flows/scripts/fetch-flows.sh
@@ -1,0 +1,7 @@
+#!/usr/bin/env bash
+# Print the LIVE Node-RED flows.json (projects mode) to stdout.
+# Usage: fetch-flows.sh [> /tmp/flows-live.json]
+set -euo pipefail
+export KUBECONFIG="${KUBECONFIG:-$HOME/projects/dapper-cluster/kubeconfig}"
+kubectl exec -n home-automation deploy/node-red -- \
+  cat /data/projects/Turtleassmanor-automations/flows.json

--- a/.claude/skills/node-red-flows/scripts/flowdump.py
+++ b/.claude/skills/node-red-flows/scripts/flowdump.py
@@ -1,0 +1,98 @@
+#!/usr/bin/env python3
+"""Explore a Node-RED flows.json without hand-parsing it.
+
+Usage:
+  flowdump.py FLOWS.json                 # list tabs with node counts
+  flowdump.py FLOWS.json --tab NAME      # nodes on a tab (type, name, disabled, id)
+  flowdump.py FLOWS.json --grep WORD     # nodes whose JSON mentions WORD (case-insensitive)
+  flowdump.py FLOWS.json --node ID       # full node JSON + incoming/outgoing wires by name
+  flowdump.py FLOWS.json --wiring TAB    # adjacency list for a whole tab
+"""
+import argparse
+import json
+import sys
+
+
+def load(path):
+    with open(path) as f:
+        return json.load(f)
+
+
+def label(nodes, nid):
+    n = nodes.get(nid, {})
+    d = " DISABLED" if n.get("d") else ""
+    return f"{n.get('name') or n.get('type', '?')} [{n.get('type')}]{d} ({nid})"
+
+
+def tab_of(flows):
+    return {n["id"]: n.get("label", "?") for n in flows if n["type"] == "tab"}
+
+
+def main():
+    ap = argparse.ArgumentParser()
+    ap.add_argument("flows")
+    ap.add_argument("--tab")
+    ap.add_argument("--grep")
+    ap.add_argument("--node")
+    ap.add_argument("--wiring")
+    args = ap.parse_args()
+
+    flows = load(args.flows)
+    nodes = {n["id"]: n for n in flows}
+    tabs = tab_of(flows)
+
+    if args.node:
+        n = nodes.get(args.node)
+        if not n:
+            sys.exit(f"no node {args.node}")
+        print(json.dumps(n, indent=2))
+        print("\n-- outgoing --")
+        for i, w in enumerate(n.get("wires", [])):
+            for t in w:
+                print(f"  out{i} -> {label(nodes, t)}")
+        print("-- incoming --")
+        for m in flows:
+            for i, w in enumerate(m.get("wires", [])):
+                if args.node in w:
+                    print(f"  {label(nodes, m['id'])} out{i} ->")
+        return
+
+    if args.grep:
+        needle = args.grep.lower()
+        for n in flows:
+            if n["type"] in ("tab", "group"):
+                continue
+            if needle in json.dumps(n).lower():
+                print(f"{tabs.get(n.get('z'), n.get('z', 'config')):20s} {label(nodes, n['id'])}")
+        return
+
+    tab_arg = args.tab or args.wiring
+    if tab_arg:
+        tid = next((i for i, l in tabs.items() if l.lower() == tab_arg.lower()), tab_arg)
+        members = [n for n in flows if n.get("z") == tid]
+        if not members:
+            sys.exit(f"no tab named/id {tab_arg}; tabs: {list(tabs.values())}")
+        for n in members:
+            if args.wiring:
+                if n["type"] in ("group", "comment"):
+                    continue
+                outs = [[label(nodes, t) for t in w] for w in n.get("wires", [])]
+                print(f"{label(nodes, n['id'])}")
+                for i, w in enumerate(outs):
+                    for t in w:
+                        print(f"    out{i} -> {t}")
+            else:
+                d = "DISABLED" if n.get("d") else ""
+                print(f"{n['type']:26s} {n.get('name', ''):45s} {d:8s} {n['id']}")
+        return
+
+    for tid, lab in tabs.items():
+        count = sum(1 for n in flows if n.get("z") == tid)
+        disabled = sum(1 for n in flows if n.get("z") == tid and n.get("d"))
+        print(f"{tid}  {lab:25s} {count} nodes ({disabled} disabled)")
+    configs = sum(1 for n in flows if "z" not in n and n["type"] not in ("tab",))
+    print(f"(+ {configs} global config nodes)")
+
+
+if __name__ == "__main__":
+    main()

--- a/.claude/skills/smart-home-map/SKILL.md
+++ b/.claude/skills/smart-home-map/SKILL.md
@@ -1,0 +1,72 @@
+---
+name: smart-home-map
+description: Orientation map of the smart-home platform — where each system's config actually lives (mostly NOT in this repo), how the pieces connect (HA, Node-RED, Zigbee2MQTT, EMQX, ESPHome), and the standing architectural patterns (appliance state machines, Inovelli LED notification platform). Read FIRST when starting any smart-home task, before searching this repo.
+allowed-tools: Bash, Read, Grep, Glob
+---
+
+# Smart-Home Map
+
+This repo (dapper-cluster) only deploys the smart-home apps. **Their behavior lives
+in app-managed state on PVCs**, reachable via kubectl — searching the repo for an
+automation finds nothing. Start here instead.
+
+## Where things actually live
+
+| System                       | Runs as                                                            | Behavior/config lives in                                                   | How to work with it                                                     |
+| ---------------------------- | ------------------------------------------------------------------ | -------------------------------------------------------------------------- | ----------------------------------------------------------------------- |
+| Home Assistant               | `home-automation/home-assistant`                                   | `/config` on PVC (UI-managed helpers, dashboards, integrations)            | `hass-api` skill (REST)                                                 |
+| Node-RED (most automations)  | `home-automation/node-red`                                         | git project on PVC: `/data/projects/Turtleassmanor-automations/flows.json` | `node-red-flows` skill                                                  |
+| Zigbee2MQTT (house + garage) | `home-automation/zigbee2mqtt`, `zigbee2mqtt-garage`                | `/app/data/configuration.yaml` + devices on PVC                            | `zigbee-mqtt` skill; frontends zigbee[-garage].chelonianlabs.com        |
+| MQTT broker                  | `database/emqx` (`emqx-listeners.database.svc.cluster.local:1883`) | —                                                                          | `zigbee-mqtt` skill (sub/pub via node-red pod)                          |
+| ESPHome devices              | `home-automation/esphome`                                          | device YAMLs on PVC                                                        | kubectl exec / ESPHome dashboard                                        |
+| Design docs / intent         | Obsidian vault `~/second-brain/Projects/HomeLab/`                  | markdown (e.g. Inovelli LED platform design)                               | grep the vault before designing                                         |
+| Alert philosophy             | this repo + memory                                                 | EEMUA 191 overhaul (issue #3541)                                           | `notification-design` skill — MANDATORY gate for anything that notifies |
+
+Event flow: Zigbee2MQTT / ESPHome / plugs → HA entities → Node-RED (websocket) →
+HA service calls + MQTT publishes → notifications (push via `notify.everyone`,
+Inovelli LED bars, TTS).
+
+## Standing patterns
+
+Two platform patterns are documented in detail in
+[references/appliance-state-machines.md](references/appliance-state-machines.md) and
+[references/led-notification-platform.md](references/led-notification-platform.md):
+
+1. **Appliance state machines** — washer/dryer/dishwasher each have a durable
+   `input_select.<x>_state` in HA (`Idle/Running/Clean[/Dirty]`), driven by
+   Node-RED from smoothed power sensors (poll + consecutive-low-minutes counter,
+   gated on `Running`). Completion → `notify.everyone` + LED.
+2. **LED notification platform** — Inovelli switch LED bars as the household
+   "annunciator panel": producers watch state, a dispatcher owns the LEDs,
+   announce-then-rest (full-bar pulse, then per-appliance LED slot until
+   tap-to-dismiss). LEDs are the _household_ console — infrastructure alerts never
+   light the panel.
+
+## Backups / disaster recovery
+
+All smart-home PVCs have VolSync (hourly on-site + daily R2 offsite):
+`home-assistant`, `node-red`, `esphome`, `zigbee2mqtt-config`,
+`zigbee2mqtt-garage-config`. Restore: `task volsync:restore APP=<name> NS=home-automation PREVIOUS=<n>`.
+
+⚠️ The Node-RED project repo cannot `git push` from the pod (no SSH key) — its
+GitHub remote is ~200 commits stale. VolSync is the real backup. If asked to "back
+up the automations", fixing the push (deploy key or HTTPS PAT) is the durable fix.
+
+## First moves for a new smart-home task
+
+```bash
+# 1. What automations exist / recent work?
+./.claude/skills/node-red-flows/scripts/fetch-flows.sh > /tmp/flows-live.json
+./.claude/skills/node-red-flows/scripts/flowdump.py /tmp/flows-live.json
+kubectl exec -n home-automation deploy/node-red -- sh -c \
+  'cd /data/projects/Turtleassmanor-automations && git log --oneline -10'
+
+# 2. What entities are involved?
+./.claude/skills/hass-api/scripts/ha.sh states <keyword>
+
+# 3. Any design intent already written down?
+grep -ril "<topic>" ~/second-brain/Projects/HomeLab/
+```
+
+If the task adds or changes any notification (push/TTS/LED), run the
+`notification-design` skill before building.

--- a/.claude/skills/smart-home-map/references/appliance-state-machines.md
+++ b/.claude/skills/smart-home-map/references/appliance-state-machines.md
@@ -1,0 +1,66 @@
+# Appliance state machines (washer / dryer / dishwasher)
+
+The canonical pattern for "is the appliance done?" logic. Live implementation:
+Node-RED project, **Appliances** tab (state machines) + **LED Notifications** tab
+(indicators). Verified working 2026-07-02.
+
+## Durable state (Home Assistant)
+
+| Entity                          | Options                     | Notes                                   |
+| ------------------------------- | --------------------------- | --------------------------------------- |
+| `input_select.washer_state`     | Idle, Running, Clean, Dirty | Dirty currently unused (flows disabled) |
+| `input_select.dryer_state`      | Idle, Running, Clean, Dirty |                                         |
+| `input_select.dishwasher_state` | Idle, Running, Clean        |                                         |
+
+State lives in HA input_selects (survives Node-RED restarts), never in Node-RED
+context. Node-RED writes them only via `input_select.select_option`.
+
+## Inputs
+
+| Sensor                               | Meaning                                       |
+| ------------------------------------ | --------------------------------------------- |
+| `sensor.washer_power_minute_average` | Emporia Vue circuit CT, W (idle draw ≈ 70 W!) |
+| `sensor.dryer_power_minute_average`  | Emporia Vue circuit CT, W (0 when off)        |
+| kitchen plugs power (dishwasher)     | third wire of the same 1-min poll             |
+
+⚠️ Ignore `sensor.dryer_inferred_power` — it's a legacy template (whole-house
+main panel minus the water heater = house baseload), NOT the dryer. It reads
+~800 W with everything off. The automations correctly use the Emporia
+`*_power_minute_average` circuit sensors.
+
+## Transitions
+
+**→ Running** (event-driven `trigger-state` on the power sensor):
+washer fires at ≥ 200 W, dryer at ≥ 1000 W.
+
+**Running → Clean** (poll + counter, NOT `for:`-timers — those flap-reset silently):
+
+```
+inject every 60 s
+  → api-current-state (power avg into payload)
+  → function counter: NaN → skip; power < threshold → count++; else count=0 + re-arm
+      washer: < 120 W for 6 consecutive minutes
+      dryer:  < 100 W for 10 consecutive minutes
+      fires ONCE at count >= N (latch survives missed polls)
+  → api-current-state gate "state == Running?"  (out0 = true!)
+      true  → input_select.select_option → Clean
+      false → drop (stale fire while Idle/Clean)
+```
+
+**Clean → notifications** (`trigger-state` on the input_select == Clean):
+`notify.everyone` push + LED producer picks up the state change (see LED platform).
+
+**Clean → Idle**: tap-to-dismiss — double-press the config button on any kitchen
+Inovelli switch sweeps all three `*_state` selects that read Clean back to Idle
+(which also clears their LEDs).
+
+## Tuning watch-items
+
+- Washer: a soak/fill phase spending > 6 consecutive minutes under 120 W while
+  mid-cycle would fire "done" early (gate is on Running, so it WILL pass). If
+  premature notifications appear, raise the 6-minute window, not the wattage.
+- Dryer: a low-heat/delicates cycle that never reaches 1000 W never gets marked
+  Running → no completion notification. If that happens, lower the Running
+  threshold (but keep it above the ~70 W-class idle noise).
+- Counters live in Node-RED memory context — a deploy/restart mid-cycle restarts
+  the countdown (worst case: notification a few minutes late; never wrong-state).

--- a/.claude/skills/smart-home-map/references/led-notification-platform.md
+++ b/.claude/skills/smart-home-map/references/led-notification-platform.md
@@ -1,0 +1,61 @@
+# Inovelli LED notification platform
+
+The household "annunciator panel": LED bars on Inovelli switches show
+household-relevant states. **Infrastructure alerts never light the panel** (EEMUA
+overhaul rule). Full design doc: Second Brain vault →
+`~/second-brain/Projects/HomeLab/` (Inovelli LED platform).
+
+Live implementation: Node-RED project, **LED Notifications** tab
+(`led_notify_tab`). Architecture: **producers → dispatcher → MQTT**.
+
+## Dispatcher contract
+
+All LED-bar writes go through one function node (`LED Dispatcher`, fed by a
+`link in` named `led-notify`). Producers send:
+
+```json
+{ "id": "washer_done", "action": "set|clear",
+  "slot": 1-7 | null,          // null = full bar
+  "zone": "kitchen|living|office|master|guest|outdoor|downstairs|house|<switch name>",
+  "effect": "pulse|solid|...",
+  "color": 0-255,              // hue: 0 red, 21 orange, 42 yellow, 85 green, 170 blue, 195 purple
+  "level": 0-100, "duration": "1-60 s | 61-120 min | 255 = until cleared",
+  "announce": true,            // announce-then-rest: 10 s full-bar pulse first
+  "priority": n }
+```
+
+The dispatcher owns: zone → switch-name fan-out (topics
+`zigbee2mqtt/<Switch Name>/set`), night-mode dimming (house_mode Night caps level
+at 20), the active-notification store (`flow.led_notifications`), and the 10-minute
+re-announce tick that replays the full-bar pulse for anything still active.
+
+## Slot allocation
+
+| Slot | Use                        | Color            |
+| ---- | -------------------------- | ---------------- |
+| 4    | alarm panel / siren states | (alarm producer) |
+| 5    | washer done                | blue (170)       |
+| 6    | dryer done                 | green (85)       |
+| 7    | dishwasher done            | purple (195)     |
+
+Appliance producers watch `input_select.<x>_state`: `Clean` → set (announce +
+persistent slot LED at level 100 in the kitchen zone, duration 255), anything else
+→ clear.
+
+## Dismissal
+
+Double-press of the **config button on any kitchen switch** (z2m action
+`config_double`) resets every appliance select currently at Clean back to Idle;
+the producers then emit `clear`. Gates use `api-current-state` — remember out0 =
+condition-true.
+
+## Adding a new notification
+
+1. Run the `notification-design` skill — does this deserve an LED? Which severity/channel?
+2. Add a producer: watch node → small function mapping state → dispatcher contract
+   msg → `link out` to `led-notify`. Never publish to `zigbee2mqtt/*/set` directly.
+3. Pick a free slot (1-3 currently unallocated) and a distinct hue.
+4. Test with the 🧪 inject nodes on the LED tab before wiring the real trigger.
+
+Workshop/garage switches are on the `zigbee2mqtt-garage` base topic and are NOT in
+the dispatcher's ZONES map yet (planned Phase 3, with a z2m broadcast group).

--- a/.claude/skills/zigbee-mqtt/SKILL.md
+++ b/.claude/skills/zigbee-mqtt/SKILL.md
@@ -1,0 +1,62 @@
+---
+name: zigbee-mqtt
+description: Inspect and drive the Zigbee/MQTT layer — list Zigbee2MQTT devices, watch live MQTT traffic (button presses, sensor reports), read retained state, publish test payloads (e.g. Inovelli LED effects). Use when debugging "the button press never arrived", finding a device's friendly name/topic, or testing an LED/switch payload without touching Node-RED.
+allowed-tools: Bash, Read
+---
+
+# Zigbee / MQTT layer
+
+Two Zigbee2MQTT instances (`home-automation` namespace) publish to the EMQX broker
+(`emqx-listeners.database.svc.cluster.local:1883`, `database` namespace):
+
+| Instance             | Base topic            | Frontend                                  | Covers                             |
+| -------------------- | --------------------- | ----------------------------------------- | ---------------------------------- |
+| `zigbee2mqtt`        | `zigbee2mqtt/`        | <https://zigbee.chelonianlabs.com>        | house (Inovelli switches, sensors) |
+| `zigbee2mqtt-garage` | `zigbee2mqtt-garage/` | <https://zigbee-garage.chelonianlabs.com> | garage/workshop                    |
+
+There is **no mosquitto client anywhere** — `scripts/mqtt.sh` runs mqtt.js inside
+the node-red pod instead (zero install, creds never leave the cluster).
+
+## Usage
+
+```bash
+MQ=./.claude/skills/zigbee-mqtt/scripts/mqtt.sh
+
+$MQ devices                        # house z2m: friendly name | vendor/model
+$MQ devices garage                 # garage instance
+$MQ get 'zigbee2mqtt/Kitchen Sink' # retained state of one device
+$MQ sub 'zigbee2mqtt/+/action' 30  # watch button presses for 30 s (press one!)
+$MQ sub 'home/#' 15                # app-level topics (appliance states etc.)
+$MQ pub 'zigbee2mqtt/Main Office/set' '{"led_effect":{"effect":"pulse","color":195,"level":60,"duration":5}}'
+```
+
+`pub` sends real commands to real devices — lights will flash, sirens can sound.
+Test on a single office switch first, never a zone. `--retain` publishes retained
+(also how you clear a stale retained topic: retained empty payload).
+
+## What lives where on the bus
+
+- `zigbee2mqtt/<Friendly Name>` — retained device state; `.../set` — commands.
+- `zigbee2mqtt/<Friendly Name>/action` — button events. Inovelli config button
+  double-press = `config_double` (drives LED tap-to-dismiss).
+- `zigbee2mqtt/bridge/#` — z2m health/devices/log; `bridge/devices` retained JSON
+  is the authoritative device list (what `devices` parses).
+- `home/#` — app-level topics for Node-RED publishes. `home/washer` /
+  `home/dryer` were the pre-redesign appliance-state topics; currently nothing
+  retained there (state moved to HA input_selects).
+- Inovelli LED-bar payload reference: [references/inovelli-led-payloads.md](references/inovelli-led-payloads.md).
+  All _automated_ LED writes must go through the Node-RED LED Dispatcher
+  (smart-home-map skill) — direct `pub` is for testing only.
+
+## Debug checklist: "device event never arrived"
+
+1. `$MQ sub 'zigbee2mqtt/<name>/#' 30` and trigger the device — does z2m see it?
+   - No → Zigbee problem: check device availability/LQI in the frontend, or
+     `kubectl logs -n home-automation deploy/zigbee2mqtt --since=10m`.
+   - Yes → broker fine; check the Node-RED side (`node-red-flows` skill): is the
+     watch node's entity/topic exact, is the node disabled, did HA rename the entity?
+2. Wrong instance? Garage devices are on `zigbee2mqtt-garage/...` — a house-topic
+   subscription never sees them (this also bit the LED platform: garage switches
+   aren't in the dispatcher ZONES map yet).
+3. z2m → HA entity naming: HA discovers via MQTT discovery; entity ids derive from
+   friendly names. After renaming a device, both MQTT topics AND HA entity ids move.

--- a/.claude/skills/zigbee-mqtt/references/inovelli-led-payloads.md
+++ b/.claude/skills/zigbee-mqtt/references/inovelli-led-payloads.md
@@ -1,0 +1,56 @@
+# Inovelli LED-bar payloads (Zigbee2MQTT `/set`)
+
+Publish to `zigbee2mqtt/<Friendly Name>/set`. Automated writes must route through
+the Node-RED LED Dispatcher (single owner of the LED store, night dimming,
+re-announce) — raw publishes are for hand testing only and will be stomped by the
+next dispatcher write.
+
+## Full-bar effect
+
+```json
+{ "led_effect": { "effect": "pulse", "color": 170, "level": 100, "duration": 10 } }
+```
+
+## Single LED (bars have 7 LEDs, led "1" = bottom)
+
+```json
+{
+  "individual_led_effect": {
+    "led": "5",
+    "effect": "solid",
+    "color": 170,
+    "level": 100,
+    "duration": 255
+  }
+}
+```
+
+## Clearing
+
+```json
+{ "led_effect": { "effect": "clear_effect" } }
+{ "individual_led_effect": { "led": "5", "effect": "clear_effect" } }
+```
+
+## Field reference
+
+- `color`: 0–255 hue — 0 red, 21 orange, 42 yellow, 85 green, 170 blue, 195 purple.
+- `level`: 0–100 brightness.
+- `duration`: 1–60 = seconds, 61–120 = (value−60) minutes, 255 = indefinite until cleared.
+- `effect` (full bar): off, solid, chase, fast_blink, slow_blink, pulse, open_close,
+  small_to_big, aurora, slow_falling, medium_falling, fast_falling, slow_rising,
+  medium_rising, fast_rising, medium_blink, slow_chase, fast_chase, fast_siren,
+  slow_siren, clear_effect.
+- `effect` (individual LED): off, solid, fast_blink, slow_blink, pulse, chase,
+  aurora, clear_effect.
+
+## Household slot allocation (see smart-home-map skill)
+
+4 = alarm, 5 = washer (blue), 6 = dryer (green), 7 = dishwasher (purple);
+1–3 free.
+
+## Button events (`zigbee2mqtt/<name>/action`)
+
+Notable: `config_single`, `config_double` (kitchen double-press = dismiss
+appliance LEDs), `up_single|double|triple`, `down_single|double|triple`,
+`up_held`, `down_held`.

--- a/.claude/skills/zigbee-mqtt/scripts/mqtt.sh
+++ b/.claude/skills/zigbee-mqtt/scripts/mqtt.sh
@@ -1,0 +1,74 @@
+#!/usr/bin/env bash
+# MQTT swiss-army knife for the smart home. No local MQTT client needed:
+# runs mqtt.js INSIDE the node-red pod; broker creds are read in-pod and never printed.
+#
+# Usage:
+#   mqtt.sh devices [house|garage]     list Zigbee2MQTT devices (friendly name | vendor model)
+#   mqtt.sh get <topic>                print first (retained) message on a topic, then exit
+#   mqtt.sh sub <topic-filter> [secs]  stream messages for N seconds (default 10); + and # wildcards ok
+#   mqtt.sh pub <topic> <payload> [--retain]   publish (REAL devices react!)
+set -euo pipefail
+export KUBECONFIG="${KUBECONFIG:-$HOME/projects/dapper-cluster/kubeconfig}"
+
+CMD="${1:?usage: mqtt.sh devices|get|sub|pub ...}"
+shift || true
+
+case "$CMD" in
+  devices)
+    BASE="zigbee2mqtt"; [ "${1:-house}" = "garage" ] && BASE="zigbee2mqtt-garage"
+    M_MODE=get M_TOPIC="$BASE/bridge/devices" M_FORMAT=devices M_SECS=10 run=1
+    ;;
+  get)
+    M_MODE=get M_TOPIC="${1:?topic required}" M_FORMAT=raw M_SECS="${2:-10}"
+    ;;
+  sub)
+    M_MODE=sub M_TOPIC="${1:?topic filter required}" M_FORMAT=raw M_SECS="${2:-10}"
+    ;;
+  pub)
+    M_MODE=pub M_TOPIC="${1:?topic required}" M_PAYLOAD="${2:?payload required}" M_RETAIN="${3:-}"
+    ;;
+  *) echo "unknown command: $CMD" >&2; exit 1 ;;
+esac
+
+kubectl exec -i -n home-automation deploy/node-red -- \
+  env M_MODE="$M_MODE" M_TOPIC="$M_TOPIC" M_SECS="${M_SECS:-10}" \
+      M_FORMAT="${M_FORMAT:-raw}" M_PAYLOAD="${M_PAYLOAD:-}" M_RETAIN="${M_RETAIN:-}" \
+  node -e '
+const fs = require("fs");
+const mqtt = require("/usr/src/node-red/node_modules/mqtt");
+const creds = JSON.parse(fs.readFileSync(
+  "/data/projects/Turtleassmanor-automations/flows_cred.json"))["329c148fa7c93659"];
+const { M_MODE, M_TOPIC, M_SECS, M_FORMAT, M_PAYLOAD, M_RETAIN } = process.env;
+const c = mqtt.connect("mqtt://emqx-listeners.database.svc.cluster.local:1883",
+  { username: creds.user, password: creds.password, connectTimeout: 8000 });
+const die = (code, msg) => { if (msg) console.error(msg); c.end(true, () => process.exit(code)); };
+c.on("error", e => die(1, "mqtt error: " + e.message));
+
+c.on("connect", () => {
+  if (M_MODE === "pub") {
+    c.publish(M_TOPIC, M_PAYLOAD, { qos: 1, retain: M_RETAIN === "--retain" },
+      err => err ? die(1, "publish failed: " + err.message)
+                 : die(0, `published to ${M_TOPIC}` + (M_RETAIN ? " (retained)" : "")));
+    return;
+  }
+  c.subscribe(M_TOPIC, { qos: 0 }, err => { if (err) die(1, "subscribe failed: " + err.message); });
+  setTimeout(() => die(M_MODE === "get" ? 1 : 0, M_MODE === "get" ? "no message within " + M_SECS + "s" : null),
+    Number(M_SECS) * 1000);
+});
+
+c.on("message", (t, p) => {
+  const s = p.toString();
+  if (M_FORMAT === "devices") {
+    let devs; try { devs = JSON.parse(s); } catch { return die(1, "unparseable bridge/devices"); }
+    for (const d of devs) {
+      if (d.type === "Coordinator") continue;
+      const def = d.definition || {};
+      console.log(`${(d.friendly_name || d.ieee_address).padEnd(35)} ${def.vendor || "?"} ${def.model || ""} ${d.disabled ? "DISABLED" : ""}`);
+    }
+    console.log(`-- ${devs.length - 1} devices --`);
+    return die(0);
+  }
+  console.log(`${new Date().toISOString()} ${t} ${s}`);
+  if (M_MODE === "get") die(0);
+});
+'


### PR DESCRIPTION
## What

Four new project skills so smart-home sessions can start doing meaningful work immediately, instead of re-discovering where everything lives. The smart-home behavior is app-managed state (Node-RED git project on the PVC, HA `.storage` helpers, z2m configs) — none of it is in this repo, and every session was paying the same discovery tax.

| Skill | Gives you |
| --- | --- |
| `smart-home-map` | Orientation: where each system's config actually lives, event flow, backup/DR notes. References: appliance state-machine architecture, Inovelli LED notification platform design. |
| `node-red-flows` | The projects-mode trap (`/data/projects/Turtleassmanor-automations/flows.json`, NOT `/data/flows.json`), `flowdump.py` analyzer (tabs/wiring/node tracing), `fetch-flows.sh`, `deploy-flows.sh` (admin API full-deploy with backup), and a gotchas reference (gate output polarity, `for:`-timer fragility, context loss on restart, reconnect replay). |
| `hass-api` | `ha.sh` — states/state/template/services/history/call against the HA REST API, token auto-extracted from Node-RED's creds. |
| `zigbee-mqtt` | `mqtt.sh` — devices/sub/pub/get with **no local MQTT client** (runs mqtt.js inside the node-red pod; creds never leave the cluster). Inovelli LED payload reference. |

All scripts tested against the live cluster (flow dump, HA state queries, z2m device list, MQTT retained reads).

## Notes

- No credential values are committed — scripts extract tokens at runtime from in-cluster sources.
- Follows the agentskills.io layout (SKILL.md + references/ + scripts/).
- Documented standing risk: the Node-RED project repo can't push to GitHub from the pod (no SSH key, remote ~200 commits stale); VolSync is the effective backup.