### PR TITLE
feat(nut-upsd): add garage SNMP UPSes (apc-ups-a/b) to NUT

### DIFF
--- a/kubernetes/apps/kube-system/nut-upsd/app/externalsecret.yaml
+++ b/kubernetes/apps/kube-system/nut-upsd/app/externalsecret.yaml
@@ -19,4 +19,48 @@ spec:
   dataFrom:
     - find:
         path: NUT_API_PASSWORD
+---
+# yaml-language-server: $schema=https://kubernetes-schemas.pages.dev/external-secrets.io/externalsecret_v1beta1.json
+apiVersion: external-secrets.io/v1
+kind: ExternalSecret
+metadata:
+  name: nut-upsd-upsconf
+spec:
+  secretStoreRef:
+    kind: ClusterSecretStore
+    name: infisical
+  target:
+    name: nut-upsd-upsconf
+    template:
+      engineVersion: v2
+      # Mounted at /etc/nut/local/ups.conf to override the env-generated config.
+      # Keeps the read-only SNMP community out of Git. The two garage cards are
+      # AP9631 NMC2 (SNMPv1 only) at 192.168.1.18/.19; the USB Smart-UPS 1500
+      # section mirrors the DRIVER/SERIAL env on the container.
+      data:
+        ups.conf: |
+          [ups]
+              driver = usbhid-ups
+              port = auto
+              serial = "AS1324133052"
+              desc = "Smart-UPS 1500 (USB)"
 
+          [garage-a]
+              driver = snmp-ups
+              port = 192.168.1.18
+              snmp_version = v1
+              community = "{{ .UPS_SNMP_COMMUNITY }}"
+              pollfreq = 30
+              desc = "Smart-UPS 2200 RM (garage rack, apc-ups-a)"
+
+          [garage-b]
+              driver = snmp-ups
+              port = 192.168.1.19
+              snmp_version = v1
+              community = "{{ .UPS_SNMP_COMMUNITY }}"
+              pollfreq = 30
+              desc = "Smart-UPS 2200 RM (garage rack, apc-ups-b)"
+  dataFrom:
+    - find:
+        name:
+          regexp: ^UPS_SNMP_COMMUNITY$

--- a/kubernetes/apps/kube-system/nut-upsd/app/helmrelease.yaml
+++ b/kubernetes/apps/kube-system/nut-upsd/app/helmrelease.yaml
@@ -46,6 +46,17 @@ spec:
         pod:
           nodeSelector:
             ups.feature.node.kubernetes.io/apc: "true"
+    persistence:
+      # Overrides the env-generated ups.conf (instantlinux honors /etc/nut/local),
+      # defining the USB Smart-UPS 1500 plus the two garage AP9631/SNMP UPSes.
+      # Templated from Infisical UPS_SNMP_COMMUNITY so the community stays out of Git.
+      ups-conf:
+        type: secret
+        name: nut-upsd-upsconf
+        globalMounts:
+          - path: /etc/nut/local/ups.conf
+            subPath: ups.conf
+            readOnly: true
     service:
       app:
         type: LoadBalancer


### PR DESCRIPTION
Brings the two new garage-rack APC UPS management cards into NUT so they show in PeaNUT and get metrics via `nut-exporter`.

## What
- Adds an `/etc/nut/local/ups.conf` override to `nut-upsd` (the `instantlinux` image honors that path) defining three UPS sections: the existing USB `Smart-UPS 1500`, plus `garage-a` (192.168.1.18) and `garage-b` (192.168.1.19) as `snmp-ups` devices.
- The community is templated from the Infisical `UPS_SNMP_COMMUNITY` secret via a new ExternalSecret (`nut-upsd-upsconf`), so it stays out of Git.

## Context
- Both cards are **APC AP9631 NMC2** (Smart-UPS 2200 RM), on DHCP reservations `192.168.1.18` (`apc-ups-a`) / `192.168.1.19` (`apc-ups-b`). SNMP verified returning telemetry (battery/load/status).
- NMC2 is **SNMPv1 only** (no v2c) with a ~15-char community cap, so these use a dedicated short read-only community rather than the shared `SNMP_RO_COMMUNITY`.
- PeaNUT and `nut-exporter` point at the same `nut-upsd` server and discover the new UPSes automatically (each has a unique id).

## Rollback
HelmRelease already has `upgrade.remediation.strategy: rollback`; a bad `ups.conf` reverts to the USB-only config.

## Post-merge verification
- `kubectl -n kube-system logs deploy/nut-upsd` — snmp-ups drivers connect to .18/.19
- `upsc garage-a@<nut-vip>` returns data
- Both appear in PeaNUT (`ups.${SECRET_DOMAIN}`)