### PR TITLE
docs(skills): route-era refresh — fix stale scaffolds, dedupe rules, add roundtable skill

### DIFF
--- a/.claude/skills/debug-k8s/SKILL.md
+++ b/.claude/skills/debug-k8s/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: debug-k8s
-description: Troubleshoot Kubernetes pods, services, networking, storage, and resource issues across the dapper-cluster
+description: Troubleshoot live workloads on the dapper-cluster — a pod CrashLooping/Pending/OOMKilled, a service unreachable, a PVC stuck, an app down after a deploy. Prefers the repo's task helpers (view-secret, node-shell, browse-pvc, restart-helmrelease) over hand-rolled kubectl. For Flux reconciliation failures use the flux-check skill instead.
 allowed-tools: Bash, Read, Grep, Glob
 ---
 
@@ -70,12 +70,8 @@ KUBECONFIG=~/projects/dapper-cluster/kubeconfig kubectl describe pvc <pvc> -n <n
 
 ### 6. Flux/GitOps Issues
 
-If the pod issue originates from a bad deployment:
-
-```bash
-KUBECONFIG=~/projects/dapper-cluster/kubeconfig kubectl get hr -n <namespace> <app-name>
-KUBECONFIG=~/projects/dapper-cluster/kubeconfig kubectl get kustomizations.kustomize.toolkit.fluxcd.io -n flux-system <app-name>
-```
+If the pod issue originates from a bad deployment (HelmRelease/Kustomization not Ready),
+switch to the `flux-check` skill — it owns that diagnosis path.
 
 ### 7. Cross-Reference with Git
 

--- a/.claude/skills/find-app/SKILL.md
+++ b/.claude/skills/find-app/SKILL.md
@@ -69,20 +69,21 @@ resources:
 
 ### 5. Critical Rules
 
+This list is the **canonical copy** — other skills (validate-helm) point here; edit it in one place.
+
 - YAML anchor: always use `&app` (not `&appname`)
 - **NEVER rename `controllers.main`** on existing apps - controller name is immutable in Deployment selectors
 - For NEW apps, name the controller after the app (e.g., `controllers.sonarr`) with `service.app.controller: sonarr`
 - HelmRelease spec order: `interval -> chartRef -> install -> upgrade -> dependsOn -> values`
-- Values order: `controllers -> defaultPodOptions -> service -> ingress -> persistence`
+- Values order: `controllers -> defaultPodOptions -> service -> route -> persistence`
+- Expose HTTP via a `route:` block on the Envoy Gateways (`parentRefs: internal | external`, namespace `network`) — **never an `ingress:` block; nginx is gone.** Details/edge cases: `gateway-route` skill
+- Uptime monitoring is automatic once the app has a route (gatus-sidecar auto-discovery) — no Gatus components or `GATUS_*` substitutions; see the `gatus-monitoring` skill for probe overrides
 - VolSync apps: set `wait: true` and `timeout: 10m` in ks.yaml
 - Stateless apps: set `wait: false` and `timeout: 5m` in ks.yaml
 - VolSync ks.yaml needs `postBuild.substitute.APP` and `VOLSYNC_CAPACITY`
-- Gatus ks.yaml needs `postBuild.substitute.GATUS_SUBDOMAIN` and `GATUS_DOMAIN`
 - sourceRef is always `name: flux-system, namespace: flux-system`
 - app-template chartRef omits namespace (resolved from common component)
 - Cluster substitution variables available: `${TIME_ZONE}`, `${SECRET_DOMAIN}`, `${SECRET_DOMAIN_MEDIA}`, `${SECRET_DOMAIN_PERSONAL}`
-- Internal ingress: `className: internal` with `external-dns.alpha.kubernetes.io/target: "internal.${SECRET_DOMAIN}"`
-- TLS secret naming: `${SECRET_DOMAIN/./-}-tls` (dots replaced with dashes)
 - Default security context: `runAsUser: 1000, runAsGroup: 150, fsGroup: 150`
 - Secrets come from Infisical via ExternalSecret, not SOPS (SOPS is only for cluster-level secrets)
 

--- a/.claude/skills/find-app/references/templates.md
+++ b/.claude/skills/find-app/references/templates.md
@@ -31,7 +31,11 @@ spec:
   timeout: 5m
 ```
 
-#### ks.yaml - With VolSync + Gatus (most common for stateful apps)
+#### ks.yaml - With VolSync (most common for stateful apps)
+
+No Gatus component or `GATUS_*` substitutions — uptime monitoring is automatic once the
+app has an HTTPRoute (gatus-sidecar auto-discovery; see the `gatus-monitoring` skill).
+The old `flux/components/gatus/*` components no longer exist.
 
 ```yaml
 ---
@@ -44,7 +48,6 @@ metadata:
 spec:
   targetNamespace: *namespace
   components:
-    - ../../../../flux/components/gatus/guarded
     - ../../../../flux/components/volsync/repository
     - ../../../../flux/components/volsync/operations
   commonMetadata:
@@ -68,8 +71,6 @@ spec:
   postBuild:
     substitute:
       APP: *app
-      GATUS_SUBDOMAIN: <app-name>
-      GATUS_DOMAIN: ${SECRET_DOMAIN}
       VOLSYNC_CAPACITY: 5Gi
 ```
 
@@ -134,22 +135,12 @@ spec:
         ports:
           http:
             port: &port <port>
-    ingress:
+    route:
       app:
-        annotations:
-          external-dns.alpha.kubernetes.io/target: "internal.${SECRET_DOMAIN}"
-        className: internal
-        hosts:
-          - host: &host "<app-name>.${SECRET_DOMAIN}"
-            paths:
-              - path: /
-                service:
-                  identifier: app
-                  port: http
-        tls:
-          - hosts:
-              - *host
-            secretName: "${SECRET_DOMAIN/./-}-tls"
+        hostnames: ["<app-name>.${SECRET_DOMAIN}"]
+        parentRefs:
+          - name: internal # internal | external — see the gateway-route skill
+            namespace: network
     persistence:
       config:
         existingClaim: <app-name>

--- a/.claude/skills/flux-check/SKILL.md
+++ b/.claude/skills/flux-check/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: flux-check
-description: Troubleshoot FluxCD reconciliation issues, check Flux component status, and diagnose GitOps deployment problems
+description: Troubleshoot Flux CD on the dapper-cluster — a Kustomization or HelmRelease not Ready, changes merged but not applying, dependency/substitution errors, a stuck or wedged release. Use when "flux get all" shows False, a deploy didn't land, or reconciliation errors appear. For pod-level symptoms use debug-k8s instead.
 allowed-tools: Read, Edit, Bash, Grep, Glob
 ---
 

--- a/.claude/skills/roundtable/SKILL.md
+++ b/.claude/skills/roundtable/SKILL.md
@@ -1,0 +1,73 @@
+---
+name: roundtable
+description: Work on the Round Table agent fleet's cluster config (roundtable namespace) — bump the operator chart/image, add or retune a Knight, edit a Chain, fix fleet RBAC/secrets. Use for "bump roundtable", "operator <sha> + chart 0.x.y", knight/chain changes, or fleet resources not reconciling. Development of the operator, chart, and knight images happens in ~/projects/roundtable, NOT here.
+allowed-tools: Read, Edit, Write, Bash, Grep, Glob
+---
+
+# Round Table fleet (cluster side)
+
+This repo only **deploys** the fleet. The operator code, Helm chart, knight/dashboard
+images, and arsenal skills live in `~/projects/roundtable` (chart + images publish to
+`ghcr.io/dapperdivers/roundtable*`). If the task is "fix the operator's behavior",
+that's the other repo; this skill covers wiring it into the cluster.
+
+## Layout (`kubernetes/apps/roundtable/`)
+
+| Dir               | Holds                                                                                                                      |
+| ----------------- | -------------------------------------------------------------------------------------------------------------------------- |
+| `operator/`       | `roundtable-operator` HelmRelease (chart + operator image pin), nix store/buildqueue PVCs, dashboard HTTPRoute             |
+| `knights/`        | `Knight` CRs (one per agent) + per-knight secrets, and the `RoundTable` CRs (`personal`, `roundtable-dev`) that group them |
+| `chains/`         | `Chain` CRs — scheduled multi-knight workflows (morning-briefing, night-watch, fleet-self-improvement)                     |
+| `chelonian/`      | The chelonian dev-team table (`cl-*` knights)                                                                              |
+| `infrastructure/` | RBAC, `roundtable-secret`, shared-workspace/vault PVCs, LimitRange, Prometheus monitors + rules                            |
+| `agent-sandbox/`  | Sandbox GitRepository + controller                                                                                         |
+
+All CRs are `ai.roundtable.io/v1alpha1`. CRDs come from the chart
+(`install/upgrade.crds: CreateReplace` on the HelmRelease).
+
+## The routine job: bump operator chart + image
+
+The most common roundtable commit. In `operator/app/helmrelease.yaml`, **two pins move
+together**:
+
+- `spec.chart.spec.version` — chart version (HelmRepository: `kubernetes/flux/meta/repositories/helm/roundtable.yaml`)
+- `spec.values.image.tag` — operator image, pinned to the **full git SHA** from the
+  roundtable repo (`git -C ~/projects/roundtable log -1 --format=%H` once CI has published it)
+
+Commit style (see `git log --oneline -- kubernetes/apps/roundtable`):
+`fix(roundtable): chart 0.14.4 — session history/replay` or
+`fix(roundtable): operator <short-sha> + chart 0.x.y — <what>`.
+
+piKnight and dashboard image tags are pinned **inside the chart's values.yaml** (since
+chart 0.12.3) — bump those in the roundtable repo, not here.
+
+Verify after merge/reconcile:
+
+```bash
+flux reconcile kustomization roundtable-operator -n flux-system
+kubectl -n roundtable get pods
+kubectl -n roundtable get knights,chains   # READY/last-run columns
+```
+
+## Knights and Chains
+
+- A `Knight` pins its `domain`, `model`, `skills`, nix `tools`, and NATS subjects. The
+  `ai.roundtable.io/table` label + NATS subject prefix must match its table — **chains
+  cannot span tables** (step subjects use the chain's table prefix), so every `knightRef`
+  in a Chain must live on that Chain's `roundTableRef` table.
+- Chain kill switch: `spec.suspended: true` (patchable live for an emergency stop).
+- Knight env secrets: per-knight `*-secret.yaml` in `knights/app/` plus the shared
+  `roundtable-secret` (infrastructure/) referenced by the `RoundTable` CRs.
+
+## Gotchas
+
+- **`notify.allowedURLPrefixes` on the operator HR is the SSRF guard** for completion
+  webhooks — anyone who can create a Chain controls `notify.url`. Keep it pinned to
+  molt's gateway hook endpoint; don't loosen it to "fix" a webhook.
+- **The shared workspace PVC persists across missions.** Uncommitted leftovers from a
+  previous mission pollute later diffs/verifications — if a knight reports mysterious
+  unrelated changes, suspect stale workspace state, not the current mission.
+- **A chain that stops progressing may be wedged on cached NATS KV state**, not broken
+  config — check the operator logs and the chain's KV entries before rewriting the Chain.
+- The `LimitRange` in `infrastructure/` applies to knight pods — a knight OOMKilled or
+  refusing to schedule may be hitting it rather than its own resources block.

--- a/.claude/skills/validate-helm/SKILL.md
+++ b/.claude/skills/validate-helm/SKILL.md
@@ -42,20 +42,14 @@ Common validation errors:
 
 ### 4. Check Canonical Structure
 
-**HelmRelease spec order:** `interval -> chartRef -> install -> upgrade -> dependsOn -> values`
+The full structure/naming rules are maintained in ONE place: the `find-app` skill,
+section "Critical Rules" (`.claude/skills/find-app/SKILL.md`) — apply those. The
+validation-critical headlines:
 
-**app-template values order:** `controllers -> defaultPodOptions -> service -> ingress -> persistence`
-
-**app-template patterns:**
-
-- Controller named after the app: `controllers.<app-name>.containers.app`
-- Service references controller: `service.app.controller: <app-name>`
-- Ingress uses service identifier: `service.identifier: app, port: http`
-- Reloader annotation: `reloader.stakater.com/auto: "true"`
-- Security context: `runAsUser: 1000, runAsGroup: 150, fsGroup: 150, fsGroupChangePolicy: OnRootMismatch`
-- Secrets via envFrom: `secretRef.name: <app-name>-secret` (from ExternalSecret)
-- Cluster vars available: `${TIME_ZONE}`, `${SECRET_DOMAIN}`, `${SECRET_DOMAIN_MEDIA}`
-- TLS secret: `${SECRET_DOMAIN/./-}-tls`
+- **HelmRelease spec order:** `interval -> chartRef -> install -> upgrade -> dependsOn -> values`
+- **app-template values order:** `controllers -> defaultPodOptions -> service -> route -> persistence`
+- HTTP exposure is a `route:` block on the Envoy Gateways — an `ingress:` block in a
+  live app is legacy (nginx is gone); see the `gateway-route` skill for conversion.
 
 ### 5. Apply Fixes
 

--- a/.claude/skills/validate-recyclarr/SKILL.md
+++ b/.claude/skills/validate-recyclarr/SKILL.md
@@ -1,146 +1,32 @@
 ---
 name: validate-recyclarr
-description: Validate recyclarr.yml config against official documentation
+description: Validate or update kubernetes/apps/media/recyclarr/app/config/recyclarr.yml against current recyclarr.dev docs and TRaSH guides. Use when editing recyclarr config, adding a *arr instance to it, after a recyclarr major-version bump, or when the sync CronJob logs deprecation/unknown-template errors.
 allowed-tools: Read, WebFetch, WebSearch, Grep, Glob
 ---
 
-# Recyclarr Configuration Validator
+# Recyclarr config validation
 
-You are validating a recyclarr.yml configuration file against the official Recyclarr documentation.
+Config: `kubernetes/apps/media/recyclarr/app/config/recyclarr.yml` — instances
+`sonarr`, `sonarr-uhd`, `radarr`, `radarr-uhd`. Config was migrated to the v8
+format (2026-03); don't reintroduce pre-v8 syntax.
 
-## Configuration File Location
+## Process
 
-The recyclarr.yml config is located at:
-`kubernetes/apps/media/recyclarr/app/config/recyclarr.yml`
+1. Read the config; note templates, `trash_ids`, quality profiles per instance.
+2. Verify against the live docs (they change often — never validate from memory):
+   - Config reference: <https://recyclarr.dev/wiki/yaml/config-reference/>
+     (subpages: `quality-definition/`, `custom-formats/`, `media-naming/`,
+     `quality-profiles/`, `include/`)
+   - Template/trash_id catalogs: <https://recyclarr.dev/wiki/guide-configs/sonarr/>
+     and `.../radarr/`
+3. Check each: `include.template` names exist; `trash_ids` current (not
+   deprecated/renamed); `quality_definition.type` valid (`series`/`movie`/`anime`);
+   `media_naming` options valid for the app (Sonarr and Radarr differ); profile
+   names match what the templates create.
+4. Also WebSearch recyclarr release notes for breaking changes since the pinned
+   image version (Renovate bumps the image without checking config compat).
 
-## Validation Process
+## Report
 
-### Step 1: Read the Current Configuration
-
-First, read the recyclarr.yml file to understand the current configuration.
-
-### Step 2: Search Official Documentation
-
-Use WebSearch and WebFetch to search the following Recyclarr documentation sources for the latest information:
-
-**Primary Documentation URLs:**
-
-- Config Reference: https://recyclarr.dev/wiki/yaml/config-reference/
-- Quality Definitions: https://recyclarr.dev/wiki/yaml/config-reference/quality-definition/
-- Custom Formats: https://recyclarr.dev/wiki/yaml/config-reference/custom-formats/
-- Media Naming: https://recyclarr.dev/wiki/yaml/config-reference/media-naming/
-- Quality Profiles: https://recyclarr.dev/wiki/yaml/config-reference/quality-profiles/
-- Include Templates: https://recyclarr.dev/wiki/yaml/config-reference/include/
-
-**TRaSH Guides Integration:**
-
-- Sonarr Templates: https://recyclarr.dev/wiki/guide-configs/sonarr/
-- Radarr Templates: https://recyclarr.dev/wiki/guide-configs/radarr/
-
-### Step 3: Validation Checklist
-
-For each instance (sonarr, sonarr-uhd, radarr, radarr-uhd), validate:
-
-1. **Schema Compliance**
-   - Verify the YAML structure matches the official schema
-   - Check for deprecated configuration options
-
-2. **Template Validation**
-   - Verify all `include.template` values exist in official TRaSH guides
-   - Cross-reference template names with: https://recyclarr.dev/wiki/guide-configs/
-
-3. **Custom Format Trash IDs**
-   - Verify all `trash_ids` are valid and current
-   - Search for any deprecated or renamed trash IDs
-   - Check for newer recommended custom formats
-
-4. **Quality Definition Types**
-   - Verify `quality_definition.type` values are valid (series, movie, anime)
-
-5. **Media Naming**
-   - Validate `media_naming` options against current documentation
-   - Check for any deprecated naming formats
-
-6. **Quality Profile Names**
-   - Verify quality profile names match those created by templates
-   - Common profiles: WEB-1080p, WEB-2160p, HD Bluray + WEB, UHD Bluray + WEB
-
-7. **API Configuration**
-   - Verify base_url format is correct
-   - Check that env_var syntax is valid
-
-### Step 4: Search for Updates
-
-Use WebSearch to find:
-
-```
-site:recyclarr.dev "breaking changes" OR "deprecated" OR "new feature" 2024 2025
-```
-
-Search for recent changes that might affect the configuration.
-
-### Step 5: Generate Report
-
-Provide a detailed report with:
-
-1. **Configuration Summary**
-   - List all configured instances
-   - Templates being used
-   - Custom formats applied
-
-2. **Validation Results**
-   - Green checkmarks for valid items
-   - Warnings for potentially outdated items
-   - Errors for invalid configurations
-
-3. **Recommendations**
-   - Suggest any newer templates available
-   - Recommend additional custom formats if beneficial
-   - Note any configuration improvements
-
-4. **Documentation Links**
-   - Provide direct links to relevant documentation for any issues found
-
-## Output Format
-
-```markdown
-## Recyclarr Configuration Validation Report
-
-### Instances Found
-
-- [ ] sonarr (1080p)
-- [ ] sonarr-uhd (4K)
-- [ ] radarr (HD)
-- [ ] radarr-uhd (4K)
-
-### Template Validation
-
-| Instance | Template | Status | Notes |
-| -------- | -------- | ------ | ----- |
-| ...      | ...      | ...    | ...   |
-
-### Custom Format Validation
-
-| Trash ID | Name | Status | Notes |
-| -------- | ---- | ------ | ----- |
-| ...      | ...  | ...    | ...   |
-
-### Issues Found
-
-1. [SEVERITY] Description - Link to docs
-
-### Recommendations
-
-1. Description - Link to docs
-
-### Documentation References
-
-- [Link description](url)
-```
-
-## Important Notes
-
-- Always use the most recent documentation from recyclarr.dev
-- The TRaSH Guides are updated frequently - verify trash_ids are current
-- Check for any v4 vs v5 Sonarr/Radarr compatibility notes
-- Media naming options differ between Sonarr and Radarr
+Per instance: what's valid, what's deprecated/broken (with doc link), and any
+newer recommended templates/custom formats worth adopting. Severity-ordered.

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -26,22 +26,24 @@ Multiple Claude Code sessions often run against this repo at once. To avoid bran
 ### Kubernetes Applications Structure (`kubernetes/apps/`)
 
 - **`actions-runner-system/`** - GitHub Actions self-hosted runners
-- **`ai/`** - AI/ML workloads (LiteLLM, n8n, Ollama, Open WebUI, Wyoming Whisper)
+- **`ai/`** - AI/ML workloads (Ollama, OpenClaw, Hermes, Speaches, voice ingest)
 - **`cert-manager/`** - TLS certificate management
-- **`database/`** - Database services (CloudNative-PG, Dragonfly Redis, EMQX)
+- **`database/`** - Database services (CloudNative-PG, Dragonfly Redis, EMQX, NATS)
 - **`default/`** - Default namespace applications
+- **`dev/`** - Development tooling
 - **`external-secrets/`** - External secrets management
 - **`flux-system/`** - Flux CD GitOps operator
 - **`home-automation/`** - Home automation stack (ESPHome, Home Assistant, Node-RED, Zigbee2MQTT)
 - **`kube-system/`** - Core Kubernetes system components
 - **`kyverno/`** - Policy engine for Kubernetes
 - **`media/`** - Media server stack (Plex, \*arr apps, Overseerr, etc.)
-- **`network/`** - Networking components (Ingress, DNS, SMTP relay)
-- **`observability/`** - Monitoring stack (Prometheus, Grafana, Loki, Gatus)
-- **`openebs-system/`** - OpenEBS storage system
+- **`network/`** - Networking components (Envoy Gateway, DNS, SMTP relay)
+- **`observability/`** - Monitoring stack (Prometheus, Grafana, VictoriaLogs, vmalert, Gatus)
+- **`rook-ceph/`** - Rook-Ceph storage cluster (ceph-rbd RWO, cephfs RWX)
+- **`roundtable/`** - Round Table AI agent fleet (operator, knights, chains)
 - **`security/`** - Security applications (Authentik, Vaultwarden)
 - **`selfhosted/`** - Self-hosted applications (Actual, Atuin, Paperless-NGX, etc.)
-- **`storage/`** - Storage providers and volume management
+- **`storage/`** - Storage support services (VolSync, snapshot-controller, Minio)
 - **`system-upgrade/`** - Automated system upgrades
 
 ## Key Patterns
@@ -208,11 +210,11 @@ For complex applications with multiple components (like Cilium with app + gatewa
 
 - **OS**: Talos Linux (immutable Kubernetes-focused OS)
 - **GitOps**: Flux CD v2
-- **Networking**: Cilium CNI with L2 announcements
-- **Storage**: OpenEBS for local storage, CSI NFS driver for NAS
-- **Monitoring**: Prometheus, Grafana, Loki, Promtail
+- **Networking**: Cilium CNI with L2 announcements; Envoy Gateway (Gateway API) for HTTP routing
+- **Storage**: Rook-Ceph (ceph-rbd for RWO, cephfs for RWX); VolSync (restic) for backups
+- **Monitoring**: Prometheus (kube-prometheus-stack), Grafana (grafana-operator), VictoriaLogs + fluent-bit, vmalert, Gatus
 - **Security**: Authentik (SSO), Vaultwarden, cert-manager
-- **Secrets**: External Secrets Operator with SOPS/age encryption
+- **Secrets**: External Secrets Operator with Infisical backend (SOPS/age for cluster-level secrets)
 - **Automation**: Renovate for dependency updates
 
 ## Common Tasks
@@ -277,11 +279,11 @@ Comprehensive home automation using Home Assistant, ESPHome, Node-RED, and Zigbe
 
 ### AI/ML Services
 
-Local AI inference with Ollama, LiteLLM proxy, Open WebUI, and automation workflows via n8n.
+Local AI inference with Ollama (2x Tesla P100), speech services (Speaches), the OpenClaw/Hermes assistants, and the Round Table agent fleet (`roundtable/` namespace: operator, knights, scheduled chains).
 
 ### Observability
 
-Full-stack monitoring with Prometheus metrics, Grafana dashboards, Loki logging, and Gatus uptime monitoring.
+Full-stack monitoring with Prometheus metrics, Grafana dashboards (grafana-operator CRs), VictoriaLogs log aggregation with vmalert log-based alerting, and Gatus uptime monitoring (auto-discovered from HTTPRoutes).
 
 ### Self-hosted Applications
 
@@ -290,7 +292,7 @@ Various productivity and utility applications including Paperless-NGX, Actual bu
 ## External Integrations
 
 - **DNS**: External DNS with Cloudflare
-- **Ingress**: NGINX ingress controllers (internal/external)
+- **Routing**: Envoy Gateway internal/external Gateways (Gateway API HTTPRoutes); external traffic arrives via Cloudflare tunnel
 - **Certificates**: Let's Encrypt via cert-manager
 - **Monitoring**: Kromgo for external status reporting
 - **Secrets**: Infisical for secret management


### PR DESCRIPTION
Full review of the in-repo Claude skills against how the repo actually works today turned up pre-gateway-migration content that would actively mislead. This PR fixes it and fills the one gap the commit history exposed.

## Fixes
- **find-app**: templates still scaffolded nginx-era \`ingress:\` blocks and a ks.yaml referencing \`flux/components/gatus/guarded\` + \`GATUS_*\` substitutions — those components no longer exist, so a scaffolded stateful app failed \`kustomize build\` outright. Now scaffolds \`route:\` blocks and the current VolSync-only ks.yaml (mirrors \`ai/speaches\`).
- **validate-helm**: values order and patterns updated to the route era; its duplicated structure-rules list (which had drifted out of agreement with find-app) is replaced with a pointer to the canonical copy in find-app.
- **debug-k8s / flux-check**: symptom-based descriptions so they trigger reliably; each now defers to the other instead of overlapping.
- **validate-recyclarr**: slimmed from 147 lines to the essentials (doc URLs + checklist); notes the v8-format migration.

## New
- **roundtable skill**: the most common manual commit type (operator chart+image bumps, knight/chain edits) had no skill. Thin cluster-side skill covering layout, the two-pins-move-together bump procedure, table/chain constraints, and known gotchas. Operator development stays in the roundtable repo.

## Docs
- **CLAUDE.md** tech stack refreshed to reality: Rook-Ceph (not OpenEBS), Envoy Gateway (not NGINX), VictoriaLogs/fluent-bit/vmalert (not Loki/Promtail), Infisical via ESO, namespace list gains rook-ceph/roundtable/dev.

No manifest changes — skills and docs only.