### PR TITLE
feat(roundtable): fleet-self-improvement minimal rehab + weekly briefing scorecard step

### DIFF
--- a/kubernetes/apps/roundtable/chains/app/fleet-self-improvement.yaml
+++ b/kubernetes/apps/roundtable/chains/app/fleet-self-improvement.yaml
@@ -8,7 +8,7 @@ spec:
   roundTableRef: personal
   description: "Weekly fleet self-improvement — knights report tool/skill gaps, Gawain PRs the fixes"
   schedule: "0 14 * * 1"
-  timeout: 3600
+  timeout: 4800
   outputKnight: gawain
   retryPolicy:
     maxRetries: 1
@@ -288,6 +288,7 @@ spec:
     # Phase 2 — Gawain aggregates and creates PR
     - name: aggregate_and_pr
       knightRef: gawain
+      continueOnFailure: true
       outputPath: "/vault/Roundtable/Improvement-Requests/{{ .Date }}.md"
       dependsOn:
         - galahad_assess
@@ -299,7 +300,7 @@ spec:
         - agravain_assess
         - gareth_assess
         - patsy_assess
-      timeout: 600
+      timeout: 1200
       task: |
         FLEET SELF-IMPROVEMENT AGGREGATION
 
@@ -346,3 +347,28 @@ spec:
         - What was deferred and why
         - Total requests vs approved
         - Any new arsenal issues created
+
+    # Weekly briefing scorecard — audits LAST week's Daily briefings, so it
+    # runs in parallel with the assess phase (no dependsOn). Procedure lives
+    # in the arsenal skill vault/briefing-scorecard.
+    - name: briefing_scorecard
+      knightRef: patsy
+      continueOnFailure: true
+      timeout: 900
+      task: |
+        WEEKLY BRIEFING SCORECARD — follow the vault/briefing-scorecard skill.
+
+        Score the trailing week of Daily briefings
+        (/vault/Briefings/Daily/YYYY-MM-DD.md, the 7 most recent by mtime)
+        claim-by-claim against the domain vault reports and the open-items
+        ledgers (/vault/Briefings/Ledger/), using the forensic taxonomy
+        (verified / stale-echo / fabricated / unverifiable-personal), and run
+        the mechanical assertions defined in the skill.
+
+        Write the scorecard to /vault/Briefings/Scorecards/YYYY-Www.md
+        (ISO week of the Monday you run on, e.g. 2026-W28). Create the
+        directory if missing.
+
+        Your NATS response: a 5-line summary — overall corruption %, per-stage
+        split, assertion pass/fail count, worst day, trend vs the previous
+        scorecard file if one exists.


### PR DESCRIPTION
Implements `briefing-verifier-design.md` §5 (workspace doc: `briefing-scorecard-step.md`): weekly scorecard cadence, hosted in fleet-self-improvement, plus the minimal rehab the chain needs to survive well enough to host it. Independent of the morning-briefing v2 PR (#3593) — can merge before or after. The `vault/briefing-scorecard` skill (arsenal #48) is already merged.

## Changes (all in `chains/app/fleet-self-improvement.yaml`)

1. **Chain timeout 3600 → 4800** — headroom for the longer aggregate step plus the scorecard.
2. **`aggregate_and_pr` (gawain): `continueOnFailure: true` + timeout 600 → 1200** — it parses 9 YAML blobs, dedupes, nix-verifies packages, and drives `gh` PR creation; it was the chain's only non-continueOnFailure step and its proven failure point. A Gawain hiccup must no longer fail the whole run.
3. **New `briefing_scorecard` step on patsy** — no `dependsOn` (it audits *last* week's Daily briefings, not this run's assessments, so it runs in parallel with the assess phase; patsy's `concurrency: 2` covers it alongside `patsy_assess`). Scores the trailing 7 Daily briefings claim-by-claim against domain vault reports and the open-items ledgers using the forensic taxonomy (verified / stale-echo / fabricated / unverifiable-personal), runs the skill's mechanical assertions, and writes `/vault/Briefings/Scorecards/YYYY-Www.md`.

**Not in scope (per design decision):** rehab of the 9 assess-step prompts, and alerting on scorecard results (behind the notification-design gate, #3541 — the scorecard file is the signal source). The scorecard degrades gracefully pre-ledger/pre-verifier: assertions that reference an absent ledger just report "ledger absent".

## Validation on the first post-merge Monday 14:00Z run

1. Chain reaches Succeeded (or at least `briefing_scorecard` Succeeded — everything is continueOnFailure now)
2. `/vault/Briefings/Scorecards/2026-Www.md` exists with the per-day table, per-stage corruption split, and assertion results
3. Numbers sanity-check against the `briefing-scorecard-2026-07` methodology (same taxonomy, so week-over-week comparison is valid)