### PR TITLE
fix(gpu): tolerate nvidia.com/gpu taint on speaches and dcgm-exporter

### DIFF
--- a/kubernetes/apps/ai/speaches/app/helmrelease.yaml
+++ b/kubernetes/apps/ai/speaches/app/helmrelease.yaml
@@ -89,6 +89,10 @@ spec:
                     operator: In
                     values:
                       - "true"
+      tolerations:
+        - key: nvidia.com/gpu
+          operator: Exists
+          effect: NoSchedule
       securityContext:
         runAsNonRoot: true
         runAsUser: 1000

--- a/kubernetes/apps/observability/exporters/dcgm-exporter/app/helmrelease.yaml
+++ b/kubernetes/apps/observability/exporters/dcgm-exporter/app/helmrelease.yaml
@@ -50,6 +50,10 @@ spec:
         value: all
     nodeSelector:
       nvidia.feature.node.kubernetes.io/gpu: "true"
+    tolerations:
+      - key: nvidia.com/gpu
+        operator: Exists
+        effect: NoSchedule
     runtimeClassName: nvidia
     serviceMonitor:
       interval: 15s


### PR DESCRIPTION
## Summary
- Add `nvidia.com/gpu:NoSchedule` toleration to **speaches** and **dcgm-exporter**, mirroring the block ollama already has.

## Context
talos-node-gpu-1 carried an out-of-band `nvidia.com/gpu=true:NoSchedule` taint that wasn't declared anywhere in this repo. It blocked speaches from scheduling (Pending for an hour after today's node reboot) and would have stranded dcgm-exporter on its next pod recreation — the rook-ceph CSI plugins, NFD worker, and fluent-bit were also locked out until the taint was removed from the node today.

The taint is gone now, so these tolerations are dormant belt-and-suspenders: GPU-pinned workloads (which request `nvidia.com/gpu` anyway) should never be excluded by a GPU-reservation taint if one reappears.