### PR TITLE
fix(roundtable): operator c542d29 — meta-mission no longer Failed when its chain succeeds

### DIFF
--- a/kubernetes/apps/roundtable/operator/app/helmrelease.yaml
+++ b/kubernetes/apps/roundtable/operator/app/helmrelease.yaml
@@ -21,7 +21,7 @@ spec:
   values:
     image:
       repository: ghcr.io/dapperdivers/roundtable
-      tag: 840dbebaf36c58cf50c0b3dc62cef8524fbed1e3
+      tag: c542d299c70cb24b3c0bc554babf8eef41619a08
       pullPolicy: Always
 
     # Persistent nix-daemon builder: a single root Deployment owns the shared


### PR DESCRIPTION
Operator image `840dbeb` → `c542d29` (chart unchanged at 0.13.1).

Pulls in **roundtable#142**: `ensureMissionChain` was fetching a bare-named source-chain template before checking whether the mission-scoped chain already existed. Meta-mission chains are created directly by the planner as `mission-<mission>-<chain>`, so the lookup failed `source chain not found` and the mission was marked Failed — even though its real chain succeeded seconds later. Reordered to short-circuit on the existing chain.

With the 401 auth fix already live (840dbeb + RoundTable `spec.secrets`), this should let a meta-mission reach Succeeded end-to-end — closing known-issue #1.

🤖 Generated with [Claude Code](https://claude.com/claude-code)