### PR TITLE
fix(renovate): close automerge coverage gaps and make deny rules authoritative

### DIFF
--- a/.renovate/autoMerge.json5
+++ b/.renovate/autoMerge.json5
@@ -3,46 +3,17 @@
   // Use image creation date when releaseTimestamp is missing (common for GHCR images).
   // Without this, minimumReleaseAge stays PENDING forever for images without timestamps.
   minimumReleaseAgeBehaviour: "creation-date-only",
+  //
+  // RULE ORDER MATTERS. Renovate applies the LAST matching rule per field, so this
+  // file is ordered allow-rules first, deny-rules last. Anything matched by a
+  // "Disable automerge" rule at the bottom stays manual no matter what an allow
+  // rule above it says. Add new allow rules ABOVE the deny block.
+  //
   packageRules: [
-    // Exclude networking and storage packages from automerge
     {
-      description: "Disable automerge for networking packages",
-      matchPackageNames: [
-        "cilium",
-        "multus",
-        "ingress-nginx",
-        "external-dns",
-        "cloudflared",
-        "k8s-gateway",
-        "coredns",
-        "/cilium/",
-        "/nginx/",
-        "/cloudflare/",
-      ],
-      automerge: false,
-    },
-    {
-      description: "Disable automerge for storage packages",
-      matchPackageNames: [
-        "openebs",
-
-        "volsync",
-        "minio",
-        "/openebs/",
-        "/minio/",
-        "/rook/",
-      ],
-      automerge: false,
-    },
-    {
-      description: "Disable automerge for dapperdivers images",
-      matchPackageNames: ["/dapperdivers/"],
-      automerge: false,
-    },
-    {
-      description: "Auto-merge all ghcr.io minor/patch updates (catch-all)",
+      description: "Auto-merge trusted-registry minor/patch updates (catch-all)",
       matchDatasources: ["docker"],
-      matchPackageNames: ["/ghcr.io/"],
+      matchPackageNames: ["/ghcr.io/", "/registry.k8s.io/"],
       excludePackageNames: [
         // Networking
         "/cilium/",
@@ -80,6 +51,8 @@
         "/ghcr.io/",
         "/linuxserver/",
         "/hotio/",
+        // Docker Hub images pinned to a rolling tag + digest (kometa :nightly)
+        "/kometateam/",
       ],
       ignoreTests: false,
     },
@@ -148,27 +121,27 @@
     {
       description: "Auto-merge Helm chart minor and patch updates",
       matchManagers: ["helm-values", "flux"],
-      // Re-state the networking/storage exclusions: Renovate applies the LAST
-      // matching rule per field, so without these this rule silently re-enables
-      // automerge for flux-managed charts (e.g. the cilium OCIRepository) that
-      // the disable rules above intended to hold.
-      matchPackageNames: [
-        "*",
-        "!/cilium/",
-        "!/nginx/",
-        "!/cloudflare/",
-        "!/coredns/",
-        "!/external-dns/",
-        "!/k8s-gateway/",
-        "!/multus/",
-        "!/openebs/",
-        "!/minio/",
-        "!/rook/",
-        "!/volsync/",
-      ],
+      // The networking/storage exclusions this rule used to re-state inline are now
+      // handled by the deny block at the bottom of the file, which runs last and
+      // wins. Renovate rejects `matchPackageNames: ["*", "!/cilium/", ...]` as a
+      // config error ("* along with other patterns"), so the list is gone entirely:
+      // flux-managed charts like the cilium OCIRepository are held by the deny block.
       automerge: true,
       automergeType: "pr",
       matchUpdateTypes: ["minor", "patch"],
+      minimumReleaseAge: "1 day",
+      ignoreTests: false,
+    },
+    {
+      description: "Auto-merge mise CLI tool patch updates",
+      // .mise.toml pins local/CI tooling (flux2, sops, kustomize, talosctl, ...).
+      // These never touch the cluster directly, so patch bumps ride through.
+      // Minor/major stay manual: they can change talhelper/flate/kustomize output.
+      // cloudflared is pinned here too and is held by the networking deny rule.
+      matchManagers: ["mise"],
+      automerge: true,
+      automergeType: "pr",
+      matchUpdateTypes: ["patch"],
       minimumReleaseAge: "1 day",
       ignoreTests: false,
     },
@@ -208,6 +181,36 @@
         "/external-secrets/",
       ],
       ignoreTests: true,
+    },
+
+    // ------------------------------------------------------------------
+    // DENY BLOCK — keep last. These override every allow rule above.
+    // ------------------------------------------------------------------
+    {
+      description: "Disable automerge for networking packages",
+      matchPackageNames: [
+        "cilium",
+        "multus",
+        "ingress-nginx",
+        "external-dns",
+        "cloudflared",
+        "k8s-gateway",
+        "coredns",
+        "/cilium/",
+        "/nginx/",
+        "/cloudflare/",
+      ],
+      automerge: false,
+    },
+    {
+      description: "Disable automerge for storage packages",
+      matchPackageNames: ["openebs", "volsync", "minio", "/openebs/", "/minio/", "/rook/"],
+      automerge: false,
+    },
+    {
+      description: "Disable automerge for dapperdivers images",
+      matchPackageNames: ["/dapperdivers/"],
+      automerge: false,
     },
   ],
 }


### PR DESCRIPTION
## Why

Seven PRs are sitting open with green CI and `Automerge: Disabled by config`. Three are deliberate holds; four fall through **every** rule in `.renovate/autoMerge.json5` and were never eligible in the first place.

| PR | Update | Why it stalled |
|---|---|---|
| #3757 | `aqua:fluxcd/flux2` 2.9.2 → 2.9.3 | no packageRule matches the `mise` manager at all |
| #3751 | `aqua:getsops/sops` 3.13.2 → 3.13.3 | same |
| #3752 | `kometateam/kometa` digest | trusted-digest list is ghcr.io/home-operations/linuxserver/hotio only; kometa is Docker Hub, pinned `:nightly@sha256` |
| #3761 | `registry.k8s.io/agent-sandbox` v0.4.5 → v0.5.3 | minor/patch catch-all matched `/ghcr.io/` only |

## Changes

- **Reordered the file: allow rules first, deny rules last.** Renovate applies the *last* matching rule per field. Previously the three `Disable automerge` rules sat at the top, so any broad allow rule below them silently re-enabled automerge — exactly the bug fixed for one rule in #3743. With the deny block last, that whole class of bug is structurally impossible.
- Catch-all now matches `registry.k8s.io` alongside `ghcr.io`.
- Trusted digest list includes `kometateam`.
- **New rule — mise CLI tool patches**, 1 day minimum release age. Patch only: minor/major on `talhelper`/`flate`/`kustomize` can change generated output, so those stay manual. `cloudflared` is pinned in `.mise.toml` but remains held by the networking deny rule.
- Dropped the helm rule's inline `["*", "!/cilium/", ...]` list. `renovate-config-validator` rejects it (`* along with other patterns`) — this was a pre-existing config error on `main`. The deny block covers those packages, and the whole config now validates clean.

## Still intentionally manual

- #3745 paperless-ngx 2.20.15 → **3.0.3** — major
- #3755 cloudflared — networking hold
- #3748 kubernetes/kubernetes v1.36.3 — not in the `github-releases` allowlist

## Validation

```
$ npx --package renovate@44.0.0-next.1 renovate-config-validator .renovate/autoMerge.json5 .renovaterc.json5
INFO: Config validated successfully
```

(`main` currently fails this with the `matchPackageNames` error above.)

Once merged, the next Renovate run should pick up #3757, #3751, #3752 and #3761 and enable automerge on them.