### PR TITLE
fix(observability): label UPS metrics + repoint Power badge to NUT

### DIFF
--- a/kubernetes/apps/observability/exporters/nut-exporter/app/helmrelease.yaml
+++ b/kubernetes/apps/observability/exporters/nut-exporter/app/helmrelease.yaml
@@ -60,10 +60,11 @@ spec:
     serviceMonitor:
       app:
         serviceName: *app
-        # nut_exporter scrapes ONE UPS per request and fails the scrape if the NUT
-        # server has >1 UPS and no `ups` param. One endpoint per UPS (the server is
-        # taken from NUT_EXPORTER_SERVER); the exporter emits a `ups=<name>` label
-        # per query, which the network-ups-tools.rules alerts key on.
+        # nut_exporter scrapes ONE UPS per request (needs a `ups` param when the NUT
+        # server has >1 UPS) and does NOT emit a `ups` label itself. One endpoint per
+        # UPS, and relabel __param_ups -> `ups` so each UPS's series are distinct
+        # (otherwise all three collide) and the network-ups-tools.rules alerts can key
+        # on `{{ $labels.ups }}`. Server comes from NUT_EXPORTER_SERVER.
         endpoints:
           - port: http
             scheme: http
@@ -72,6 +73,9 @@ spec:
             path: /ups_metrics
             params:
               ups: ["ups"]
+            relabelings: &upsLabel
+              - sourceLabels: [__param_ups]
+                targetLabel: ups
           - port: http
             scheme: http
             interval: 60s
@@ -79,6 +83,7 @@ spec:
             path: /ups_metrics
             params:
               ups: ["garage-a"]
+            relabelings: *upsLabel
           - port: http
             scheme: http
             interval: 60s
@@ -86,3 +91,4 @@ spec:
             path: /ups_metrics
             params:
               ups: ["garage-b"]
+            relabelings: *upsLabel

--- a/kubernetes/apps/observability/kromgo/app/resources/config.yaml
+++ b/kubernetes/apps/observability/kromgo/app/resources/config.yaml
@@ -51,12 +51,15 @@ metrics:
     title: Memory
 
   - name: cluster_power_usage
-    query: round(upsHighPrecOutputLoad, 0.1)
+    # UPSes moved from SNMP to NUT, which has no watts var. Estimate the garage
+    # rack draw from NUT load% x the 2200 VA rating of the two Smart-UPS 2200 RM
+    # (VA ~= W for the server PSUs). Needs the per-UPS `ups` label from nut-exporter.
+    query: round(sum(network_ups_tools_ups_load{ups=~"garage-.*"}) / 100 * 2200, 1)
     suffix: "w"
     colors:
-      - { color: "green", min: 0, max: 400 }
-      - { color: "orange", min: 401, max: 750 }
-      - { color: "red", min: 751, max: 9999 }
+      - { color: "green", min: 0, max: 2500 }
+      - { color: "orange", min: 2501, max: 3500 }
+      - { color: "red", min: 3501, max: 9999 }
     title: Power
 
   - name: cluster_age_days


### PR DESCRIPTION
Two follow-up fixes to the UPS → NUT migration (#3615, #3616). #3616 auto-merged before its relabeling fix landed, so `main` currently has colliding UPS metrics — this repairs that and also fixes the README Power badge.

## 1. nut-exporter — label each UPS (fixes a collision on `main`)
#3616 added one scrape endpoint per UPS but **without relabeling**. `nut_exporter` emits **no `ups` label of its own**, so all three scrapes (`ups`, `garage-a`, `garage-b`) produce identical series that collide in Prometheus. This relabels `__param_ups` → `ups` on each endpoint, so each UPS is a distinct series and the `network-ups-tools.rules` alerts resolve `{{ $labels.ups }}`.

Verified against the live exporter: `/ups_metrics?ups=garage-a|garage-b` return each device's data and carry no `ups` label until relabeled.

## 2. kromgo — repoint the Power badge
The README Power badge queried `upsHighPrecOutputLoad`, an SNMP-exporter metric that died when the UPSes moved to NUT. NUT exposes **no watts variable** (no `ups.realpower`), so the badge now estimates garage-rack draw from `load% × 2200 VA` (the two Smart-UPS 2200 RM; VA ≈ W for server PSUs):

```
round(sum(network_ups_tools_ups_load{ups=~"garage-.*"}) / 100 * 2200, 1)
```

Depends on the `ups` label from part 1, hence one PR. Thresholds re-scaled for the ~2 kVA rack (green <2500 / orange <3500 / red ≥3501) — easy to tune.

## Post-merge verification
- Prometheus: three `nut-exporter` targets UP; `network_ups_tools_ups_status{ups="garage-a"|"garage-b"}` present, no duplicate-series errors.
- Kromgo `cluster_power_usage` returns a live value; README Power badge lights up.
