### PR TITLE
fix(roundtable): operator image 08a173cd — warm-pool InvalidKnightRef + planning-result fixes

### DIFF
--- a/kubernetes/apps/roundtable/operator/app/helmrelease.yaml
+++ b/kubernetes/apps/roundtable/operator/app/helmrelease.yaml
@@ -21,7 +21,7 @@ spec:
   values:
     image:
       repository: ghcr.io/dapperdivers/roundtable
-      tag: 8e500097c9faecf6275b33442677f292b1f5f3a5
+      tag: 08a173cd9754386dbc1d399ae4533d2107c2cd7c
       pullPolicy: Always
 
     # Persistent nix-daemon builder: a single root Deployment owns the shared


### PR DESCRIPTION
Bumps the roundtable operator image `8e50009` → `08a173cd` (chart stays 0.12.3; piKnight/dashboard tags are pinned in the chart).

Pulls in dapperdivers/roundtable#135 + dapperdivers/roundtable#136:
- Meta-missions no longer fail with `InvalidKnightRef` when a warm-pool knight is claimed — the claim now recreates the knight under the mission-prefixed name that chain steps reference.
- `planningResult` counters/`completedAt` are no longer zeroed by the spec-update status overwrite (dashboard showed 0/0/0).
- Planning prompt no longer steers generated knights to sonnet — they inherit the cheap `base` template model (`openrouter/deepseek/deepseek-v3.2`); companion skill change already live via roundtable-arsenal#43.

Found in the 2026-07-04 live dashboard verification; operator test suite green on the source PRs.

🤖 Generated with [Claude Code](https://claude.com/claude-code)