### PR TITLE
feat(knights): Fleet self-improvement tooling additions (2026-07-06)

### DIFF
--- a/kubernetes/apps/roundtable/knights/app/galahad.yaml
+++ b/kubernetes/apps/roundtable/knights/app/galahad.yaml
@@ -36,6 +36,11 @@ spec:
       # SAST & Code Analysis (Added 2026-03-23)
       - semgrep        # Static application security testing
       - gosec          # Go security checker
+      # Added 2026-03-30 - Fleet self-improvement assessment
+      - kubectl        # Kubernetes CLI for live cluster security verification
+      - kubescape      # Kubernetes security posture assessment
+      # Added 2026-07-06 - Fleet self-improvement assessment
+      - nikto          # Web server vulnerability scanner for security assessments
     # shodan: pip package, installed by Galahad's skills on-demand (not in mise registry)
   nats:
     url: nats://nats.database.svc:4222

--- a/kubernetes/apps/roundtable/knights/app/percival.yaml
+++ b/kubernetes/apps/roundtable/knights/app/percival.yaml
@@ -19,6 +19,8 @@ spec:
       - sqlite
       - units
       - dateutils
+      # Added 2026-07-06 - Fleet self-improvement assessment
+      - jq             # JSON processing for financial data
   nats:
     url: nats://nats.database.svc:4222
     subjects:

--- a/kubernetes/apps/roundtable/knights/app/tristan.yaml
+++ b/kubernetes/apps/roundtable/knights/app/tristan.yaml
@@ -42,6 +42,8 @@ spec:
       - jq             # JSON processing
       - tree
       - curl
+      # Added 2026-07-06 - Fleet self-improvement assessment
+      - kustomize      # Kubernetes native configuration management tool
   nats:
     url: nats://nats.database.svc:4222
     subjects:


### PR DESCRIPTION
## Fleet Self-Improvement Cycle — 2026-07-06

Based on 9 knight self-assessments, this PR adds missing Nix tools to Knight CRs.

### Tool Additions

- **Galahad (security)**: 
  - `kubectl` — Live cluster security verification (restored from 03-30 cycle)
  - `kubescape` — Kubernetes security posture assessment (restored from 03-30 cycle)
  - `nikto` — Web server vulnerability scanner
  
- **Tristan (infra)**: 
  - `kustomize` — Kubernetes native configuration management

- **Percival (finance)**: 
  - `jq` — JSON processing for financial data pipelines

### Deduplication

- `nikto` was also requested by Galahad in a previous cycle; now included.
- `yq` was requested by Kay, but `yq-go` is already present in their CR and provides the `yq` binary.
- `bc` was flagged missing by Percival, but is already present in their CR.

### Deferred

- `yq` for Kay — already present as `yq-go`.
- All skill requests deferred to `dapperdivers/roundtable-arsenal` issues.