### PR TITLE
fix(container): update chart roundtable-operator ( 0.12.2 → 0.12.3 )

### DIFF
--- a/kubernetes/apps/roundtable/operator/app/helmrelease.yaml
+++ b/kubernetes/apps/roundtable/operator/app/helmrelease.yaml
@@ -13,7 +13,7 @@ spec:
   chart:
     spec:
       chart: roundtable-operator
-      version: "0.12.2"
+      version: "0.12.3"
       sourceRef:
         kind: HelmRepository
         name: roundtable
@@ -21,7 +21,7 @@ spec:
   values:
     image:
       repository: ghcr.io/dapperdivers/roundtable
-      tag: 72bef61e62467decc570d67739b53ba6f53c7ec0
+      tag: 8e500097c9faecf6275b33442677f292b1f5f3a5
       pullPolicy: Always
 
     # Persistent nix-daemon builder: a single root Deployment owns the shared
@@ -38,14 +38,8 @@ spec:
         cpu: 200m
         memory: 256Mi
 
-    # Centralized image tags — bump here, everything updates
-    images:
-      piKnight:
-        repository: ghcr.io/dapperdivers/pi-knight
-        tag: 36aa86f97f23776686be01666d2ae2b8e4c69c5f
-      dashboard:
-        repository: ghcr.io/dapperdivers/roundtable-ui
-        tag: 2dbd0af7d181e40f95a263104102b34290fc12dd
+    # Image tags (piKnight, dashboard) are pinned in the chart's values.yaml
+    # as of chart 0.12.3 — bump them in the roundtable repo, not here.
 
     # Built-in planner knight — meta-mission planning
     planner:


### PR DESCRIPTION
Deploys the Round Table dashboard overhaul.

## Changes
- Chart `0.12.2` → `0.12.3`
- Operator image → `8e50009`
- **Removed the `spec.values.images` overrides** (piKnight/dashboard tags) — as of chart 0.12.3 these are pinned in the chart's own `values.yaml`; the local overrides were shadowing them.

## What chart 0.12.3 pins
- **dashboard → `f7fccb6`** — roundtable-ui #144 (forward-auth login removal, typed API client, shared UI primitives, chain metadata in the API) + #145 (meta-mission null-crash fix)
- pi-knight → `7abd75f` (CI-only vs current, identical runtime)

## Verification
The exact dashboard image (`f7fccb6`) was driven end-to-end against **this cluster** before merge: all 11 pages load clean, a real meta-mission was dispatched through the wizard (planner validation + CR creation), task dispatch returned a real id, and the WebSocket connected without the removed `api_key` param.

Auth note: chart 0.12.3 ships the UI in forward-auth mode (no in-browser login). `DASHBOARD_API_KEY` is currently unset for the dashboard, so it stays in open mode — no behavior change until a forward-auth middleware is added.

🤖 Generated with [Claude Code](https://claude.com/claude-code)