### PR TITLE
fix(konflate): raise memory limit 1Gi -> 2Gi to stop OOMKill crashloop

### DIFF
--- a/kubernetes/apps/flux-system/konflate/app/helmrelease.yaml
+++ b/kubernetes/apps/flux-system/konflate/app/helmrelease.yaml
@@ -39,5 +39,6 @@ spec:
     resources:
       requests:
         cpu: 50m
+        memory: 512Mi
       limits:
-        memory: 1Gi
+        memory: 2Gi


### PR DESCRIPTION
konflate has been OOMKilled (exit 137) in a crashloop for ~3 days. The 0.4.0 upgrade (#3680) brought upstream's serialized sweeping renders fix, which helped (pod survives 80s+ instead of 10s), but with a cold diff cache and ~19 open PRs it still exceeds 1Gi during the initial render sweep (observed 808Mi+ steady climb before the kill).

- limits.memory: 1Gi -> 2Gi
- requests.memory: add 512Mi (was unset; pod idles well above the old implicit floor)