### PR TITLE
fix(roundtable): operator 9dbb4b6 + repoint 7 knights off dead ollama pool

### DIFF
--- a/kubernetes/apps/roundtable/knights/app/bedivere.yaml
+++ b/kubernetes/apps/roundtable/knights/app/bedivere.yaml
@@ -9,7 +9,7 @@ spec:
   domain: home
   image: ""
   # Local P100 pool (was openrouter/deepseek/deepseek-v3.2) — endpoint env below.
-  model: "ollama/qwen3.5:9b"
+  model: "openrouter/deepseek/deepseek-v3.2"
   skills:
     - shared
     - home

--- a/kubernetes/apps/roundtable/knights/app/galahad.yaml
+++ b/kubernetes/apps/roundtable/knights/app/galahad.yaml
@@ -11,7 +11,7 @@ spec:
   domain: security
   image: ""
   # Local P100 pool (was openrouter/anthropic/claude-haiku-4.5) — endpoint env below.
-  model: "ollama/qwen3.5:9b"
+  model: "openrouter/deepseek/deepseek-v3.2"
   skills:
     - security
     - shared
@@ -30,18 +30,18 @@ spec:
       - cosign
       - tfsec
       # OSINT & threat intel
-      - gitleaks       # Secret scanning
-      - grype          # Container image vuln scanner
-      - syft           # SBOM generation
-      - subfinder      # Passive subdomain discovery
-      - httpx          # Fast HTTP probing
-      - dnsx           # DNS toolkit
-      - osv-scanner    # Google OSV vuln scanner
+      - gitleaks # Secret scanning
+      - grype # Container image vuln scanner
+      - syft # SBOM generation
+      - subfinder # Passive subdomain discovery
+      - httpx # Fast HTTP probing
+      - dnsx # DNS toolkit
+      - osv-scanner # Google OSV vuln scanner
       # SAST & Code Analysis (Added 2026-03-23)
-      - semgrep        # Static application security testing
-      - gosec          # Go security checker
+      - semgrep # Static application security testing
+      - gosec # Go security checker
       # Cluster Operations (Added 2026-04-06)
-      - kubectl        # Kubernetes cluster access for CVE verification
+      - kubectl # Kubernetes cluster access for CVE verification
     # shodan: pip package, installed by Galahad's skills on-demand (not in mise registry)
   nats:
     url: nats://nats.database.svc:4222

--- a/kubernetes/apps/roundtable/knights/app/gareth.yaml
+++ b/kubernetes/apps/roundtable/knights/app/gareth.yaml
@@ -9,7 +9,7 @@ spec:
   domain: wellness
   image: ""
   # Local P100 pool (was openrouter/deepseek/deepseek-v3.2) — endpoint env below.
-  model: "ollama/qwen3.5:9b"
+  model: "openrouter/deepseek/deepseek-v3.2"
   skills:
     - shared
     - wellness

--- a/kubernetes/apps/roundtable/knights/app/kay.yaml
+++ b/kubernetes/apps/roundtable/knights/app/kay.yaml
@@ -9,7 +9,7 @@ spec:
   domain: research
   image: ""
   # Local P100 pool (was openrouter/google/gemini-2.5-flash) — endpoint env below.
-  model: "ollama/qwen3.5:9b"
+  model: "openrouter/deepseek/deepseek-v3.2"
   skills:
     - shared
     - research
@@ -26,14 +26,14 @@ spec:
       - eza
       - yt-dlp
       - pandoc
-      - python3          # Required for fetch-news.py and arsenal scripts
-      - jq               # JSON processing for API responses
+      - python3 # Required for fetch-news.py and arsenal scripts
+      - jq # JSON processing for API responses
       # Research & Data Processing (Added 2026-03-23)
-      - ripgrep          # Faster grep alternative for large file searches
-      - httpie           # User-friendly HTTP client for API research
-      - yq-go            # YAML processing for structured data analysis
+      - ripgrep # Faster grep alternative for large file searches
+      - httpie # User-friendly HTTP client for API research
+      - yq-go # YAML processing for structured data analysis
       # Web Scraping (Added 2026-04-06)
-      - pup              # HTML parser for cleaner web scraping
+      - pup # HTML parser for cleaner web scraping
   nats:
     url: nats://nats.database.svc:4222
     subjects:

--- a/kubernetes/apps/roundtable/knights/app/lancelot.yaml
+++ b/kubernetes/apps/roundtable/knights/app/lancelot.yaml
@@ -9,7 +9,7 @@ spec:
   domain: career
   image: ""
   # Local P100 pool (was openrouter/deepseek/deepseek-v3.2) — endpoint env below.
-  model: "ollama/qwen3.5:9b"
+  model: "openrouter/deepseek/deepseek-v3.2"
   skills:
     - shared
     - career
@@ -18,9 +18,9 @@ spec:
       - python3
       - lynx
       - pandoc
-      - jq             # JSON processing (Added 2026-04-06)
-      - yq-go          # YAML processing (Added 2026-04-06)
-      - curl           # HTTP requests (Added 2026-04-06)
+      - jq # JSON processing (Added 2026-04-06)
+      - yq-go # YAML processing (Added 2026-04-06)
+      - curl # HTTP requests (Added 2026-04-06)
   nats:
     url: nats://nats.database.svc:4222
     subjects:

--- a/kubernetes/apps/roundtable/knights/app/percival.yaml
+++ b/kubernetes/apps/roundtable/knights/app/percival.yaml
@@ -9,7 +9,7 @@ spec:
   domain: finance
   image: ""
   # Local P100 pool (was openrouter/deepseek/deepseek-v3.2) — endpoint env below.
-  model: "ollama/qwen3.5:9b"
+  model: "openrouter/deepseek/deepseek-v3.2"
   skills:
     - shared
     - finance

--- a/kubernetes/apps/roundtable/knights/app/tristan.yaml
+++ b/kubernetes/apps/roundtable/knights/app/tristan.yaml
@@ -10,14 +10,14 @@ spec:
   serviceAccountName: tristan
   image: ""
   # Local P100 pool (was openrouter/deepseek/deepseek-v3.2) — endpoint env below.
-  model: "ollama/qwen3.5:9b"
+  model: "openrouter/deepseek/deepseek-v3.2"
   skills:
     - shared
     - infra
   tools:
     nix:
       - kubectl
-      - kubectx        # Fast context/namespace switching (Added 2026-04-06)
+      - kubectx # Fast context/namespace switching (Added 2026-04-06)
       - kubernetes-helm
       - stern
       - k9s
@@ -27,21 +27,21 @@ spec:
       - cilium-cli
       - yq-go
       # Container & Cluster Analysis (Added 2026-03-23)
-      - trivy          # Vulnerability scanning for container images and IaC
-      - popeye         # Kubernetes cluster sanity checks
-      - crane          # Container image inspection and manipulation
+      - trivy # Vulnerability scanning for container images and IaC
+      - popeye # Kubernetes cluster sanity checks
+      - crane # Container image inspection and manipulation
       # Added 2026-03-09 - Fleet self-improvement assessment
-      - procps         # ps, top, free, vmstat - CRITICAL for process visibility
-      - bind           # dig, host, nslookup - CRITICAL for DNS debugging
-      - iputils        # ping - CRITICAL for network connectivity testing
-      - traceroute     # Network path debugging
-      - htop           # Interactive process monitor
-      - iftop          # Network bandwidth monitor
-      - netcat-gnu     # Network testing (nc)
-      - go             # Go compiler for operator development
-      - gnumake        # make for CRD generation
-      - gh             # GitHub CLI for PR creation
-      - jq             # JSON processing
+      - procps # ps, top, free, vmstat - CRITICAL for process visibility
+      - bind # dig, host, nslookup - CRITICAL for DNS debugging
+      - iputils # ping - CRITICAL for network connectivity testing
+      - traceroute # Network path debugging
+      - htop # Interactive process monitor
+      - iftop # Network bandwidth monitor
+      - netcat-gnu # Network testing (nc)
+      - go # Go compiler for operator development
+      - gnumake # make for CRD generation
+      - gh # GitHub CLI for PR creation
+      - jq # JSON processing
       - tree
       - curl
   nats:

--- a/kubernetes/apps/roundtable/operator/app/helmrelease.yaml
+++ b/kubernetes/apps/roundtable/operator/app/helmrelease.yaml
@@ -21,7 +21,7 @@ spec:
   values:
     image:
       repository: ghcr.io/dapperdivers/roundtable
-      tag: 08a173cd9754386dbc1d399ae4533d2107c2cd7c
+      tag: 9dbb4b6448625e697a34c6541b49d3ad9d4be14a
       pullPolicy: Always
 
     # Persistent nix-daemon builder: a single root Deployment owns the shared


### PR DESCRIPTION
Two changes from the 2026-07-04 live verification follow-up:

**1. Operator image `08a173cd` → `9dbb4b6`** — pulls in dapperdivers/roundtable#137: Failed missions no longer report `Succeeded` after passing through CleaningUp; `OnSuccess`/`OnFailure` cleanup policies actually match now; expired missions end `Expired`; assembly window floored at 3 min (was ~100s with the wizard default, shorter than a healthy cold start post-#136). No chart/CRD change.

**2. Repoint 7 knights off the dead local ollama pool** — bedivere, galahad, gareth, kay, lancelot, percival, tristan move from `ollama/qwen3.5:9b` → `openrouter/deepseek/deepseek-v3.2`. `talos-node-gpu-1` containerd is wedged (ollama stuck ContainerCreating 29h+), so every ollama-model knight fails pi-knight's startup preflight (`Model endpoint unreachable`) and sits in CrashLoopBackOff. deepseek-v3.2 is the cheap OpenRouter model used across the rest of the fleet (gawain's own history comment confirms it as a prior pin). Reversible one-liner if the GPU node is ever revived.

**Note on diff size:** the intended change is 8 one-line edits (7 model lines + operator tag). The extra churn is this repo's own `format-yaml` (oxfmt) pre-commit hook normalizing inline-comment spacing on the touched knight files — formatting-only, semantically identical, and the repo's canonical style.

After Flux reconciles: operator pod on 9dbb4b6, the 7 knights become Ready, and a live meta-mission re-run confirms the #137 phase fix + assembly floor.

🤖 Generated with [Claude Code](https://claude.com/claude-code)