### PR TITLE
ci: pin mise to 2026.7.16 to unbreak Image Pull

### DIFF
--- a/.github/workflows/pre-pull-images.yaml
+++ b/.github/workflows/pre-pull-images.yaml
@@ -43,6 +43,13 @@ jobs:
       - name: Setup Mise
         uses: jdx/mise-action@9e7f7633ff6f6d6048a9418a68d48f288f50eb14 # v4.2.3
         with:
+          # Pinned: mise 2026.7.17 cannot resolve aqua packages whose upstream
+          # tags are prefixed (kubernetes-sigs/kustomize tags as kustomize/vX.Y.Z),
+          # so `mise install` 404s on the repo's .mise.toml toolchain and every
+          # run of this workflow fails. Deliberately NOT renovate-annotated —
+          # auto-bumping would reintroduce the break. Unpin once mise resolves
+          # prefixed aqua tags again.
+          version: 2026.7.16
           cache: false
           tool_versions: |
             github:home-operations/flate 0.4.9
@@ -68,6 +75,13 @@ jobs:
       - name: Setup Mise
         uses: jdx/mise-action@9e7f7633ff6f6d6048a9418a68d48f288f50eb14 # v4.2.3
         with:
+          # Pinned: mise 2026.7.17 cannot resolve aqua packages whose upstream
+          # tags are prefixed (kubernetes-sigs/kustomize tags as kustomize/vX.Y.Z),
+          # so `mise install` 404s on the repo's .mise.toml toolchain and every
+          # run of this workflow fails. Deliberately NOT renovate-annotated —
+          # auto-bumping would reintroduce the break. Unpin once mise resolves
+          # prefixed aqua tags again.
+          version: 2026.7.16
           cache: false
           tool_versions: |
             talosctl latest


### PR DESCRIPTION
## Problem

`Image Pull` has been failing on **every branch** since this morning — including every open Renovate PR:

```
Failed to install aqua:kubernetes-sigs/kustomize@5.6.0:
  404 for https://api.github.com/repos/kubernetes-sigs/kustomize/releases/tags/5.6.0
  404 for https://api.github.com/repos/kubernetes-sigs/kustomize/releases/tags/v5.6.0
```

kustomize tags its releases `kustomize/vX.Y.Z` (a prefixed tag). mise **2026.7.17**, published 2026-07-30 01:58Z, resolves the release by unprefixed tag and 404s.

Two things turned that upstream regression into total CI failure:

1. `jdx/mise-action`'s `version` input defaults to *the latest release*, so the pinned action SHA still floats the mise binary. Every run picked up 2026.7.17 the moment it shipped.
2. The action also runs `mise install` against the repo's `.mise.toml`, so a break in **any** tool fails the whole step — even though these jobs only need `flate` and `talosctl`.

## Fix

Pin `version: 2026.7.16` on both `Setup Mise` steps.

## Verification

Ran the standalone mise binaries against the same pin in isolated data dirs:

| mise | result |
|---|---|
| 2026.7.17 | ❌ 404 |
| 2026.7.16 | ✅ installs cleanly |
| 2026.7.15 | ✅ installs cleanly |

Also ruled out the lockfile as a fix — `mise.lock` already carries the correctly-prefixed download URL, but 2026.7.17 logs `lockfile asset 'kustomize_v5.6.0_linux_amd64.tar.gz' doesn't match registry, refreshing` and falls back to the same failing tag lookup. Regenerating the lock does not help.

## Note on Renovate

Deliberately **not** `# renovate:`-annotated. The repo's `customManagers` regex in `.renovate/customManagers.json5` matches annotated `key: value` pairs in any YAML, so an annotation here would bump the pin straight back to 2026.7.17 and reintroduce the break. Unpin by hand once mise resolves prefixed aqua tags again.

## Possible follow-up

These jobs install the entire `.mise.toml` toolchain to get two tools. Scoping them (`install_args`, or `install: false` alongside the `tool_versions` already declared) would make the workflow immune to breakage in unrelated tools and cut setup time. Left out here to keep the fix minimal.