### PR TITLE
feat(nut-exporter): complete UPS alerting (unreachable + overload, drop dead SNMP alert)

### DIFF
--- a/kubernetes/apps/observability/exporters/nut-exporter/app/prometheusrule.yaml
+++ b/kubernetes/apps/observability/exporters/nut-exporter/app/prometheusrule.yaml
@@ -46,3 +46,29 @@ spec:
           labels:
             # Order a battery — an act-today task, not a 3am page.
             severity: warning
+        - alert: UpsUnreachable
+          annotations:
+            description: >
+              NUT can no longer read UPS {{ $labels.ups }} — its management card is
+              likely offline (network/power) or the driver lost communication. We
+              have no battery/status data or graceful-shutdown coverage for it until
+              it returns. (NutExporterAbsent only covers the whole exporter dying.)
+            summary: A UPS dropped off monitoring.
+          expr: |
+            up{job=~".*nut-exporter.*"} == 0
+          for: 5m
+          labels:
+            # Lost visibility for one UPS, not an active power event — same-day fix.
+            severity: warning
+        - alert: UpsOverload
+          annotations:
+            description: >
+              UPS {{ $labels.ups }} output load is {{ printf "%.0f" $value }}% —
+              sustained high load cuts runtime and risks an overload trip. Rebalance
+              the rack or move load to the other UPS.
+            summary: UPS running near capacity.
+          expr: |
+            network_ups_tools_ups_load > 90
+          for: 15m
+          labels:
+            severity: warning

--- a/kubernetes/apps/observability/exporters/snmp-exporter/app/prometheusrule.yaml
+++ b/kubernetes/apps/observability/exporters/snmp-exporter/app/prometheusrule.yaml
@@ -6,19 +6,9 @@ metadata:
   name: snmp-exporter-rules
 spec:
   groups:
-    - name: snmp-exporter.rules
-      rules:
-        - alert: UPSOnBattery
-          expr: |
-            (upsAdvBatteryRunTimeRemaining/60/100 <= 5 and upsBasicBatteryTimeOnBattery > 0)
-          annotations:
-            summary: >
-              ZPM {{$labels.instance}} is running on batteries and has less than 5 minutes of battery left
-            description: >
-              ZPM UPS {{$labels.instance}} has lost power and is running on battery with less than 5 minutes of runtime remaining. Prepare for shutdown.
-          for: 30s
-          labels:
-            severity: critical
+    # NOTE: the old UPSOnBattery alert (ZPM UPS via SNMP) was removed — those UPSes
+    # moved to NUT and are covered by network-ups-tools.rules (UpsOnBattery /
+    # UpsLowBattery). Its metrics (upsAdvBatteryRunTimeRemaining) no longer exist.
     - name: snmp-network.rules
       rules:
         # Fires only on ports the operator has DESCRIBED with an infra keyword


### PR DESCRIPTION
Makes the UPS alerting genuinely complete now that all three UPSes report to NUT (follow-up to #3615/#3619). Notification path is already solid: all UPS alerts → Alertmanager → ntfy, with `severity=critical` also paging via Pushover (urgent, bypasses DND).

## Added (nut-exporter rules)
- **UpsUnreachable** (warning, 5m) — `up{job=~".*nut-exporter.*"} == 0`. Fires when NUT can no longer read a single UPS (its NMC went offline or the driver lost comms). Previously only `NutExporterAbsent` existed, which covers the *whole* exporter dying — so one card going dark was a blind spot (no status/graceful-shutdown coverage, silently).
- **UpsOverload** (warning, 15m) — `network_ups_tools_ups_load > 90`. Sustained near-capacity load cuts runtime and risks an overload trip.

## Removed (snmp-exporter rules)
- **UPSOnBattery** (the old "ZPM UPS" SNMP alert) — its metrics (`upsAdvBatteryRunTimeRemaining`, `upsBasicBatteryTimeOnBattery`) no longer exist (confirmed empty in Prometheus), so it could never fire. The NUT `UpsOnBattery`/`UpsLowBattery` alerts cover this properly now.

## Existing coverage (unchanged, verified working)
`UpsOnBattery` (critical), `UpsLowBattery` (critical), `UpsBatteryReplace` (warning), `NutExporterAbsent` (warning) — all evaluating live against per-UPS data; on-battery/low-battery cover all three UPSes (incl. the USB one, which reports status).

Validated: both rule files parse (`promtool`-style eval of the new exprs returns clean/empty = healthy).
