### PR TITLE
docs: drop redundant network mermaid + sync GPU count to 2x P100

### DIFF
--- a/README.md
+++ b/README.md
@@ -161,71 +161,12 @@ My network spans two physical locations connected via a 60GHz wireless bridge, f
   <img src="docs/src/assets/infographics/network-topology.jpg" alt="ChelonianLabs home network and fabric bandwidth: two-building multi-vendor fabric with 40/80G LACP" width="100%"/>
 </div>
 
-<details>
-  <summary>Physical Network Topology (source diagram)</summary>
-
-```mermaid
-graph TB
-    %% Styling
-    classDef router fill:#d83933,stroke:#fff,stroke-width:2px,color:#fff
-    classDef coreswitch fill:#2f73d8,stroke:#fff,stroke-width:2px,color:#fff
-    classDef distswitch fill:#389826,stroke:#fff,stroke-width:2px,color:#fff
-    classDef accessswitch fill:#f39c12,stroke:#fff,stroke-width:2px,color:#fff
-    classDef server fill:#8e44ad,stroke:#fff,stroke-width:2px,color:#fff
-    classDef wireless fill:#e74c3c,stroke:#fff,stroke-width:2px,color:#fff
-
-    subgraph House["🏠 House"]
-        OPN["OPNsense<br/>192.168.1.1<br/>Gateway"]:::router
-        ARUBA["Aruba S2500-48p<br/>192.168.1.26<br/>PoE Access Switch"]:::accessswitch
-        CLIENTS["Client Devices"]
-        WHOUSE["Mikrotik NRay60<br/>192.168.1.7"]:::wireless
-
-        OPN --- ARUBA
-        ARUBA --- CLIENTS
-        ARUBA --- WHOUSE
-    end
-
-    subgraph Bridge["⚡ 60GHz Bridge"]
-        WHOUSE -.1Gbps Wireless.-> WSHOP
-    end
-
-    subgraph Garage["🏭 Garage/Shop"]
-        WSHOP["Mikrotik NRay60<br/>192.168.1.8"]:::wireless
-        BROCADE["Brocade ICX6610<br/>192.168.1.20<br/>Core L3 Switch"]:::coreswitch
-        ARISTA["Arista 7050<br/>192.168.1.21<br/>40Gb Distribution"]:::distswitch
-
-        PX1["Proxmox-01<br/>4C/16GB"]:::server
-        PX2["Proxmox-02<br/>24C/196GB"]:::server
-        PX3["Proxmox-03<br/>64C/516GB"]:::server
-        PX4["Proxmox-04<br/>24C/196GB"]:::server
-
-        WSHOP --- BROCADE
-        BROCADE <-->|2x 40Gb LAG| ARISTA
-
-        PX1 -->|2x10Gb + 2x1Gb| BROCADE
-        PX2 -->|2x10Gb + 2x1Gb| BROCADE
-        PX3 -->|2x10Gb + 2x1Gb| BROCADE
-        PX4 -->|2x10Gb + 2x1Gb| BROCADE
-
-        PX1 -.40Gb Storage.-> ARISTA
-        PX2 -.40Gb Storage.-> ARISTA
-        PX3 -.40Gb Storage.-> ARISTA
-        PX4 -.40Gb Storage.-> ARISTA
-    end
-
-    style House fill:#ecf0f1,stroke:#34495e,stroke-width:3px
-    style Garage fill:#ecf0f1,stroke:#34495e,stroke-width:3px
-    style Bridge fill:#ffebee,stroke:#c62828,stroke-width:2px
-```
-
 **Key Features:**
 
 - Dual locations connected via 60GHz wireless (1Gbps)
 - Multi-tier switching: Core (Brocade), Distribution (Arista), Access (Aruba)
 - Dedicated 40Gb storage network on Arista
 - LACP bonding on server links for redundancy
-
-</details>
 
 <details>
   <summary>Kubernetes Cluster</summary>

--- a/docs/src/README.md
+++ b/docs/src/README.md
@@ -15,7 +15,7 @@ graph TD
     subgraph Worker Nodes
         W1[Worker 1<br>16 CPU, 128GB]
         W2[Worker 2<br>16 CPU, 128GB]
-        GPU[GPU Node<br>16 CPU, 128GB<br>4x Tesla P100]
+        GPU[GPU Node<br>16 CPU, 128GB<br>2x Tesla P100]
     end
 
     CP1 --- CP2
@@ -44,7 +44,7 @@ graph TD
 - Specialized GPU worker node
 - 16 CPU cores
 - 128GB RAM
-- 4x NVIDIA Tesla P100 GPUs
+- 2x NVIDIA Tesla P100 GPUs
 - Handles ML/AI and GPU-accelerated workloads
 
 ## Key Features

--- a/docs/src/architecture/hardware.md
+++ b/docs/src/architecture/hardware.md
@@ -28,7 +28,7 @@
 - **Chassis**: ASUS ESC4000 G3 (8x 3.5" bays)
 - **CPU**: 2x Intel Xeon E5-2697A v4 @ 2.60GHz (64 cores total)
 - **RAM**: 516 GiB
-- **GPU**: 4x NVIDIA P100 16GB
+- **GPU**: 2x NVIDIA P100 16GB
 - **Network**: 2x1Gbe, 2x 10GbE, 2x 40Gbe
 - **OS Drive**: 2x120GB ZFS mirror
 

--- a/docs/src/architecture/overview.md
+++ b/docs/src/architecture/overview.md
@@ -20,7 +20,7 @@ graph TD
     end
 
     subgraph GPU Node
-        GPU[GPU Worker<br>16 CPU, 128GB<br>4x Tesla P100]
+        GPU[GPU Worker<br>16 CPU, 128GB<br>2x Tesla P100]
     end
 
     Control Plane --> Worker Nodes
@@ -57,7 +57,7 @@ graph TD
 - **Hardware**:
   - 16 CPU cores
   - 128GB RAM
-  - 4x NVIDIA Tesla P100 GPUs
+  - 2x NVIDIA Tesla P100 GPUs
 - **Workload Types**:
   - ML/AI workloads
   - Video transcoding

--- a/docs/src/operations/installation.md
+++ b/docs/src/operations/installation.md
@@ -35,7 +35,7 @@ graph TD
 
 - CPU: 16 cores
 - RAM: 128GB
-- GPU: 4x NVIDIA Tesla P100
+- GPU: 2x NVIDIA Tesla P100
 - Role: GPU-accelerated workloads
 
 ### Worker Nodes (2x)


### PR DESCRIPTION
Follow-up cleanup after adding the infographics.

## Changes
- **README:** removed the *Physical Network Topology* mermaid `<details>` — the new topology infographic replaces it. Kept the Key Features caption. The other three mermaids (Flux workflow, Kubernetes cluster, VLAN segmentation) are intact.
- **docs/ mdBook:** corrected `4x -> 2x Tesla P100` in 6 places (README, architecture/overview, architecture/hardware, operations/installation) to match current reality — 2 P100s were pulled this weekend.

## Checked, no action needed
- No mermaid diagrams were broken (only text-label edits).
- Scanned docs for other stale architecture facts (nginx Ingress, Loki/Promtail, OpenEBS/Longhorn/Mayastor, pinned versions) — **none present**.
- Storage totals (76 drives / 476.96TB physical inventory) left as-is per request; Ceph version in docs (18.2.x Reef) already matches live.