### PR TITLE
fix(roundtable): chart 0.14.1 — dashboard NATS reconnect fix

### DIFF
--- a/kubernetes/apps/roundtable/operator/app/helmrelease.yaml
+++ b/kubernetes/apps/roundtable/operator/app/helmrelease.yaml
@@ -13,7 +13,7 @@ spec:
   chart:
     spec:
       chart: roundtable-operator
-      version: "0.14.0"
+      version: "0.14.1"
       sourceRef:
         kind: HelmRepository
         name: roundtable


### PR DESCRIPTION
Bumps the roundtable-operator chart `0.14.0` → `0.14.1`, which carries the dashboard image bump to `6332301` (roundtable#145 → roundtable-ui#147).

Fixes the dashboard live-feed flapping 🟢/🔴: the API was using the nats.go default reconnect settings and permanently closed its NATS connection ~2 min after a NATS restart, 401-lookalike-closing every `/api/ws` (actually 1011 "NATS unavailable") and 500/504ing the NATS-backed REST endpoints. The new image reconnects forever (`MaxReconnects(-1)`), rejects the WS upgrade with 503 while NATS is down (no more false-"Connected" flicker), and surfaces the close reason.

Single line: `spec.chart.spec.version` `0.14.0` → `0.14.1`. Dashboard/piKnight image pins live in the chart values (since 0.12.3), so no image override changes here.