### PR TITLE
feat(ai,roundtable): molt completion-webhook receiving side + operator 0.14.0

### DIFF
--- a/kubernetes/apps/ai/openclaw/app/externalsecret.yaml
+++ b/kubernetes/apps/ai/openclaw/app/externalsecret.yaml
@@ -26,6 +26,9 @@ spec:
         GH_TOKEN_ROUNDTABLE: "{{ .MOLT_ROUNDTABLE_GITHUB_TOKEN }}"
         # Discord bot token (openclaw reads DISCORD_BOT_TOKEN natively)
         DISCORD_BOT_TOKEN: "{{ .MOLT_DISCORD_TOKEN }}"
+        # Bearer token for the gateway webhook endpoint (/hooks/*) — shared
+        # with the roundtable operator's completion notifications
+        MOLT_HOOKS_TOKEN: "{{ .MOLT_HOOKS_TOKEN }}"
   dataFrom:
     - find:
         name:

--- a/kubernetes/apps/ai/openclaw/app/helmrelease.yaml
+++ b/kubernetes/apps/ai/openclaw/app/helmrelease.yaml
@@ -124,6 +124,14 @@ spec:
                 # which broke Discord delivery.
                 set +e
                 openclaw plugins install @openclaw/discord
+                # install alone does NOT re-sync an npm-installed copy to the
+                # bundled version (drifted to 2026.6.5 against a 2026.6.11
+                # gateway) — update does.
+                openclaw plugins update discord
+                # web search: tools.web.search.provider=searxng is set on the
+                # PVC config, but since ~2026.6 searxng is an external plugin;
+                # without it web_search silently falls back.
+                openclaw plugins install @openclaw/searxng-plugin
                 set -e
 
                 echo "Tool installation complete"
@@ -193,6 +201,11 @@ spec:
                   // node-llama-cpp CUDA 13 build that dropped sm_60 — see ollama notes).
                   c.plugins = c.plugins || {};
                   c.plugins.entries = c.plugins.entries || {};
+                  // plugins.allow is a non-empty exclusive allowlist on the PVC;
+                  // configuring active-memory without allowlisting it left the
+                  // plugin silently disabled and this whole block inert.
+                  c.plugins.allow = Array.isArray(c.plugins.allow) ? c.plugins.allow : [];
+                  if (!c.plugins.allow.includes('active-memory')) c.plugins.allow.push('active-memory');
                   c.plugins.entries['active-memory'] = c.plugins.entries['active-memory'] || { enabled: true, config: {} };
                   c.plugins.entries['active-memory'].config = c.plugins.entries['active-memory'].config || {};
                   c.plugins.entries['active-memory'].config.timeoutMs = 120000;
@@ -316,9 +329,25 @@ spec:
                     c.plugins.allow = (c.plugins.allow || []).filter(p => p !== 'whatsapp');
                     if (c.plugins.entries) delete c.plugins.entries.whatsapp;
                   }
+                  // Gateway webhooks — receiving end of the roundtable operator's
+                  // completion notifications (operator posts roundtable.notify/v1
+                  // to /hooks/roundtable; the mapping wakes the main session so
+                  // Tim relays the result in chat). Header-only bearer auth.
                   if (process.env.MOLT_HOOKS_TOKEN) {
                     c.hooks = c.hooks || {};
+                    c.hooks.enabled = true;
                     c.hooks.token = process.env.MOLT_HOOKS_TOKEN;
+                    c.hooks.path = '/hooks';
+                    c.hooks.mappings = Array.isArray(c.hooks.mappings) ? c.hooks.mappings : [];
+                    const rtMapping = {
+                      id: 'roundtable',
+                      match: { path: 'roundtable' },
+                      action: 'wake',
+                      wakeMode: 'now',
+                      textTemplate: 'Round Table {{ payload.kind }} \"{{ payload.name }}\" finished with phase {{ payload.phase }} (requested by {{ payload.context.requestedBy }}, session {{ payload.context.sessionKey }}). Output: {{ payload.output }} — full output in NATS KV if truncated. Relay the outcome to Derek in the originating conversation.'
+                    };
+                    const rtIdx = c.hooks.mappings.findIndex(m => m && m.id === 'roundtable');
+                    if (rtIdx >= 0) c.hooks.mappings[rtIdx] = rtMapping; else c.hooks.mappings.push(rtMapping);
                   }
                   if (process.env.MOLT_GOOGLE_PLACES_API_KEY) {
                     c.skills = c.skills || {};

--- a/kubernetes/apps/roundtable/infrastructure/app/kustomization.yaml
+++ b/kubernetes/apps/roundtable/infrastructure/app/kustomization.yaml
@@ -9,6 +9,7 @@ resources:
   - watchman-rbac.yaml
   - patsy-rbac.yaml
   - roundtable-secret.yaml
+  - molt-hook-token.yaml
   - vault-pv.yaml
   - vault-pvc.yaml
   - shared-workspace-pvc.yaml

--- a/kubernetes/apps/roundtable/infrastructure/app/molt-hook-token.yaml
+++ b/kubernetes/apps/roundtable/infrastructure/app/molt-hook-token.yaml
@@ -1,0 +1,24 @@
+# yaml-language-server: $schema=https://kubernetes-schemas.pages.dev/external-secrets.io/externalsecret_v1beta1.json
+---
+apiVersion: external-secrets.io/v1
+kind: ExternalSecret
+metadata:
+  name: molt-hook-token
+  namespace: roundtable
+spec:
+  secretStoreRef:
+    kind: ClusterSecretStore
+    name: infisical
+  target:
+    name: molt-hook-token
+    template:
+      engineVersion: v2
+      data:
+        # Referenced by Chain/Mission spec.notify.webhook.tokenSecretRef —
+        # bearer token for molt's gateway /hooks endpoint. Same Infisical key
+        # feeds molt-secret in the ai namespace (the validating side).
+        token: "{{ .MOLT_HOOKS_TOKEN }}"
+  dataFrom:
+    - find:
+        name:
+          regexp: ^MOLT_HOOKS_TOKEN$

--- a/kubernetes/apps/roundtable/operator/app/helmrelease.yaml
+++ b/kubernetes/apps/roundtable/operator/app/helmrelease.yaml
@@ -13,7 +13,7 @@ spec:
   chart:
     spec:
       chart: roundtable-operator
-      version: "0.13.1"
+      version: "0.14.0"
       sourceRef:
         kind: HelmRepository
         name: roundtable
@@ -29,6 +29,14 @@ spec:
     # PVC — replaces the per-knight build Jobs + global store lock.
     nixBuilder:
       enabled: true
+
+    # Completion webhooks (chart 0.14.0): spec.notify on Chains/Missions posts
+    # roundtable.notify/v1 to matching URLs only — this prefix list is the SSRF
+    # guard, since anyone who can create a Chain controls notify.url. Keep it
+    # pinned to molt's gateway hook endpoint.
+    notify:
+      allowedURLPrefixes:
+        - http://molt.ai.svc:18789/hooks/
 
     resources:
       requests:


### PR DESCRIPTION
Receiving side of roundtable completion webhooks (operator side shipped in roundtable#144), plus the three boot-script fixes from today's upgrade-residue audit.

**Requires a new Infisical key before the hooks activate: `MOLT_HOOKS_TOKEN`** — until it exists, molt-secret keeps its last-synced state and the two ExternalSecrets show SecretSyncedError (expected).

- roundtable-operator 0.14.0 + `notify.allowedURLPrefixes: [http://molt.ai.svc:18789/hooks/]`
- molt gateway hooks enabled; `/hooks/roundtable` mapping wakes the main session with chain name/phase/output
- `molt-hook-token` Secret in roundtable ns for `spec.notify.webhook.tokenSecretRef`
- audit fixes: active-memory allowlisted, discord plugin version re-sync, searxng plugin install