### PR TITLE
fix(roundtable): session history/replay via chart 0.14.4

### DIFF
--- a/kubernetes/apps/roundtable/operator/app/helmrelease.yaml
+++ b/kubernetes/apps/roundtable/operator/app/helmrelease.yaml
@@ -13,7 +13,7 @@ spec:
   chart:
     spec:
       chart: roundtable-operator
-      version: "0.14.3"
+      version: "0.14.4"
       sourceRef:
         kind: HelmRepository
         name: roundtable


### PR DESCRIPTION
Bumps the roundtable-operator chart to `0.14.4` — session history/replay in the
Session Explorer.

- pi-knight `a220890`: introspect `history`/`session` types (browse & replay past sessions)
- dashboard `5d8702f`: Session Explorer session picker + API passthrough

Chart `0.14.4` published to ghcr (roundtable `helm` job green). Operator pin unchanged.

- helmrelease chart version `0.14.3` → `0.14.4`