### PR TITLE
fix(nats-nui): run as uid 1001 to match image's baked-in user

### DIFF
--- a/kubernetes/apps/database/nats-nui/app/helmrelease.yaml
+++ b/kubernetes/apps/database/nats-nui/app/helmrelease.yaml
@@ -67,10 +67,14 @@ spec:
 
     defaultPodOptions:
       securityContext:
+        # The NUI image bakes in a `nui` user at uid/gid 1001; its entrypoint
+        # only execs the server directly when running as 1001 (any other uid
+        # takes a `su nui` path that fails without suid). Match it and let
+        # fsGroup grant write to the /db PVC.
         runAsNonRoot: true
-        runAsUser: 1000
-        runAsGroup: 1000
-        fsGroup: 1000
+        runAsUser: 1001
+        runAsGroup: 1001
+        fsGroup: 1001
         fsGroupChangePolicy: OnRootMismatch
 
     service:


### PR DESCRIPTION
## What

nats-nui was crashlooping post-merge (#3636) with:

```
chown: /db: Operation not permitted
su: must be suid to work properly
```

## Why

The [nui image](https://github.com/nats-nui/nui/blob/main/docker/entrypoint.sh) bakes in a `nui` user at **uid/gid 1001**. Its entrypoint only execs the server directly when `id -u == 1001`; any other uid falls through to `su -c ... nui`, which fails without a suid `su` and crashes the container. We were pinning uid **1000**.

## Fix

Align `runAsUser`/`runAsGroup`/`fsGroup` to **1001**. The entrypoint then execs directly and `/db` PVC writes go through `fsGroup`. Still non-root, caps dropped. The harmless `chown /db` warning may still print (non-owner) but is non-fatal.