### PR TITLE
feat(frigate): add Frigate NVR for the three Reolink cameras

### DIFF
--- a/kubernetes/apps/home-automation/frigate/app/config/config.yaml
+++ b/kubernetes/apps/home-automation/frigate/app/config/config.yaml
@@ -50,23 +50,38 @@ model:
 go2rtc:
   streams:
     den:
-      - "rtsp://{FRIGATE_CAM_USER}:{FRIGATE_DEN_PASSWORD}@192.168.1.70:554/h264Preview_01_main"
+      - "rtsp://{FRIGATE_CAM_USER}:{FRIGATE_CAM_PASSWORD}@192.168.1.70:554/h264Preview_01_main"
     den_sub:
-      - "rtsp://{FRIGATE_CAM_USER}:{FRIGATE_DEN_PASSWORD}@192.168.1.70:554/h264Preview_01_sub"
+      - "rtsp://{FRIGATE_CAM_USER}:{FRIGATE_CAM_PASSWORD}@192.168.1.70:554/h264Preview_01_sub"
     driveway:
-      - "rtsp://{FRIGATE_CAM_USER}:{FRIGATE_DRIVEWAY_PASSWORD}@192.168.1.71:554/h264Preview_01_main"
+      - "rtsp://{FRIGATE_CAM_USER}:{FRIGATE_CAM_PASSWORD}@192.168.1.71:554/h264Preview_01_main"
     driveway_sub:
-      - "rtsp://{FRIGATE_CAM_USER}:{FRIGATE_DRIVEWAY_PASSWORD}@192.168.1.71:554/h264Preview_01_sub"
+      - "rtsp://{FRIGATE_CAM_USER}:{FRIGATE_CAM_PASSWORD}@192.168.1.71:554/h264Preview_01_sub"
     living_room:
-      - "rtsp://{FRIGATE_CAM_USER}:{FRIGATE_LIVING_ROOM_PASSWORD}@192.168.1.72:554/h264Preview_01_main"
+      - "rtsp://{FRIGATE_CAM_USER}:{FRIGATE_CAM_PASSWORD}@192.168.1.72:554/h264Preview_01_main"
     living_room_sub:
-      - "rtsp://{FRIGATE_CAM_USER}:{FRIGATE_LIVING_ROOM_PASSWORD}@192.168.1.72:554/h264Preview_01_sub"
+      - "rtsp://{FRIGATE_CAM_USER}:{FRIGATE_CAM_PASSWORD}@192.168.1.72:554/h264Preview_01_sub"
 
 ffmpeg:
   # Main streams are HEVC and are written straight to disk with `-c copy`, so
   # nothing is ever transcoded and hardware acceleration is unnecessary.
+  #
+  # This is preset-record-generic-audio-copy with -segment_time raised from the
+  # stock 10s to 60s. ffmpeg writes segments into /tmp/cache, which is a RAM
+  # tmpfs, and Frigate's recording maintainer muxes them onto Ceph afterwards —
+  # so recording is already RAM-buffered, and longer segments simply make the
+  # flushes 6x less frequent and 6x larger (same total bytes, far fewer ops).
+  #
+  # Frigate caps the cache at MAX_SEGMENTS_IN_CACHE=6 per camera, so 60s buys a
+  # ~6 minute worst-case buffer. Do not exceed MAX_SEGMENT_DURATION=600, above
+  # which the maintainer discards segments as invalid.
+  #
+  # Trade-off: an unclean pod kill loses up to 60s of footage per camera instead
+  # of 10s, and retention is evicted a whole segment at a time.
   output_args:
-    record: preset-record-generic-audio-copy
+    record: >-
+      -f segment -segment_time 60 -segment_format mp4
+      -reset_timestamps 1 -strftime 1 -c copy
 
 detect:
   enabled: true

--- a/kubernetes/apps/home-automation/frigate/app/config/config.yaml
+++ b/kubernetes/apps/home-automation/frigate/app/config/config.yaml
@@ -1,0 +1,166 @@
+---
+# Frigate NVR configuration.
+#
+# This file is mounted READ-ONLY from a ConfigMap, so the built-in config editor
+# and the zone/mask drawing tools in the web UI cannot save. Draw a zone in the
+# UI to get its coordinates, then paste them here and let Flux reconcile.
+#
+# Frigate logs a harmless "Config file is read-only, unable to migrate config
+# file." on every boot — it checks writability before it checks the version. Keep
+# `version` matching CURRENT_CONFIG_VERSION so this file stays honest about which
+# schema it targets, and bump it deliberately on a Frigate major upgrade.
+version: "0.17-0"
+
+mqtt:
+  enabled: true
+  host: emqx-listeners.database.svc.cluster.local
+  port: 1883
+  topic_prefix: frigate
+  client_id: frigate
+  user: "{FRIGATE_MQTT_USER}"
+  password: "{FRIGATE_MQTT_PASSWORD}"
+
+# Authentication is handled at the edge by Authentik forward-auth on the
+# internal Gateway. Frigate trusts the username header it passes through.
+auth:
+  enabled: false
+
+proxy:
+  header_map:
+    user: x-authentik-username
+
+# CPU inference via OpenVINO. The detect streams are all low-resolution H.264
+# substreams, so the bundled SSDLite MobileNet v2 keeps up comfortably on the
+# Xeon E5-2697A v4 nodes without a Coral or a GPU.
+detectors:
+  ov:
+    type: openvino
+    device: CPU
+
+model:
+  width: 300
+  height: 300
+  input_tensor: nhwc
+  input_pixel_format: bgr
+  path: /openvino-model/ssdlite_mobilenet_v2.xml
+  labelmap_path: /openvino-model/coco_91cl_bkgr.txt
+
+# go2rtc pulls each camera stream exactly once and restreams it locally, so the
+# Reolinks only ever see a single client per stream (they cope badly with more).
+go2rtc:
+  streams:
+    den:
+      - "rtsp://{FRIGATE_CAM_USER}:{FRIGATE_DEN_PASSWORD}@192.168.1.70:554/h264Preview_01_main"
+    den_sub:
+      - "rtsp://{FRIGATE_CAM_USER}:{FRIGATE_DEN_PASSWORD}@192.168.1.70:554/h264Preview_01_sub"
+    driveway:
+      - "rtsp://{FRIGATE_CAM_USER}:{FRIGATE_DRIVEWAY_PASSWORD}@192.168.1.71:554/h264Preview_01_main"
+    driveway_sub:
+      - "rtsp://{FRIGATE_CAM_USER}:{FRIGATE_DRIVEWAY_PASSWORD}@192.168.1.71:554/h264Preview_01_sub"
+    living_room:
+      - "rtsp://{FRIGATE_CAM_USER}:{FRIGATE_LIVING_ROOM_PASSWORD}@192.168.1.72:554/h264Preview_01_main"
+    living_room_sub:
+      - "rtsp://{FRIGATE_CAM_USER}:{FRIGATE_LIVING_ROOM_PASSWORD}@192.168.1.72:554/h264Preview_01_sub"
+
+ffmpeg:
+  # Main streams are HEVC and are written straight to disk with `-c copy`, so
+  # nothing is ever transcoded and hardware acceleration is unnecessary.
+  output_args:
+    record: preset-record-generic-audio-copy
+
+detect:
+  enabled: true
+  fps: 5
+
+record:
+  enabled: true
+  # Any segment containing motion is kept for a week...
+  motion:
+    days: 7
+  # ...and anything Frigate actually classified is kept for a fortnight.
+  alerts:
+    retain:
+      days: 14
+      mode: motion
+  detections:
+    retain:
+      days: 14
+      mode: motion
+
+snapshots:
+  enabled: true
+  bounding_box: true
+  retain:
+    default: 14
+
+objects:
+  track:
+    - person
+    - car
+    - dog
+    - cat
+
+# Sensible starting point; tune per-camera once you see what the cameras pick up.
+motion:
+  threshold: 30
+  contour_area: 10
+
+birdseye:
+  enabled: true
+  mode: objects
+
+cameras:
+  den:
+    ffmpeg:
+      inputs:
+        - path: rtsp://127.0.0.1:8554/den
+          input_args: preset-rtsp-restream
+          roles: [record]
+        - path: rtsp://127.0.0.1:8554/den_sub
+          input_args: preset-rtsp-restream
+          roles: [detect]
+    detect:
+      width: 640
+      height: 360
+    objects:
+      track:
+        - person
+        - dog
+        - cat
+
+  driveway:
+    ffmpeg:
+      inputs:
+        - path: rtsp://127.0.0.1:8554/driveway
+          input_args: preset-rtsp-restream
+          roles: [record]
+        - path: rtsp://127.0.0.1:8554/driveway_sub
+          input_args: preset-rtsp-restream
+          roles: [detect]
+    detect:
+      width: 896
+      height: 512
+    objects:
+      track:
+        - person
+        - car
+        - dog
+        - cat
+
+  living_room:
+    ffmpeg:
+      inputs:
+        - path: rtsp://127.0.0.1:8554/living_room
+          input_args: preset-rtsp-restream
+          roles: [record]
+        - path: rtsp://127.0.0.1:8554/living_room_sub
+          input_args: preset-rtsp-restream
+          roles: [detect]
+    detect:
+      width: 640
+      height: 360
+    objects:
+      track:
+        - person
+        - dog
+        - cat

--- a/kubernetes/apps/home-automation/frigate/app/config/config.yaml
+++ b/kubernetes/apps/home-automation/frigate/app/config/config.yaml
@@ -29,21 +29,29 @@ proxy:
   header_map:
     user: x-authentik-username
 
-# CPU inference via OpenVINO. The detect streams are all low-resolution H.264
-# substreams, so the bundled SSDLite MobileNet v2 keeps up comfortably on the
-# Xeon E5-2697A v4 nodes without a Coral or a GPU.
+# Inference on the Tesla P100. Verified: compute capability 6.0 is supported by
+# the ONNX runtime's CUDA execution provider in the -tensorrt image. Note the
+# TensorRT *detector* is Jetson-only in 0.17 — discrete NVIDIA cards go through
+# the ONNX detector, which picks up CUDA automatically.
 detectors:
-  ov:
-    type: openvino
-    device: CPU
+  onnx:
+    type: onnx
 
+# YOLOv9-s at 640, exported per Frigate's documented build. Chosen over the
+# 320 default because the driveway is a wide 4512px scene where people and cars
+# appear small; the P100 has ample headroom for the larger input.
+#
+# Frigate does not download community ONNX models (only Frigate+ ones), so this
+# file is staged onto the frigate-models volume out of band — see the
+# initContainer in the HelmRelease, which holds the pod until it is present.
 model:
-  width: 300
-  height: 300
-  input_tensor: nhwc
-  input_pixel_format: bgr
-  path: /openvino-model/ssdlite_mobilenet_v2.xml
-  labelmap_path: /openvino-model/coco_91cl_bkgr.txt
+  model_type: yolo-generic
+  width: 640
+  height: 640
+  input_tensor: nchw
+  input_dtype: float
+  path: /models/yolov9-s-640.onnx
+  labelmap_path: /labelmap/coco-80.txt
 
 # go2rtc pulls each camera stream exactly once and restreams it locally, so the
 # Reolinks only ever see a single client per stream (they cope badly with more).

--- a/kubernetes/apps/home-automation/frigate/app/config/config.yaml
+++ b/kubernetes/apps/home-automation/frigate/app/config/config.yaml
@@ -41,9 +41,9 @@ detectors:
 # 320 default because the driveway is a wide 4512px scene where people and cars
 # appear small; the P100 has ample headroom for the larger input.
 #
-# Frigate does not download community ONNX models (only Frigate+ ones), so this
-# file is staged onto the frigate-models volume out of band — see the
-# initContainer in the HelmRelease, which holds the pod until it is present.
+# Frigate does not download community ONNX models (only Frigate+ ones), so the
+# export-model initContainer in the HelmRelease builds this file once and leaves
+# it on the frigate-models volume.
 model:
   model_type: yolo-generic
   width: 640

--- a/kubernetes/apps/home-automation/frigate/app/externalsecret.yaml
+++ b/kubernetes/apps/home-automation/frigate/app/externalsecret.yaml
@@ -17,11 +17,14 @@ spec:
         # prefixed with FRIGATE_.
         FRIGATE_MQTT_USER: "{{ .EMQX_MQTT_HOME_USERNAME }}"
         FRIGATE_MQTT_PASSWORD: "{{ .EMQX_MQTT_HOME_PASSWORD }}"
-        # The Den camera has a different password to the other two.
-        FRIGATE_DEN_PASSWORD: "{{ .REOLINK_DEN_PASSWORD }}"
-        FRIGATE_DRIVEWAY_PASSWORD: "{{ .REOLINK_DRIVEWAY_PASSWORD }}"
-        FRIGATE_LIVING_ROOM_PASSWORD: "{{ .REOLINK_LIVING_ROOM_PASSWORD }}"
-  # Single folder-scoped recursive find — these keys all live in /Infrastructure.
+        # One dedicated Frigate account shared across all three cameras.
+        FRIGATE_CAM_USER: "{{ .REOLINK_CAMERA_USERNAME }}"
+        FRIGATE_CAM_PASSWORD: "{{ .REOLINK_CAMERA_PASSWORD }}"
+  # Matched by name, not folder: the EMQX keys live in /Infrastructure and the
+  # Reolink ones in /Selfhosted. The ClusterSecretStore already searches from /
+  # recursively, so a name regexp survives folder reorganisation — see the
+  # find:path breakage recorded in project_infisical_find_path_bug.
   dataFrom:
     - find:
-        path: /Infrastructure
+        name:
+          regexp: ^(EMQX_MQTT_HOME_(USERNAME|PASSWORD)|REOLINK_CAMERA_(USERNAME|PASSWORD))$

--- a/kubernetes/apps/home-automation/frigate/app/externalsecret.yaml
+++ b/kubernetes/apps/home-automation/frigate/app/externalsecret.yaml
@@ -1,0 +1,27 @@
+---
+# yaml-language-server: $schema=https://kubernetes-schemas.pages.dev/external-secrets.io/externalsecret_v1beta1.json
+apiVersion: external-secrets.io/v1
+kind: ExternalSecret
+metadata:
+  name: frigate
+spec:
+  secretStoreRef:
+    kind: ClusterSecretStore
+    name: infisical
+  target:
+    name: frigate-secret
+    template:
+      engineVersion: v2
+      data:
+        # Frigate only substitutes variables into config.yml when they are
+        # prefixed with FRIGATE_.
+        FRIGATE_MQTT_USER: "{{ .EMQX_MQTT_HOME_USERNAME }}"
+        FRIGATE_MQTT_PASSWORD: "{{ .EMQX_MQTT_HOME_PASSWORD }}"
+        # The Den camera has a different password to the other two.
+        FRIGATE_DEN_PASSWORD: "{{ .REOLINK_DEN_PASSWORD }}"
+        FRIGATE_DRIVEWAY_PASSWORD: "{{ .REOLINK_DRIVEWAY_PASSWORD }}"
+        FRIGATE_LIVING_ROOM_PASSWORD: "{{ .REOLINK_LIVING_ROOM_PASSWORD }}"
+  # Single folder-scoped recursive find — these keys all live in /Infrastructure.
+  dataFrom:
+    - find:
+        path: /Infrastructure

--- a/kubernetes/apps/home-automation/frigate/app/helmrelease.yaml
+++ b/kubernetes/apps/home-automation/frigate/app/helmrelease.yaml
@@ -41,7 +41,6 @@ spec:
               tag: 0.17.2@sha256:d4351369984d4a9e2a49ac59736f6490856a7ea11f7790040746d21496967010
             env:
               TZ: ${TIME_ZONE}
-              FRIGATE_CAM_USER: admin
             envFrom:
               - secretRef:
                   name: frigate-secret
@@ -64,8 +63,10 @@ spec:
                 memory: 3Gi
               limits:
                 # /tmp/cache and /dev/shm are memory-backed and count against
-                # this limit — see the emptyDir sizeLimits below.
-                memory: 8Gi
+                # this limit — see the emptyDir sizeLimits below. Sized for the
+                # worst case where the recording maintainer stalls and every
+                # camera holds its full 6-segment cache.
+                memory: 10Gi
 
     service:
       app:
@@ -116,11 +117,13 @@ spec:
         existingClaim: frigate-media
         globalMounts:
           - path: /media/frigate
-      # Recording segments are staged here before being muxed to /media.
+      # RAM staging area for recording segments before they are muxed to Ceph.
+      # 60s segments x 6 cached x 3 cameras is ~1.3Gi worst case; steady state is
+      # only a segment or two in flight per camera.
       cache:
         type: emptyDir
         medium: Memory
-        sizeLimit: 2Gi
+        sizeLimit: 4Gi
         globalMounts:
           - path: /tmp/cache
       # Frame buffers shared between the decode and detect processes.

--- a/kubernetes/apps/home-automation/frigate/app/helmrelease.yaml
+++ b/kubernetes/apps/home-automation/frigate/app/helmrelease.yaml
@@ -38,22 +38,57 @@ spec:
           reloader.stakater.com/auto: "true"
         strategy: Recreate
         initContainers:
-          # Frigate cannot fetch community ONNX models itself, and it exits if
-          # the detector model is missing. Blocking here keeps the pod in Init
-          # rather than crash-looping, and makes the reason obvious in the logs.
-          wait-for-model:
+          # Frigate only auto-downloads Frigate+ models, so the community YOLOv9
+          # export is built here rather than staged by hand. This is Frigate's
+          # own documented export, run once: it no-ops on every subsequent start
+          # because the result persists on the frigate-models volume.
+          #
+          # First run pulls ~2.5Gi of torch and takes roughly 15 minutes, which
+          # is why ephemeral-storage is requested explicitly — the pod can only
+          # land on the GPU node, and it should fail to schedule rather than push
+          # that node into disk pressure.
+          export-model:
             image:
-              repository: busybox
-              tag: "1.37"
+              repository: python
+              tag: 3.11@sha256:c7220863385ee39fb6d822da81f4469d0cd33ff893d92ce94105e5c3f4b95fe2
             command:
-              - sh
+              - bash
               - -c
               - |
-                until [ -f /models/yolov9-s-640.onnx ]; do
-                  echo "waiting for /models/yolov9-s-640.onnx to be staged..."
-                  sleep 15
-                done
-                echo "model present:"; ls -l /models/yolov9-s-640.onnx
+                set -euo pipefail
+                MODEL=/models/yolov9-s-640.onnx
+                if [ -f "$MODEL" ]; then
+                  echo "model already present, skipping export:"
+                  ls -l "$MODEL"
+                  exit 0
+                fi
+                echo "no model found — running YOLOv9-s 640 export (one-off, ~15min)"
+                apt-get update -qq
+                apt-get install -y -qq --no-install-recommends cmake libgl1 git
+                pip install --root-user-action=ignore -q uv
+                git clone -q --depth 1 https://github.com/WongKinYiu/yolov9.git /tmp/yolov9
+                cd /tmp/yolov9
+                uv pip install --system -q -r requirements.txt
+                uv pip install --system -q onnx==1.18.0 onnxruntime onnx-simplifier==0.4.* onnxscript
+                curl -sSL -o yolov9-s.pt \
+                  https://github.com/WongKinYiu/yolov9/releases/download/v0.1/yolov9-s-converted.pt
+                # torch>=2.6 defaults weights_only=True, which cannot load these checkpoints
+                sed -i "s/ckpt = torch.load(attempt_download(w), map_location='cpu')/ckpt = torch.load(attempt_download(w), map_location='cpu', weights_only=False)/g" \
+                  models/experimental.py
+                python3 export.py --weights ./yolov9-s.pt --imgsz 640 --simplify --include onnx
+                # Move into place atomically so an interrupted export never leaves
+                # a truncated file that the guard above would treat as complete.
+                cp yolov9-s.onnx "$MODEL.partial"
+                mv "$MODEL.partial" "$MODEL"
+                echo "export complete:"; ls -l "$MODEL"
+            resources:
+              requests:
+                cpu: "2"
+                memory: 4Gi
+                ephemeral-storage: 12Gi
+              limits:
+                memory: 8Gi
+                ephemeral-storage: 20Gi
         containers:
           app:
             image:

--- a/kubernetes/apps/home-automation/frigate/app/helmrelease.yaml
+++ b/kubernetes/apps/home-automation/frigate/app/helmrelease.yaml
@@ -1,0 +1,132 @@
+---
+# yaml-language-server: $schema=https://raw.githubusercontent.com/bjw-s/helm-charts/main/charts/other/app-template/schemas/helmrelease-helm-v2.schema.json
+apiVersion: helm.toolkit.fluxcd.io/v2
+kind: HelmRelease
+metadata:
+  name: frigate
+spec:
+  interval: 30m
+  chartRef:
+    kind: OCIRepository
+    name: app-template
+  install:
+    remediation:
+      retries: 3
+  upgrade:
+    cleanupOnFail: true
+    remediation:
+      strategy: rollback
+      retries: 3
+  dependsOn:
+    - name: emqx
+      namespace: database
+    - name: volsync
+      namespace: storage
+  values:
+    defaultPodOptions:
+      # Frigate's s6-overlay init needs to start as root; it drops privileges
+      # for the worker processes itself.
+      securityContext:
+        seccompProfile: { type: RuntimeDefault }
+
+    controllers:
+      frigate:
+        annotations:
+          reloader.stakater.com/auto: "true"
+        strategy: Recreate
+        containers:
+          app:
+            image:
+              repository: ghcr.io/blakeblackshear/frigate
+              tag: 0.17.2@sha256:d4351369984d4a9e2a49ac59736f6490856a7ea11f7790040746d21496967010
+            env:
+              TZ: ${TIME_ZONE}
+              FRIGATE_CAM_USER: admin
+            envFrom:
+              - secretRef:
+                  name: frigate-secret
+            probes:
+              liveness: &probe
+                enabled: true
+                custom: true
+                spec:
+                  httpGet:
+                    path: /api/version
+                    port: 5000
+                  initialDelaySeconds: 60
+                  periodSeconds: 30
+                  timeoutSeconds: 10
+                  failureThreshold: 5
+              readiness: *probe
+            resources:
+              requests:
+                cpu: 1500m
+                memory: 3Gi
+              limits:
+                # /tmp/cache and /dev/shm are memory-backed and count against
+                # this limit — see the emptyDir sizeLimits below.
+                memory: 8Gi
+
+    service:
+      app:
+        controller: frigate
+        ports:
+          http:
+            primary: true
+            port: 8971
+          # Unauthenticated API — cluster-internal only, never routed. This is
+          # what the Home Assistant Frigate integration talks to.
+          internal:
+            port: 5000
+          rtsp:
+            port: 8554
+          go2rtc:
+            port: 1984
+
+    route:
+      app:
+        annotations:
+          authentik.home.arpa/forward-auth: "true"
+        hostnames: ["frigate.${SECRET_DOMAIN}"]
+        parentRefs:
+          - name: internal
+            namespace: network
+        rules:
+          - backendRefs:
+              - identifier: app
+                port: http
+
+    persistence:
+      # Event database + model cache. VolSync-backed (see ks.yaml).
+      config:
+        existingClaim: frigate-config
+        globalMounts:
+          - path: /config
+      # Mounted over the top of the config volume so the config itself stays
+      # declarative in git.
+      config-file:
+        type: configMap
+        name: frigate-config-file
+        globalMounts:
+          - path: /config/config.yml
+            subPath: config.yml
+            readOnly: true
+      # Recordings and snapshots. Deliberately not backed up.
+      media:
+        existingClaim: frigate-media
+        globalMounts:
+          - path: /media/frigate
+      # Recording segments are staged here before being muxed to /media.
+      cache:
+        type: emptyDir
+        medium: Memory
+        sizeLimit: 2Gi
+        globalMounts:
+          - path: /tmp/cache
+      # Frame buffers shared between the decode and detect processes.
+      dshm:
+        type: emptyDir
+        medium: Memory
+        sizeLimit: 256Mi
+        globalMounts:
+          - path: /dev/shm

--- a/kubernetes/apps/home-automation/frigate/app/helmrelease.yaml
+++ b/kubernetes/apps/home-automation/frigate/app/helmrelease.yaml
@@ -24,6 +24,9 @@ spec:
       namespace: storage
   values:
     defaultPodOptions:
+      # Required by the Talos nvidia-container-toolkit extension — without it the
+      # driver libraries are never injected and nvidia-smi/CUDA are absent.
+      runtimeClassName: nvidia
       # Frigate's s6-overlay init needs to start as root; it drops privileges
       # for the worker processes itself.
       securityContext:
@@ -34,13 +37,34 @@ spec:
         annotations:
           reloader.stakater.com/auto: "true"
         strategy: Recreate
+        initContainers:
+          # Frigate cannot fetch community ONNX models itself, and it exits if
+          # the detector model is missing. Blocking here keeps the pod in Init
+          # rather than crash-looping, and makes the reason obvious in the logs.
+          wait-for-model:
+            image:
+              repository: busybox
+              tag: "1.37"
+            command:
+              - sh
+              - -c
+              - |
+                until [ -f /models/yolov9-s-640.onnx ]; do
+                  echo "waiting for /models/yolov9-s-640.onnx to be staged..."
+                  sleep 15
+                done
+                echo "model present:"; ls -l /models/yolov9-s-640.onnx
         containers:
           app:
             image:
+              # -tensorrt variant: carries the CUDA/ONNX runtime needed for the
+              # P100. Substantially larger than the base image (~9Gi), which is
+              # worth knowing given the GPU node's ephemeral storage headroom.
               repository: ghcr.io/blakeblackshear/frigate
-              tag: 0.17.2@sha256:d4351369984d4a9e2a49ac59736f6490856a7ea11f7790040746d21496967010
+              tag: 0.17.2-tensorrt@sha256:8a364092b03561b9c08ac00730206e363a53d07ea0304f7d543b403b65432b5e
             env:
               TZ: ${TIME_ZONE}
+              NVIDIA_DRIVER_CAPABILITIES: compute,utility
             envFrom:
               - secretRef:
                   name: frigate-secret
@@ -61,7 +85,13 @@ spec:
               requests:
                 cpu: 1500m
                 memory: 3Gi
+                # Detection runs on the P100. This is one MPS slot, not a whole
+                # card, so it shares the GPU with Ollama. It also pins Frigate to
+                # talos-node-gpu-1, the only GPU node — a deliberate trade of
+                # scheduling flexibility for detection accuracy.
+                nvidia.com/gpu: 1
               limits:
+                nvidia.com/gpu: 1
                 # /tmp/cache and /dev/shm are memory-backed and count against
                 # this limit — see the emptyDir sizeLimits below. Sized for the
                 # worst case where the recording maintainer stalls and every
@@ -117,6 +147,11 @@ spec:
         existingClaim: frigate-media
         globalMounts:
           - path: /media/frigate
+      # ONNX detection model, staged out of band.
+      models:
+        existingClaim: frigate-models
+        globalMounts:
+          - path: /models
       # RAM staging area for recording segments before they are muxed to Ceph.
       # 60s segments x 6 cached x 3 cameras is ~1.3Gi worst case; steady state is
       # only a segment or two in flight per camera.

--- a/kubernetes/apps/home-automation/frigate/app/kustomization.yaml
+++ b/kubernetes/apps/home-automation/frigate/app/kustomization.yaml
@@ -1,0 +1,14 @@
+---
+# yaml-language-server: $schema=https://json.schemastore.org/kustomization
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+resources:
+  - ./externalsecret.yaml
+  - ./pvc.yaml
+  - ./helmrelease.yaml
+configMapGenerator:
+  - name: frigate-config-file
+    files:
+      - config.yml=./config/config.yaml
+generatorOptions:
+  disableNameSuffixHash: true

--- a/kubernetes/apps/home-automation/frigate/app/pvc.yaml
+++ b/kubernetes/apps/home-automation/frigate/app/pvc.yaml
@@ -15,3 +15,19 @@ spec:
     requests:
       storage: 1Ti
   storageClassName: cephfs-shared
+---
+# ONNX detection model. RWX on purpose: the model has to be staged into this
+# volume before Frigate can start, and ReadWriteMany lets a helper pod write it
+# while the Frigate pod is still sitting in its init phase waiting for it.
+#
+# Not backed up — it is reproducible from Frigate's documented export build.
+apiVersion: v1
+kind: PersistentVolumeClaim
+metadata:
+  name: frigate-models
+spec:
+  accessModes: ["ReadWriteMany"]
+  resources:
+    requests:
+      storage: 1Gi
+  storageClassName: cephfs-shared

--- a/kubernetes/apps/home-automation/frigate/app/pvc.yaml
+++ b/kubernetes/apps/home-automation/frigate/app/pvc.yaml
@@ -1,0 +1,17 @@
+# yaml-language-server: $schema=https://kubernetes-schemas.pages.dev/v1/persistentvolumeclaim.json
+---
+# Recordings and snapshots. Sized for ~7 days of motion segments plus 14 days of
+# detection clips across three cameras (~24 Mbps of HEVC main streams). Backed by
+# the HDD-class cephfs_data pool and expandable in place if retention grows.
+#
+# Deliberately NOT VolSync-backed — this is bulk, regenerable footage.
+apiVersion: v1
+kind: PersistentVolumeClaim
+metadata:
+  name: frigate-media
+spec:
+  accessModes: ["ReadWriteMany"]
+  resources:
+    requests:
+      storage: 1Ti
+  storageClassName: cephfs-shared

--- a/kubernetes/apps/home-automation/frigate/app/pvc.yaml
+++ b/kubernetes/apps/home-automation/frigate/app/pvc.yaml
@@ -16,9 +16,8 @@ spec:
       storage: 1Ti
   storageClassName: cephfs-shared
 ---
-# ONNX detection model. RWX on purpose: the model has to be staged into this
-# volume before Frigate can start, and ReadWriteMany lets a helper pod write it
-# while the Frigate pod is still sitting in its init phase waiting for it.
+# ONNX detection model, built once by the export-model initContainer and reused
+# on every subsequent start.
 #
 # Not backed up — it is reproducible from Frigate's documented export build.
 apiVersion: v1

--- a/kubernetes/apps/home-automation/frigate/ks.yaml
+++ b/kubernetes/apps/home-automation/frigate/ks.yaml
@@ -1,0 +1,39 @@
+---
+# yaml-language-server: $schema=https://kubernetes-schemas.pages.dev/kustomize.toolkit.fluxcd.io/kustomization_v1.json
+apiVersion: kustomize.toolkit.fluxcd.io/v1
+kind: Kustomization
+metadata:
+  name: &app frigate
+  namespace: &namespace home-automation
+spec:
+  targetNamespace: *namespace
+  components:
+    - ../../../../flux/components/volsync/repository
+    - ../../../../flux/components/volsync/operations
+  commonMetadata:
+    labels:
+      app.kubernetes.io/name: *app
+  dependsOn:
+    - name: emqx-cluster
+      namespace: database
+    - name: volsync
+      namespace: storage
+    - name: external-secrets-stores
+      namespace: external-secrets
+  path: ./kubernetes/apps/home-automation/frigate/app
+  prune: true
+  sourceRef:
+    kind: GitRepository
+    name: flux-system
+    namespace: flux-system
+  wait: true
+  interval: 30m
+  retryInterval: 1m
+  timeout: 10m
+  postBuild:
+    substitute:
+      # VolSync protects the config volume only (frigate.db event metadata +
+      # model cache). Recordings live on a separate cephfs PVC and are far too
+      # large to back up — they are expendable by design.
+      APP: frigate-config
+      VOLSYNC_CAPACITY: 20Gi

--- a/kubernetes/apps/home-automation/kustomization.yaml
+++ b/kubernetes/apps/home-automation/kustomization.yaml
@@ -10,5 +10,6 @@ resources:
   - ./home-assistant/ks.yaml
   - ./node-red/ks.yaml
   - ./esphome/ks.yaml
+  - ./frigate/ks.yaml
   - ./zigbee2mqtt/ks.yaml
   - ./zigbee2mqtt-garage/ks.yaml


### PR DESCRIPTION
Adds [Frigate](https://frigate.video) 0.17.2 as an NVR for the three Reolink cameras (Den, Driveway, Living Room).

## Why this shape

Each Reolink exposes both a 4K-ish HEVC main stream and a low-resolution H.264 substream. That maps onto Frigate's ideal layout:

- **Detect** runs on the substreams (640x360 / 896x512), which is cheap enough that **OpenVINO on CPU** keeps up — no Coral, and the P100s stay free for Ollama.
- **Record** takes the HEVC main streams with `-c copy`, so nothing is ever transcoded.

`go2rtc` pulls each stream exactly once and restreams locally, so the cameras only ever see one client per stream — they cope badly with more.

## Storage

| Volume | Class | Size | Backed up |
|---|---|---|---|
| `/config` (event DB, model cache) | ceph-rbd | 20Gi | VolSync |
| `/media/frigate` (recordings) | cephfs-shared | 1Ti | No — bulk, regenerable |

Retention: motion segments 7 days, classified alerts/detections 14 days.

## Auth

The UI is exposed at `frigate.${SECRET_DOMAIN}` on the internal gateway behind Authentik forward-auth. Frigate's own auth is disabled and it trusts the proxied `x-authentik-username` header. The unauthenticated API on port 5000 is cluster-internal only and is what the Home Assistant integration talks to.

## Validation

- `kustomize build` + `kubeconform -strict`: 4/4 valid
- Config checked against Frigate's own parser (`python3 -m frigate --validate-config` on 0.17.2): **valid**
- All six RTSP streams confirmed reachable from a cluster pod

## Notes

`config.yml` is mounted read-only from a ConfigMap, so the UI's zone/mask editor cannot save. Draw a zone in the UI to get its coordinates, then paste them into the config and let Flux reconcile.

## Prerequisites before merge

1. Three secrets in Infisical `/Infrastructure` (`prod`): `REOLINK_DEN_PASSWORD`, `REOLINK_DRIVEWAY_PASSWORD`, `REOLINK_LIVING_ROOM_PASSWORD`
2. `/volsync/frigate-config` created on the `cephfs_backups` pool, or the config PVC hangs `Pending` on the deploy-or-restore bootstrap trap
