### PR TITLE
fix(roundtable): completion-webhook allowlist uses molt-app service name

### DIFF
--- a/kubernetes/apps/roundtable/operator/app/helmrelease.yaml
+++ b/kubernetes/apps/roundtable/operator/app/helmrelease.yaml
@@ -36,7 +36,7 @@ spec:
     # pinned to molt's gateway hook endpoint.
     notify:
       allowedURLPrefixes:
-        - http://molt.ai.svc:18789/hooks/
+        - http://molt-app.ai.svc.cluster.local:18789/hooks/
 
     resources:
       requests:


### PR DESCRIPTION
End-to-end test found the service is `molt-app` (app-template naming), not `molt`. The operator fired the webhook correctly but failed DNS on `molt.ai.svc`. Corrected to the FQDN `molt-app.ai.svc.cluster.local:18789`, verified resolvable + reachable (401) from the roundtable namespace.