### PR TITLE
fix: clear easy alertmanager alerts (opencti-minio PVC, dcgm scrapeTimeout)

### DIFF
--- a/kubernetes/apps/observability/exporters/dcgm-exporter/app/helmrelease.yaml
+++ b/kubernetes/apps/observability/exporters/dcgm-exporter/app/helmrelease.yaml
@@ -57,6 +57,7 @@ spec:
     runtimeClassName: nvidia
     serviceMonitor:
       interval: 15s
+      scrapeTimeout: 10s
       honorLabels: true
     livenessProbe:
       initialDelaySeconds: 60

--- a/kubernetes/apps/security/opencti/app/helmrelease.yaml
+++ b/kubernetes/apps/security/opencti/app/helmrelease.yaml
@@ -157,7 +157,7 @@ spec:
       enabled: true
       persistence:
         enabled: true
-        size: 40Gi
+        size: 60Gi
         storageClass: ceph-rbd
       resources:
         requests:


### PR DESCRIPTION
Clears two of the currently-firing Alertmanager alerts:

## KubePersistentVolumeFillingUp (critical) — opencti-minio
The 40Gi ceph-rbd PVC backing OpenCTI's MinIO is at 40G/40G (0 bytes free on /export). Expand to 60Gi — ceph-rbd has `allowVolumeExpansion: true`, so this is an online expand with no pod disruption.

## PrometheusOperatorRejectedResources — dcgm-exporter
The operator has rejected the dcgm-exporter ServiceMonitor since 2026-07-16: chart default `scrapeTimeout: 25s` > our `interval: 15s`. Set `scrapeTimeout: 10s` so the ServiceMonitor is accepted and GPU metrics scrape again.

(Third easy win, the stale failed `media/kometa-29740680` Job, was deleted directly — latest kometa run completed fine.)