### PR TITLE
feat(galahad): cloud deepseek-v4-pro so it uses skills

### DIFF
--- a/kubernetes/apps/roundtable/knights/app/galahad.yaml
+++ b/kubernetes/apps/roundtable/knights/app/galahad.yaml
@@ -10,8 +10,10 @@ spec:
     browser: true
   domain: security
   image: ""
-  # Local P100 pool (was openrouter/anthropic/claude-haiku-4.5) — endpoint env below.
-  model: "openrouter/deepseek/deepseek-v3.2"
+  # Cloud deepseek-v4-pro (was local ollama-pool qwen3.5:9b) — the small local
+  # model ignored skills; v4-pro follows the "read the skill file" instruction
+  # (matches watchman). Routes to OpenRouter via roundtable-secret.
+  model: "openrouter/deepseek/deepseek-v4-pro"
   skills:
     - security
     - shared
@@ -71,16 +73,6 @@ spec:
       value: "/data/scratch/.cache"
     - name: OPENCTI_URL
       value: "http://opencti-server.security.svc:80"
-    # Local inference via the ollama-pool Service (2x P100, qwen3.5:9b).
-    # "ollama/..." is not in pi's model registry, so pi-knight builds an
-    # openai-completions model from these envs (pi-knight dist/model.js).
-    # MODEL_CONTEXT_WINDOW must match the pool's OLLAMA_CONTEXT_LENGTH.
-    - name: OPENAI_BASE_URL
-      value: "http://ollama-pool.ai.svc.cluster.local:11434/v1"
-    - name: MODEL_CONTEXT_WINDOW
-      value: "32768"
-    - name: MODEL_MAX_TOKENS
-      value: "4096"
   envFrom:
     - secretRef:
         name: roundtable-secret


### PR DESCRIPTION
## Why

Galahad was configured `model: deepseek-v3.2` but the `OPENAI_BASE_URL` env override actually routed it to a **local ~9B model** (ollama-pool qwen3.5:9b, 32K ctx, 4K output). A fleet-wide scan of `SKILL.md` reads showed galahad read **0** skill files across its 5 latest sessions — even when tasks literally named a skill's domain (e.g. "check open-cti and cross-reference shodan" with `opencti-intel`/`shodan-recon` skills available; "daily THREAT INTELLIGENCE briefing" with `threat-briefing`). By contrast **watchman** (cloud `deepseek-v4-pro`) reads skills **16×**, and kimi knights (patsy 15, planner 11) also engage them.

pi surfaces skills as a system-prompt list ("read the full skill file when the task matches"); the local 9B model is too weak an instruction-follower to act on it.

## Change

- `model`: `deepseek-v3.2` → `deepseek-v4-pro` (matches watchman).
- Remove the local-pool overrides (`OPENAI_BASE_URL`, `MODEL_CONTEXT_WINDOW`, `MODEL_MAX_TOKENS`) so it routes to OpenRouter via `roundtable-secret` (`OPENROUTER_API_KEY`). Kept `OPENCTI_URL` + cache envs.

**Cost note:** moves galahad from free local GPU inference to paid OpenRouter (value-tier, same as watchman).

## Verify after merge
Operator restarts galahad on v4-pro; re-run the skill-read scan on its next few security tasks — expect it to start reading `/skills/**/SKILL.md`.