### PR TITLE
feat(skills): hass-api WebSocket helper for registries and voice exposure

### DIFF
--- a/.claude/skills/hass-api/SKILL.md
+++ b/.claude/skills/hass-api/SKILL.md
@@ -50,13 +50,39 @@ export HASS_TOKEN=$($HA token)
   Node-RED depends on — PR #3553). Before blaming a flow, check
   `kubectl logs -n home-automation deploy/node-red` for websocket reconnect loops.
 
-## Raw API (when the script doesn't cover it)
+## WebSocket API — registries, areas, voice exposure
+
+`scripts/haws.sh` covers what REST can't: entity/device/area/floor registries and
+Assist exposure. It pipes a JSON array of WS commands (no ids) through node inside
+the node-red pod and prints one JSON result line per command:
+
+```bash
+WS=./.claude/skills/hass-api/scripts/haws.sh
+
+echo '[{"type":"config/area_registry/list"},{"type":"config/floor_registry/list"}]' | $WS
+echo '[{"type":"config/entity_registry/list"}]' | $WS > /tmp/ents.jsonl   # ~4000 entities
+echo '[{"type":"homeassistant/expose_entity/list"}]' | $WS               # what Assist can hear
+echo '[{"type":"config/device_registry/update","device_id":"<id>","area_id":"kitchen"}]' | $WS
+```
+
+Conventions learned the hard way (2026-07 voice-naming pass):
+
+- **Rename for voice at the HA layer** (`config/entity_registry/update` with
+  `name:`/`aliases:`) — entity_id and MQTT topics stay put, Node-RED keeps working.
+  Renaming a Zigbee2MQTT friendly name moves both and silently breaks flows.
+- Prefer `device_registry/update` for areas (entities inherit); use entity-level
+  `area_id` only for helper groups with no device.
+- Zigbee2MQTT **groups** show up as underscore-named devices (`Living_Room_Sides`)
+  whose entity_ids collided with same-named switches → `light.living_room_sides_2`
+  IS the group, not a stale duplicate. Voice-expose the group, not the smart-bulb-mode
+  switch.
+- Exposure gotcha: everything defaulted to exposed — including
+  `switch.zigbee2mqtt_bridge_permit_join` (unexposed 2026-07-02; keep it that way).
+
+## Raw API (when the scripts don't cover it)
 
 ```bash
 curl -s -H "Authorization: Bearer $HASS_TOKEN" https://hass.chelonianlabs.com/api/states | jq length
 # Docs: https://developers.home-assistant.io/docs/api/rest/
+#       https://developers.home-assistant.io/docs/api/websocket/
 ```
-
-WebSocket API (entity registry, device registry, traces) isn't covered by ha.sh;
-for registry-level questions, exec into the HA pod and read
-`/config/.storage/core.entity_registry` (read-only!) or ask the user to check the UI.

--- a/.claude/skills/hass-api/scripts/haws.sh
+++ b/.claude/skills/hass-api/scripts/haws.sh
@@ -1,0 +1,61 @@
+#!/usr/bin/env bash
+# Home Assistant WebSocket API helper — covers what the REST API (ha.sh) can't:
+# entity/device/area/floor registries, Assist exposure, labels, config subsystems.
+#
+# Reads a JSON ARRAY of command objects (WITHOUT ids) on stdin, runs them
+# sequentially, prints one JSON line per command:
+#   {"i": <index>, "success": bool, "result": ..., "error": ...}
+#
+# Like mqtt.sh, it runs inside the node-red pod (ws module + HA token in-pod,
+# token never printed). Commands are the standard HA WS API:
+#   https://developers.home-assistant.io/docs/api/websocket/
+#
+# Read-only examples:
+#   echo '[{"type":"config/area_registry/list"},{"type":"config/floor_registry/list"}]' | haws.sh
+#   echo '[{"type":"config/entity_registry/list"}]'  | haws.sh   # ~4000 entities, pipe to a file
+#   echo '[{"type":"config/device_registry/list"}]'  | haws.sh
+#   echo '[{"type":"homeassistant/expose_entity/list"}]' | haws.sh   # Assist/voice exposure
+#
+# Mutations (CHANGE the live registry — batch them deliberately):
+#   {"type":"config/area_registry/create","name":"Pantry","floor_id":"main_floor"}
+#   {"type":"config/device_registry/update","device_id":"<id>","area_id":"kitchen"}
+#   {"type":"config/entity_registry/update","entity_id":"light.x","area_id":"kitchen"}
+#   {"type":"config/entity_registry/update","entity_id":"light.x","name":"HA-layer name","aliases":["voice alias"]}
+#   {"type":"homeassistant/expose_entity","assistants":["conversation"],"entity_ids":["light.x"],"should_expose":false}
+#
+# NOTE: an entity-registry "name"/aliases update is the SAFE way to rename for
+# voice/TTS — entity_id and MQTT topics are untouched, so Node-RED flows keep
+# working. Renaming a Zigbee2MQTT friendly name instead moves BOTH (breaks flows).
+set -euo pipefail
+export KUBECONFIG="${KUBECONFIG:-$HOME/projects/dapper-cluster/kubeconfig}"
+
+kubectl exec -i -n home-automation deploy/node-red -- node -e '
+const fs = require("fs");
+const WebSocket = require("/usr/src/node-red/node_modules/ws");
+const token = JSON.parse(fs.readFileSync(
+  "/data/projects/Turtleassmanor-automations/flows_cred.json"))["4a296574.4626bc"].access_token;
+
+let input = "";
+process.stdin.on("data", d => input += d);
+process.stdin.on("end", () => {
+  const cmds = JSON.parse(input);
+  const ws = new WebSocket("ws://home-assistant.home-automation.svc.cluster.local:8123/api/websocket");
+  let id = 0, sent = 0;
+  const next = () => {
+    if (sent >= cmds.length) { ws.close(); process.exit(0); }
+    ws.send(JSON.stringify(Object.assign({ id: ++id }, cmds[sent])));
+  };
+  ws.on("message", raw => {
+    const msg = JSON.parse(raw);
+    if (msg.type === "auth_required") { ws.send(JSON.stringify({ type: "auth", access_token: token })); return; }
+    if (msg.type === "auth_ok") { next(); return; }
+    if (msg.type === "auth_invalid") { console.error("auth failed"); process.exit(1); }
+    if (msg.type === "result") {
+      console.log(JSON.stringify({ i: sent, success: msg.success, result: msg.result, error: msg.error }));
+      sent++; next();
+    }
+  });
+  ws.on("error", e => { console.error("ws error: " + e.message); process.exit(1); });
+  setTimeout(() => { console.error("timeout"); process.exit(1); }, 120000);
+});
+'

--- a/.claude/skills/smart-home-map/SKILL.md
+++ b/.claude/skills/smart-home-map/SKILL.md
@@ -42,6 +42,13 @@ Two platform patterns are documented in detail in
    tap-to-dismiss). LEDs are the _household_ console — infrastructure alerts never
    light the panel.
 
+Voice prep (2026-07): HA areas + floors (top/main/basement) are populated and
+Assist exposure is curated (groups exposed, individual bulbs/dev entities hidden) —
+maintain both when adding devices; registry work goes through `haws.sh` in the
+hass-api skill. Not everything is Zigbee: basement/cat-room/bathroom lights ride
+the `vivint` integration, and some plugs are `tasmota`. Voice plan + buy list:
+vault note "Voice Assistants - Alexa Bridge and Local Voice Plan".
+
 ## Backups / disaster recovery
 
 All smart-home PVCs have VolSync (hourly on-site + daily R2 offsite):


### PR DESCRIPTION
## What

- Adds `.claude/skills/hass-api/scripts/haws.sh`: batch runner for the HA WebSocket API, executed via node inside the node-red pod (same zero-install pattern as `mqtt.sh`; token read in-pod, never printed). Covers what the REST helper can't: entity/device/area/floor registries and Assist voice exposure.
- Documents WS usage + conventions in the hass-api SKILL.md: HA-layer renames/aliases are the voice-safe rename path (entity_id + MQTT topics untouched, Node-RED unaffected), device-level area assignment preferred, z2m groups masquerade as `_2`-suffixed light entities, and the permit_join exposure footgun.
- smart-home-map: notes that areas/floors + Assist exposure are now curated, and that vivint/tasmota lights exist outside the Zigbee bus.

## Why

Used today for the voice-prep first pass (areas assigned to 60+ devices, exposure curated 77→52 lights, z2m group entities renamed for speech). Proven against live HA — 81/81 registry mutations applied cleanly.