### PR TITLE
fix(roundtable): dashboard image 12be217 via chart 0.14.2

### DIFF
--- a/kubernetes/apps/roundtable/operator/app/helmrelease.yaml
+++ b/kubernetes/apps/roundtable/operator/app/helmrelease.yaml
@@ -13,7 +13,7 @@ spec:
   chart:
     spec:
       chart: roundtable-operator
-      version: "0.14.1"
+      version: "0.14.2"
       sourceRef:
         kind: HelmRepository
         name: roundtable


### PR DESCRIPTION
Bumps the roundtable-operator chart to `0.14.2`, which pins the dashboard
(roundtable-ui) image to `12be217` — the Session Explorer legibility fix
(roundtable-ui#148 / roundtable#146): capped tree indentation, non-wrapping
timestamps, and role-aware timeline labels.

Chart `0.14.2` published to ghcr (roundtable `helm` job green). Operator and
pi-knight pins unchanged — dashboard image only.

- helmrelease chart version `0.14.1` → `0.14.2`