### PR TITLE
fix(roundtable): align agent-sandbox manifests with v0.5.3 image

### DIFF
--- a/kubernetes/apps/roundtable/agent-sandbox/controller/kustomization.yaml
+++ b/kubernetes/apps/roundtable/agent-sandbox/controller/kustomization.yaml
@@ -5,13 +5,13 @@ kind: Kustomization
 # Pull controller + RBAC from upstream, add extensions RBAC + patch
 resources:
   # Upstream core: namespace, SA, CRB, service, deployment
-  - https://raw.githubusercontent.com/kubernetes-sigs/agent-sandbox/v0.2.1/k8s/controller.yaml
+  - https://raw.githubusercontent.com/kubernetes-sigs/agent-sandbox/v0.5.3/k8s/controller.yaml
   # Upstream core RBAC (ClusterRole)
-  - https://raw.githubusercontent.com/kubernetes-sigs/agent-sandbox/v0.2.1/k8s/rbac.generated.yaml
+  - https://raw.githubusercontent.com/kubernetes-sigs/agent-sandbox/v0.5.3/k8s/rbac.generated.yaml
   # Upstream extensions RBAC (ClusterRole)
-  - https://raw.githubusercontent.com/kubernetes-sigs/agent-sandbox/v0.2.1/k8s/extensions-rbac.generated.yaml
+  - https://raw.githubusercontent.com/kubernetes-sigs/agent-sandbox/v0.5.3/k8s/extensions-rbac.generated.yaml
   # Extensions ClusterRoleBinding
-  - https://raw.githubusercontent.com/kubernetes-sigs/agent-sandbox/v0.2.1/k8s/extensions.yaml
+  - https://raw.githubusercontent.com/kubernetes-sigs/agent-sandbox/v0.5.3/k8s/extensions.yaml
 images:
   # Override ko:// dev image with release image
   - name: ko://sigs.k8s.io/agent-sandbox/cmd/agent-sandbox-controller


### PR DESCRIPTION
## Problem

`agent-sandbox-controller` has been crashlooping (432 restarts / 36h) and its Flux Kustomization has been `False` on a health-check timeout.

Root cause is version skew inside `controller/kustomization.yaml`: the upstream manifests were pinned to the **v0.2.1** raw URLs while the image was overridden to **v0.5.3**.

v0.5.3 bootstraps its own webhook serving certs at startup and ships a namespaced `Role`/`RoleBinding` granting `secrets` create/get/patch on `agent-sandbox-webhook-certs`. v0.2.1's manifests have no such Role, so the v0.5.3 binary dies immediately:

```
unable to prepare webhook certificates: failed to check for existing shared Secret:
secrets "agent-sandbox-webhook-certs" is forbidden: User
"system:serviceaccount:agent-sandbox-system:agent-sandbox-controller" cannot get
resource "secrets" in API group "" in the namespace "agent-sandbox-system"
```

## Fix

Bump the four upstream manifest pins v0.2.1 → v0.5.3, matching the image tag and the CRDs already sourced from the v0.5.3 `GitRepository`.

## Verification

`kustomize build` renders cleanly and now includes the previously-missing RBAC:

- `Role/agent-sandbox-controller` + `RoleBinding/agent-sandbox-controller` (the fix)
- `ClusterRole` at v0.5.3 covers the `customresourcedefinitions` patching the webhook bootstrap needs
- Deployment: `registry.k8s.io/agent-sandbox/agent-sandbox-controller:v0.5.3`, args `[--leader-elect=true, --extensions]`, resource requests/limits preserved
- All four upstream files still exist at v0.5.3 with unchanged resource shapes; `extensions.yaml` is still just the ClusterRoleBinding, so there's no duplicate Deployment

The rendered set matches upstream's own `k8s/kustomization.yaml` GitOps assembly (core + extensions, single Deployment, `--extensions` patch).

## Notes

- Nothing consumes this yet — zero `Sandbox`/`SandboxClaim`/`SandboxTemplate`/`SandboxWarmPool` CRs exist and all 27 Knights are `runtime: deployment`. Keeping it installed and healthy so the fleet can move to the sandbox runtime if it grows custom-harness support.
- Upstream's kustomization also mounts an optional `agent-sandbox-config` ConfigMap at `/etc/sandbox-config`. Omitted here — the volume is `optional: true` and no such ConfigMap exists.