### PR TITLE
fix(roundtable): chart 0.14.0 + operator image 7739db6 — completion webhooks

### DIFF
--- a/kubernetes/apps/roundtable/operator/app/helmrelease.yaml
+++ b/kubernetes/apps/roundtable/operator/app/helmrelease.yaml
@@ -13,7 +13,7 @@ spec:
   chart:
     spec:
       chart: roundtable-operator
-      version: "0.13.1"
+      version: "0.14.0"
       sourceRef:
         kind: HelmRepository
         name: roundtable
@@ -21,7 +21,7 @@ spec:
   values:
     image:
       repository: ghcr.io/dapperdivers/roundtable
-      tag: c542d299c70cb24b3c0bc554babf8eef41619a08
+      tag: 7739db667110a76f5ba21f53392f93cb32bd3d9b
       pullPolicy: Always
 
     # Persistent nix-daemon builder: a single root Deployment owns the shared


### PR DESCRIPTION
Deploys dapperdivers/roundtable#144: optional \`spec.notify.webhook\` on Chain/Mission — the operator POSTs a completion payload once per run when a resource reaches a terminal phase.

- Chart 0.13.1 → **0.14.0** (new NotifySpec CRD fields, notify env plumbing, secrets-read RBAC)
- Operator image \`c542d29\` → \`7739db667110a76f5ba21f53392f93cb32bd3d9b\`

Feature ships **inert**: \`notify.allowedURLPrefixes\` defaults to empty, so every notification URL is rejected until the molt receiving side (hooks config + token secret + allowlist values) lands in a follow-up PR.

🤖 Generated with [Claude Code](https://claude.com/claude-code)