### PR TITLE
feat(media): add radarr-es (Castilian Spanish) movie instance

### DIFF
--- a/kubernetes/apps/media/kustomization.yaml
+++ b/kubernetes/apps/media/kustomization.yaml
@@ -8,7 +8,7 @@ components:
 resources:
   - ./namespace.yaml
   # - ./media-nfs-storage/ks.yaml  # NFS PVCs - deprecated, using CephFS only
-  - ./storage/ks.yaml  # CephFS static PVs
+  - ./storage/ks.yaml # CephFS static PVs
   #- ./autobrr/ks.yaml
   - ./bazarr/ks.yaml
   - ./bazarr-uhd/ks.yaml
@@ -19,6 +19,7 @@ resources:
   # - ./huntarr/ks.yaml
   - ./radarr/ks.yaml
   - ./radarr-uhd/ks.yaml
+  - ./radarr-es/ks.yaml
   - ./kometa/ks.yaml
   - ./posterizarr/ks.yaml
   # - ./nzbget/ks.yaml

--- a/kubernetes/apps/media/radarr-es/app/externalsecret.yaml
+++ b/kubernetes/apps/media/radarr-es/app/externalsecret.yaml
@@ -1,0 +1,27 @@
+---
+# yaml-language-server: $schema=https://kubernetes-schemas.pages.dev/external-secrets.io/externalsecret_v1beta1.json
+apiVersion: external-secrets.io/v1
+kind: ExternalSecret
+metadata:
+  name: radarr-es
+spec:
+  secretStoreRef:
+    kind: ClusterSecretStore
+    name: infisical
+  target:
+    name: radarr-es-secret
+    template:
+      engineVersion: v2
+      mergePolicy: Replace
+      data:
+        RADARR__AUTH__APIKEY: "{{ .RADARR_ES_API_KEY }}"
+        PUSHOVER_API_TOKEN: "{{ .PUSHOVER_API_TOKEN }}"
+        PUSHOVER_USER_KEY: "{{ .PUSHOVER_USER_KEY }}"
+
+  dataFrom:
+    - find:
+        path: RADARR_ES_API_KEY
+    - find:
+        path: PUSHOVER_API_TOKEN
+    - find:
+        path: PUSHOVER_USER_KEY

--- a/kubernetes/apps/media/radarr-es/app/helmrelease.yaml
+++ b/kubernetes/apps/media/radarr-es/app/helmrelease.yaml
@@ -1,0 +1,93 @@
+---
+# yaml-language-server: $schema=https://raw.githubusercontent.com/bjw-s/helm-charts/main/charts/other/app-template/schemas/helmrelease-helm-v2.schema.json
+apiVersion: helm.toolkit.fluxcd.io/v2
+kind: HelmRelease
+metadata:
+  name: radarr-es # redeploy
+
+spec:
+  interval: 30m
+  chartRef:
+    kind: OCIRepository
+    name: app-template
+  install:
+    remediation:
+      retries: 3
+  upgrade:
+    cleanupOnFail: true
+    remediation:
+      strategy: rollback
+      retries: 3
+  dependsOn:
+    - name: volsync
+      namespace: storage
+  values:
+    controllers:
+      radarr-es:
+        annotations:
+          reloader.stakater.com/auto: "true"
+        containers:
+          app:
+            image:
+              repository: ghcr.io/home-operations/radarr
+              tag: 6.3.0.10514@sha256:ca30ff27d24c1fd548b1c8efd684b6a9238b7fed2bd5b834ea700aa09c16fe11
+            env:
+              TZ: "${TIME_ZONE}"
+              RADARR__APP__INSTANCENAME: Radarr (Español)
+              RADARR__APP__THEME: dark
+              RADARR__AUTH__METHOD: External
+              RADARR__AUTH__REQUIRED: DisabledForLocalAddresses
+              RADARR__LOG__DBENABLED: "False"
+              RADARR__LOG__LEVEL: info
+              RADARR__SERVER__PORT: &port 80
+              RADARR__UPDATE__BRANCH: develop
+              PUSHOVER_APP_URL: &host "radarr-es.${SECRET_DOMAIN_MEDIA}"
+              PUSHOVER_DEBUG: "false"
+              PUSHOVER_PRIORITY: "0"
+            envFrom:
+              - secretRef:
+                  name: radarr-es-secret
+            securityContext:
+              allowPrivilegeEscalation: false
+              readOnlyRootFilesystem: true
+              capabilities: { drop: ["ALL"] }
+            resources:
+              requests:
+                memory: 512Mi
+                cpu: 250m
+              limits:
+                memory: 5Gi
+                cpu: 2
+    defaultPodOptions:
+      securityContext:
+        runAsNonRoot: true
+        runAsUser: 1000
+        runAsGroup: 140
+        fsGroup: 150
+        fsGroupChangePolicy: OnRootMismatch
+        supplementalGroups: [10000]
+        seccompProfile: { type: RuntimeDefault }
+    service:
+      app:
+        controller: radarr-es
+        ports:
+          http:
+            port: *port
+    route:
+      app:
+        annotations:
+          authentik.home.arpa/forward-auth: "true"
+        hostnames: ["radarr-es.${SECRET_DOMAIN_MEDIA}"]
+        parentRefs:
+          - name: internal
+            namespace: network
+
+    persistence:
+      config:
+        existingClaim: radarr-es
+      tmp:
+        type: emptyDir
+      media:
+        existingClaim: media-cephfs-pvc
+        globalMounts:
+          - path: /media

--- a/kubernetes/apps/media/radarr-es/app/kustomization.yaml
+++ b/kubernetes/apps/media/radarr-es/app/kustomization.yaml
@@ -1,0 +1,7 @@
+---
+# yaml-language-server: $schema=https://json.schemastore.org/kustomization
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+resources:
+  - ./externalsecret.yaml
+  - ./helmrelease.yaml

--- a/kubernetes/apps/media/radarr-es/ks.yaml
+++ b/kubernetes/apps/media/radarr-es/ks.yaml
@@ -1,0 +1,35 @@
+---
+# yaml-language-server: $schema=https://kubernetes-schemas.pages.dev/kustomize.toolkit.fluxcd.io/kustomization_v1.json
+apiVersion: kustomize.toolkit.fluxcd.io/v1
+kind: Kustomization
+metadata:
+  name: &app radarr-es
+  namespace: &namespace media
+spec:
+  targetNamespace: *namespace
+  components:
+    - ../../../../flux/components/volsync/repository
+    - ../../../../flux/components/volsync/operations
+  commonMetadata:
+    labels:
+      app.kubernetes.io/name: *app
+  dependsOn:
+    - name: volsync
+      namespace: storage
+    - name: external-secrets-stores
+      namespace: external-secrets
+  path: ./kubernetes/apps/media/radarr-es/app
+  prune: true
+  sourceRef:
+    kind: GitRepository
+    name: flux-system
+    namespace: flux-system
+  wait: true
+  interval: 30m
+  retryInterval: 1m
+  timeout: 10m
+  postBuild:
+    substitute:
+      APP: *app
+      VOLSYNC_CAPACITY: 10Gi
+      VOLSYNC_CACHE_CAPACITY: 20Gi

--- a/kubernetes/apps/media/recyclarr/app/config/recyclarr.yml
+++ b/kubernetes/apps/media/recyclarr/app/config/recyclarr.yml
@@ -150,6 +150,48 @@ radarr:
           - name: HD Bluray + WEB
           - name: Bluray + WEB 1080p
 
+  radarr-es:
+    base_url: http://radarr-es.media.svc.cluster.local
+    api_key: !env_var RADARR_ES_API_KEY
+    delete_old_custom_formats: true
+    media_management:
+      propers_and_repacks: do_not_prefer
+    media_naming:
+      folder: plex-imdb
+      movie:
+        rename: true
+        standard: plex-imdb
+    quality_definition:
+      type: movie
+    quality_profiles:
+      # Permissive 1080p profile — Castilian releases are far scarcer than English,
+      # so accept Bluray-1080p + WEBDL/WEBRip-1080p. NO reset_unmatched_scores: the
+      # Castellano/Latino language custom formats are created + scored manually in the
+      # radarr-es UI (TRaSH has no trash_ids for them), and the profile's Language gate
+      # is set to Spanish in the UI. Both are left untouched by recyclarr on sync.
+      - name: Bluray + WEB 1080p (ES)
+        upgrade:
+          allowed: true
+          until_quality: Bluray-1080p
+          until_score: 10000
+        min_format_score: 0
+        quality_sort: top
+        qualities:
+          - name: Bluray-1080p
+          - name: WEB 1080p
+            qualities:
+              - WEBDL-1080p
+              - WEBRip-1080p
+    custom_formats:
+      - # Unwanted — trimmed vs. the English instances (Scene + Retags dropped so the
+        # scarcer Castilian pool isn't starved); keeps the genuinely-bad releases out.
+        trash_ids:
+          - b6832f586342ef70d9c128d40c07b872 # Bad Dual Groups
+          - ae9b7c9ebde1f3bd336a8cbd1ec4c5e5 # No-RlsGroup
+          - 7357cf5161efbf8c4d5d0c30b4815ee2 # Obfuscated
+        assign_scores_to:
+          - name: Bluray + WEB 1080p (ES)
+
   radarr-uhd:
     base_url: http://radarr-uhd.media.svc.cluster.local
     api_key: !env_var RADARR_UHD_API_KEY

--- a/kubernetes/apps/media/recyclarr/app/externalsecret.yaml
+++ b/kubernetes/apps/media/recyclarr/app/externalsecret.yaml
@@ -15,8 +15,10 @@ spec:
     - find:
         path: RADARR_UHD_API_KEY
     - find:
-        path : SONARR_UHD_API_KEY
+        path: SONARR_UHD_API_KEY
     - find:
         path: SONARR_API_KEY
     - find:
         path: RADARR_API_KEY
+    - find:
+        path: RADARR_ES_API_KEY


### PR DESCRIPTION
## What & why

Adds a **third parallel Radarr instance, `radarr-es`**, for movies in **Spanish from Spain (Castilian)** — for my wife, a native speaker.

Radarr is one-file-per-movie-per-instance, so a single instance can't hold both an English and a Spanish version of the same film (the same reason `radarr` and `radarr-uhd` are already separate). `radarr-es` is cloned from the HD `radarr` with its own root folder, own API key, syncing from the same Prowlarr and managed by Recyclarr.

**Separate folders for the robots, one library for the humans:** each instance keeps its own root folder so they don't fight; Plex then folds `/media/movies-es` into the existing Movies library so each film shows **once with a version picker (1080p / 4K / Español)**.

## Design decisions
- **1080p only** (Castilian 4K is scarce) — clones HD `radarr`, not `radarr-uhd`.
- **Prefer Castilian, allow Latino** — Castellano scored higher so it wins when both exist; LATAM not hard-blocked.
- **Permissive quality profile** (`Bluray + WEB 1080p (ES)`) with trimmed "Unwanted" CFs (drops Scene/Retags) so the scarcer Castilian pool isn't starved.

## Recyclarr note (important)
TRaSH publishes **no** Castilian/Latino trash_ids, and Recyclarr can't set a manual profile's Language. Both are handled deliberately:
- The manual profile means Recyclarr leaves the **Language field alone** → the `Language = Spanish` gate set in the UI survives every sync.
- **No `reset_unmatched_scores`** → Recyclarr never wipes the hand-made Castellano/Latino language custom formats.

## Post-merge steps (click-ops — can't live in the repo)
1. **Infisical:** create `RADARR_ES_API_KEY`, then `task kubernetes:sync-secrets`.
2. **radarr-es UI:** add root folder `/media/movies-es`; set profile default; set profile **Language = Spanish**; import Castellano (+) / Latino (small +) custom formats.
3. **Prowlarr:** add `radarr-es` as an app (Full Sync). Recommended: enable + tag Spanish trackers, sync that tag to `radarr-es` only.
4. **Plex:** add `/media/movies-es` to the existing **Movies** library.

## Validation
- `kubectl kustomize` builds clean for both `radarr-es/app` and the `media` namespace.
- `validate-recyclarr` skill: no errors; trash_ids are verbatim reuse of live IDs; profile structure mirrors the live `radarr-uhd` custom profile.
- gitleaks + yaml formatters pass (pre-commit).