### PR TITLE
fix(roundtable): operator 30705c0 + chart 0.13.0

### DIFF
--- a/kubernetes/apps/roundtable/operator/app/helmrelease.yaml
+++ b/kubernetes/apps/roundtable/operator/app/helmrelease.yaml
@@ -13,7 +13,7 @@ spec:
   chart:
     spec:
       chart: roundtable-operator
-      version: "0.12.3"
+      version: "0.13.0"
       sourceRef:
         kind: HelmRepository
         name: roundtable
@@ -21,7 +21,7 @@ spec:
   values:
     image:
       repository: ghcr.io/dapperdivers/roundtable
-      tag: 9dbb4b6448625e697a34c6541b49d3ad9d4be14a
+      tag: 30705c0c5b62edc195f271147a64ff3a0d04b02a
       pullPolicy: Always
 
     # Persistent nix-daemon builder: a single root Deployment owns the shared


### PR DESCRIPTION
Chart `0.12.3` → `0.13.0`, operator image `9dbb4b6` → `30705c0`. The chart bump also ships its pinned pi-knight `fb42dae` and dashboard `630f8df`.

Pulls in since the last bump:
- **roundtable#138** — stop chain reconcile noise after mission cleanup (the cosmetic `InvalidKnightRef` requeue-spam identified in the 07-04 verification).
- **roundtable#139** — default bare Knights to the cheap OpenRouter model (CRD default).
- **pi-knight#37** — surface the real LLM error ("LLM call failed: <provider message>" / explicit abort-timeout) instead of the generic "Agent produced no deliverable output"; content-free session-tail summary on every no-deliverable task.

After Flux reconciles: operator pod on `30705c0`, dashboard on `630f8df`, knights on `fb42dae`. A meta-mission re-run should now name the real cause in the chain step error if the deliverable-output failure recurs.

🤖 Generated with [Claude Code](https://claude.com/claude-code)