### PR TITLE
feat(nats-nui): NATS JetStream web UI

### DIFF
--- a/kubernetes/apps/database/kustomization.yaml
+++ b/kubernetes/apps/database/kustomization.yaml
@@ -11,3 +11,4 @@ resources:
   - ./emqx/ks.yaml
   - ./dragonfly-redis/ks.yaml
   - ./nats/ks.yaml
+  - ./nats-nui/ks.yaml

--- a/kubernetes/apps/database/nats-nui/app/helmrelease.yaml
+++ b/kubernetes/apps/database/nats-nui/app/helmrelease.yaml
@@ -1,0 +1,95 @@
+---
+# yaml-language-server: $schema=https://raw.githubusercontent.com/bjw-s/helm-charts/main/charts/other/app-template/schemas/helmrelease-helm-v2.schema.json
+apiVersion: helm.toolkit.fluxcd.io/v2
+kind: HelmRelease
+metadata:
+  name: nats-nui
+spec:
+  interval: 30m
+  chartRef:
+    kind: OCIRepository
+    name: app-template
+  install:
+    remediation:
+      retries: 3
+  upgrade:
+    cleanupOnFail: true
+    remediation:
+      strategy: rollback
+      retries: 3
+  values:
+    controllers:
+      nats-nui:
+        annotations:
+          reloader.stakater.com/auto: "true"
+        containers:
+          app:
+            image:
+              repository: ghcr.io/nats-nui/nui
+              tag: 0.9.3@sha256:331b3f34f8aa626f88e3aa3e35749196607a3a56d7fddc6fb642938dcd659c04
+            env:
+              TZ: America/Chicago
+            probes:
+              liveness:
+                enabled: true
+                custom: true
+                spec:
+                  tcpSocket:
+                    port: &port 31311
+                  initialDelaySeconds: 15
+                  periodSeconds: 30
+                  timeoutSeconds: 5
+                  failureThreshold: 3
+              readiness:
+                enabled: true
+                custom: true
+                spec:
+                  tcpSocket:
+                    port: *port
+                  initialDelaySeconds: 10
+                  periodSeconds: 20
+                  timeoutSeconds: 5
+                  failureThreshold: 3
+            resources:
+              requests:
+                cpu: 10m
+                memory: 64Mi
+              limits:
+                memory: 256Mi
+            securityContext:
+              allowPrivilegeEscalation: false
+              # NUI writes a SQLite db under /db (PVC) and may write ephemeral
+              # state to its workdir, so the root FS is left writable.
+              readOnlyRootFilesystem: false
+              capabilities:
+                drop:
+                  - ALL
+
+    defaultPodOptions:
+      securityContext:
+        runAsNonRoot: true
+        runAsUser: 1000
+        runAsGroup: 1000
+        fsGroup: 1000
+        fsGroupChangePolicy: OnRootMismatch
+
+    service:
+      app:
+        controller: nats-nui
+        ports:
+          http:
+            port: *port
+
+    route:
+      app:
+        hostnames: ["nats-nui.${SECRET_DOMAIN}"]
+        parentRefs:
+          - name: internal
+            namespace: network
+
+    persistence:
+      # Saved NATS connections live in a SQLite db at /db.
+      db:
+        existingClaim: nats-nui-data
+        globalMounts:
+          - path: /db

--- a/kubernetes/apps/database/nats-nui/app/helmrelease.yaml
+++ b/kubernetes/apps/database/nats-nui/app/helmrelease.yaml
@@ -82,6 +82,8 @@ spec:
 
     route:
       app:
+        annotations:
+          authentik.home.arpa/forward-auth: "true"
         hostnames: ["nats-nui.${SECRET_DOMAIN}"]
         parentRefs:
           - name: internal

--- a/kubernetes/apps/database/nats-nui/app/kustomization.yaml
+++ b/kubernetes/apps/database/nats-nui/app/kustomization.yaml
@@ -1,0 +1,7 @@
+---
+# yaml-language-server: $schema=https://json.schemastore.org/kustomization
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+resources:
+  - ./helmrelease.yaml
+  - ./pvc.yaml

--- a/kubernetes/apps/database/nats-nui/app/pvc.yaml
+++ b/kubernetes/apps/database/nats-nui/app/pvc.yaml
@@ -1,0 +1,13 @@
+# yaml-language-server: $schema=https://kubernetes-schemas.pages.dev/v1/persistentvolumeclaim.json
+---
+apiVersion: v1
+kind: PersistentVolumeClaim
+metadata:
+  name: nats-nui-data
+spec:
+  accessModes:
+    - ReadWriteOnce
+  storageClassName: ceph-rbd
+  resources:
+    requests:
+      storage: 1Gi

--- a/kubernetes/apps/database/nats-nui/ks.yaml
+++ b/kubernetes/apps/database/nats-nui/ks.yaml
@@ -1,0 +1,22 @@
+---
+# yaml-language-server: $schema=https://kubernetes-schemas.pages.dev/kustomize.toolkit.fluxcd.io/kustomization_v1.json
+apiVersion: kustomize.toolkit.fluxcd.io/v1
+kind: Kustomization
+metadata:
+  name: &app nats-nui
+  namespace: &namespace database
+spec:
+  targetNamespace: *namespace
+  commonMetadata:
+    labels:
+      app.kubernetes.io/name: *app
+  path: ./kubernetes/apps/database/nats-nui/app
+  prune: true
+  sourceRef:
+    kind: GitRepository
+    name: flux-system
+    namespace: flux-system
+  wait: true
+  interval: 30m
+  retryInterval: 1m
+  timeout: 5m

--- a/kubernetes/apps/security/authentik/app/blueprints.yaml
+++ b/kubernetes/apps/security/authentik/app/blueprints.yaml
@@ -194,6 +194,14 @@ data:
       - model: authentik_core.application
         identifiers: { slug: zigbee-garage-code }
         attrs: { name: Zigbee Garage Code, group: home, provider: !KeyOf zigbeegaragecode-provider, meta_icon: "https://cdn.jsdelivr.net/gh/selfhst/icons/svg/coder.svg", meta_launch_url: "https://zigbee-garage-code.${SECRET_DOMAIN}" }
+      # nats-nui
+      - model: authentik_providers_proxy.proxyprovider
+        identifiers: { name: Provider for NATS NUI }
+        id: natsnui-provider
+        attrs: { <<: *proxy, external_host: "https://nats-nui.${SECRET_DOMAIN}" }
+      - model: authentik_core.application
+        identifiers: { slug: nats-nui }
+        attrs: { name: NATS NUI, group: internal, provider: !KeyOf natsnui-provider, meta_icon: "https://cdn.jsdelivr.net/gh/cncf/artwork/projects/nats/icon/color/nats-icon-color.svg", meta_launch_url: "https://nats-nui.${SECRET_DOMAIN}" }
       # Embedded outpost: disables the k8s Ingress AND declaratively owns the assigned-
       # provider list. Adding an app = its 2 entries above (with id:) + one !KeyOf line here.
       - model: authentik_outposts.outpost
@@ -241,3 +249,4 @@ data:
             - !KeyOf blackbox-provider
             - !KeyOf zigbeecode-provider
             - !KeyOf zigbeegaragecode-provider
+            - !KeyOf natsnui-provider


### PR DESCRIPTION
## What

Deploys **NUI** ([nats-nui](https://github.com/nats-nui/nui)) — a web UI for NATS/JetStream — into the `database` namespace next to NATS. There was no NATS visualizer before; only the `nats-box` CLI and the `:8222` JSON monitoring endpoint.

Lets you browse streams (`fleet_a_tasks`, `fleet_a_results`, …), read/replay messages, inspect consumers, and publish/sub live — handy for the dispatch/session tracing we've been doing.

## How

Standard `app-template` app modeled on `outlook-bridge`:
- Image `ghcr.io/nats-nui/nui:0.9.3` (digest-pinned), HTTP port **31311**.
- 1Gi `ceph-rbd` PVC mounted at `/db` (NUI's SQLite for saved connections).
- Exposed via the `internal` gateway at `nats-nui.${SECRET_DOMAIN}`.
- Non-root (uid 1000), caps dropped, TCP probes on 31311.
- Wired into `apps/database/kustomization.yaml`.

## After merge (one-time)

Open `https://nats-nui.${SECRET_DOMAIN}` and add a connection to `nats://nats.database.svc:4222` (NATS here is unauthenticated, so no creds). It persists on the PVC.

Validated with `kubectl kustomize` (app + parent namespace build clean).

## Follow-ups (not in this PR)
- Pre-seed the NATS connection via a mounted CLI context so it's turnkey.
- If you'd rather have metrics dashboards too, add nats-surveyor + a Grafana dashboard (separate concern from this message-browser UI).