### PR TITLE
fix(observability): repair UPS metrics + Power badge after NUT migration

### DIFF
--- a/kubernetes/apps/observability/exporters/nut-exporter/app/helmrelease.yaml
+++ b/kubernetes/apps/observability/exporters/nut-exporter/app/helmrelease.yaml
@@ -60,6 +60,10 @@ spec:
     serviceMonitor:
       app:
         serviceName: *app
+        # nut_exporter scrapes ONE UPS per request and fails the scrape if the NUT
+        # server has >1 UPS and no `ups` param. One endpoint per UPS (the server is
+        # taken from NUT_EXPORTER_SERVER); the exporter emits a `ups=<name>` label
+        # per query, which the network-ups-tools.rules alerts key on.
         endpoints:
           - port: http
             scheme: http
@@ -67,8 +71,18 @@ spec:
             scrapeTimeout: 10s
             path: /ups_metrics
             params:
-              targets:
-                - nut-upsd.kube-system.svc.cluster.local:3493
-            relabelings:
-              - sourceLabels: [__param_target]
-                targetLabel: target
+              ups: ["ups"]
+          - port: http
+            scheme: http
+            interval: 60s
+            scrapeTimeout: 10s
+            path: /ups_metrics
+            params:
+              ups: ["garage-a"]
+          - port: http
+            scheme: http
+            interval: 60s
+            scrapeTimeout: 10s
+            path: /ups_metrics
+            params:
+              ups: ["garage-b"]


### PR DESCRIPTION
Finishes the UPS → NUT migration on the observability side (follow-up to #3615).

## 1. nut-exporter: scrape all three UPSes (`fix(nut-exporter)`)
`nut_exporter` scrapes **one UPS per request** (needs a `ups` param once the NUT server exposes >1 UPS) and emits **no `ups` label of its own**. After #3615, `nut-upsd` serves three UPSes (`ups`, `garage-a`, `garage-b`) but the ServiceMonitor had a single, unparameterised scrape.

- One ServiceMonitor endpoint per UPS, each passing its `ups` param.
- Relabel `__param_ups` → `ups` on every endpoint, so each UPS gets a distinct labelled series (without it the three scrapes collide) and the existing `network-ups-tools.rules` alerts resolve `{{ $labels.ups }}`.

Verified against the live exporter: `/ups_metrics?ups=garage-a|garage-b` return each device's data; neither carries a `ups` label until relabeled.

## 2. kromgo: repoint the Power badge (`fix(kromgo)`)
The README Power badge queried `upsHighPrecOutputLoad` — an SNMP-exporter metric that died when the UPSes moved to NUT. NUT exposes **no watts variable** (confirmed: no `ups.realpower`), so the badge now estimates garage-rack draw from `load% × 2200 VA` (the two Smart-UPS 2200 RM; VA ≈ W for server PSUs):

```
round(sum(network_ups_tools_ups_load{ups=~"garage-.*"}) / 100 * 2200, 1)
```

Depends on the `ups` label from change #1, hence the same PR. Thresholds re-scaled for the ~2 kVA rack (green <2500 / orange <3500 / red ≥3501) — easy to tune.

## Post-merge verification
- Prometheus: three `nut-exporter` targets UP; `network_ups_tools_ups_status{ups="garage-a"|"garage-b"}` present.
- Kromgo `cluster_power_usage` returns a live value; README Power badge lights up.
