### PR TITLE
fix(ai): mount molt SA token + bind roundtable RBAC to the molt SA

### DIFF
--- a/kubernetes/apps/ai/openclaw/app/helmrelease.yaml
+++ b/kubernetes/apps/ai/openclaw/app/helmrelease.yaml
@@ -465,6 +465,12 @@ spec:
             fsGroupChangePolicy: OnRootMismatch
     defaultPodOptions:
       shareProcessNamespace: true
+      # Mount the SA token so Tim's kubectl can reach the API (roundtable
+      # Chains/Missions). app-template 5.x runs the pod as the auto-created
+      # 'molt' SA with automount off by default; without this the token is
+      # absent and kubectl falls back to localhost:8080. Pairs with the RBAC
+      # bindings repointed to the 'molt' SA (rbac.yaml, molt-rbac.yaml).
+      automountServiceAccountToken: true
       securityContext:
         runAsUser: 1000
         runAsGroup: 1000

--- a/kubernetes/apps/ai/openclaw/app/rbac.yaml
+++ b/kubernetes/apps/ai/openclaw/app/rbac.yaml
@@ -9,7 +9,16 @@ rules:
     resources: ["nodes", "namespaces", "persistentvolumes"]
     verbs: ["get", "list", "watch"]
   - apiGroups: [""]
-    resources: ["pods", "pods/log", "services", "endpoints", "persistentvolumeclaims", "configmaps", "events"]
+    resources:
+      [
+        "pods",
+        "pods/log",
+        "services",
+        "endpoints",
+        "persistentvolumeclaims",
+        "configmaps",
+        "events",
+      ]
     verbs: ["get", "list", "watch"]
   # Apps
   - apiGroups: ["apps"]
@@ -63,6 +72,7 @@ roleRef:
   kind: ClusterRole
   name: openclaw-reader
 subjects:
+  # The molt pod runs as the app-template-created 'molt' SA (not 'default').
   - kind: ServiceAccount
-    name: default
+    name: molt
     namespace: ai

--- a/kubernetes/apps/roundtable/infrastructure/app/molt-rbac.yaml
+++ b/kubernetes/apps/roundtable/infrastructure/app/molt-rbac.yaml
@@ -7,7 +7,17 @@ metadata:
   namespace: roundtable
 rules:
   - apiGroups: [""]
-    resources: ["pods", "pods/exec", "pods/log", "services", "configmaps", "secrets", "persistentvolumeclaims", "events"]
+    resources:
+      [
+        "pods",
+        "pods/exec",
+        "pods/log",
+        "services",
+        "configmaps",
+        "secrets",
+        "persistentvolumeclaims",
+        "events",
+      ]
     verbs: ["get", "list", "watch", "create", "update", "patch", "delete"]
   - apiGroups: ["apps"]
     resources: ["deployments", "replicasets"]
@@ -28,8 +38,9 @@ metadata:
   name: molt-knight-admin
   namespace: roundtable
 subjects:
+  # The molt pod runs as the app-template-created 'molt' SA (not 'default').
   - kind: ServiceAccount
-    name: default
+    name: molt
     namespace: ai
 roleRef:
   kind: Role


### PR DESCRIPTION
## Root cause
The app-template 5.x chart runs the molt pod as an auto-created `molt` ServiceAccount with token automount **off**, but the roundtable RBAC (`molt-knight-admin`) and `openclaw-reader` were bound to `ai:default`. So Tim's kubectl either had **no token** (falls back to localhost:8080) or got **forbidden** — the recurring 'RBAC lockout' that `dispatch-wait.sh` was hardened to tolerate by falling back to NATS (2026-06-16).

Verified: `kubectl auth can-i create chains --as=ai:molt` → **no**, `--as=ai:default` → **yes**.

## Fix
- `automountServiceAccountToken: true` on the molt controller → token mounts at `/var/run/secrets/...`
- repoint both bindings `default` → `molt` (the SA the pod actually uses)

## Effect
Unblocks the CRD Chain/Mission dispatch path — including the new `spec.notify` completion webhooks — so Tim can create+trigger tracked chains and get pushed results, instead of the NATS-only fallback.