### PR TITLE
fix(roundtable): operator 840dbeb + chart 0.13.1; RoundTable secrets for ephemeral knights

### DIFF
--- a/kubernetes/apps/roundtable/chelonian/app/roundtable-chelonian.yaml
+++ b/kubernetes/apps/roundtable/chelonian/app/roundtable-chelonian.yaml
@@ -5,6 +5,8 @@ metadata:
   name: chelonian
   namespace: roundtable
 spec:
+  secrets:
+    - name: roundtable-secret
   description: |
     ChelonianLabs product development team. Builds and maintains the finance
     application ecosystem — transaction categorization AI, personal finance

--- a/kubernetes/apps/roundtable/knights/app/roundtable-dev.yaml
+++ b/kubernetes/apps/roundtable/knights/app/roundtable-dev.yaml
@@ -5,6 +5,8 @@ metadata:
   name: roundtable-dev
   namespace: roundtable
 spec:
+  secrets:
+    - name: roundtable-secret
   description: |
     Round Table ecosystem development team. Builds and maintains the Round Table
     platform itself — the operator, pi-knight SDK, arsenal skills, and dashboard UI.

--- a/kubernetes/apps/roundtable/knights/app/roundtable.yaml
+++ b/kubernetes/apps/roundtable/knights/app/roundtable.yaml
@@ -5,6 +5,8 @@ metadata:
   name: personal
   namespace: roundtable
 spec:
+  secrets:
+    - name: roundtable-secret
   description: |
     Derek's personal life management fleet. Handles security research, threat intel,
     penetration testing, personal finance, career coaching, home automation, wellness,

--- a/kubernetes/apps/roundtable/operator/app/helmrelease.yaml
+++ b/kubernetes/apps/roundtable/operator/app/helmrelease.yaml
@@ -13,7 +13,7 @@ spec:
   chart:
     spec:
       chart: roundtable-operator
-      version: "0.13.0"
+      version: "0.13.1"
       sourceRef:
         kind: HelmRepository
         name: roundtable
@@ -21,7 +21,7 @@ spec:
   values:
     image:
       repository: ghcr.io/dapperdivers/roundtable
-      tag: 30705c0c5b62edc195f271147a64ff3a0d04b02a
+      tag: 840dbebaf36c58cf50c0b3dc62cef8524fbed1e3
       pullPolicy: Always
 
     # Persistent nix-daemon builder: a single root Deployment owns the shared


### PR DESCRIPTION
Two halves that together close the ephemeral-knight 401 ("Agent produced no deliverable output") issue.

**Bump**
- operator image `30705c0` → `840dbeb` — roundtable#140: inject RoundTable secrets into ephemeral knight assembly; scope task subjects to `<prefix>.tasks.<domain>.<knight>` (was the domain wildcard, which let a knight steal other missions' tasks).
- chart `0.13.0` → `0.13.1` — ships pi-knight `f2ab01a`: #38 (pre-warm agent session at startup) and #39 (degraded 503 instead of crash-loop on preflight failure).

**RoundTable secrets (cluster half of the 401 fix)**
- Set `spec.secrets: [roundtable-secret]` on **chelonian**, **personal**, **roundtable-dev** (all three were unset). Planner-generated ephemeral knights received no `envFrom`, so their OpenRouter call went out with no auth header → `401 Missing Authentication header` → generic no-deliverable failure. With #140 deployed, the operator now injects `rt.Spec.Secrets` into ephemeral knights; `roundtable-secret` carries `OPENROUTER_API_KEY`.

After Flux reconciles both, a fresh meta-mission should authenticate and complete — closing known-issue #1.

🤖 Generated with [Claude Code](https://claude.com/claude-code)