### PR TITLE
fix(roundtable): pi-knight 4d747ff via chart 0.14.3

### DIFF
--- a/kubernetes/apps/roundtable/operator/app/helmrelease.yaml
+++ b/kubernetes/apps/roundtable/operator/app/helmrelease.yaml
@@ -13,7 +13,7 @@ spec:
   chart:
     spec:
       chart: roundtable-operator
-      version: "0.14.2"
+      version: "0.14.3"
       sourceRef:
         kind: HelmRepository
         name: roundtable


### PR DESCRIPTION
Bumps the roundtable-operator chart to `0.14.3`, which pins pi-knight to
`4d747ff` — the session introspect fix (pi-knight#40 / roundtable#147): the
Session Explorer timeline now shows real message content (tool results,
assistant tool calls, correct tokens/cost) instead of empty rows.

Chart `0.14.3` published to ghcr (roundtable `helm` job green). Operator and
dashboard pins unchanged — pi-knight image only.

- helmrelease chart version `0.14.2` → `0.14.3`