### PR TITLE
ci(github-action): bump mise pin to 2026.7.18 and scope image-extract install

### DIFF
--- a/.github/workflows/pre-pull-images.yaml
+++ b/.github/workflows/pre-pull-images.yaml
@@ -43,14 +43,17 @@ jobs:
       - name: Setup Mise
         uses: jdx/mise-action@9e7f7633ff6f6d6048a9418a68d48f288f50eb14 # v4.2.3
         with:
-          # Pinned: mise 2026.7.17 cannot resolve aqua packages whose upstream
-          # tags are prefixed (kubernetes-sigs/kustomize tags as kustomize/vX.Y.Z),
-          # so `mise install` 404s on the repo's .mise.toml toolchain and every
-          # run of this workflow fails. Deliberately NOT renovate-annotated —
-          # auto-bumping would reintroduce the break. Unpin once mise resolves
-          # prefixed aqua tags again.
-          version: 2026.7.17
+          # Pinned so a broken mise release can't float into CI on its own
+          # (mise-action's `version` defaults to "latest"). 2026.7.17 could not
+          # resolve aqua packages with prefixed upstream tags — kubernetes-sigs/
+          # kustomize tags as kustomize/vX.Y.Z — and 404'd on this repo's
+          # .mise.toml; 2026.7.18 fixes it.
+          # renovate: datasource=github-releases depName=jdx/mise
+          version: v2026.7.18
           cache: false
+          # Only install what this job actually uses. Without this, one broken
+          # tool anywhere in .mise.toml takes down image pulling.
+          install_args: github:home-operations/flate
           tool_versions: |
             github:home-operations/flate 0.4.9
 
@@ -75,14 +78,19 @@ jobs:
       - name: Setup Mise
         uses: jdx/mise-action@9e7f7633ff6f6d6048a9418a68d48f288f50eb14 # v4.2.3
         with:
-          # Pinned: mise 2026.7.17 cannot resolve aqua packages whose upstream
-          # tags are prefixed (kubernetes-sigs/kustomize tags as kustomize/vX.Y.Z),
-          # so `mise install` 404s on the repo's .mise.toml toolchain and every
-          # run of this workflow fails. Deliberately NOT renovate-annotated —
-          # auto-bumping would reintroduce the break. Unpin once mise resolves
-          # prefixed aqua tags again.
-          version: 2026.7.17
+          # Pinned so a broken mise release can't float into CI on its own
+          # (mise-action's `version` defaults to "latest"). 2026.7.17 could not
+          # resolve aqua packages with prefixed upstream tags — kubernetes-sigs/
+          # kustomize tags as kustomize/vX.Y.Z — and 404'd on this repo's
+          # .mise.toml; 2026.7.18 fixes it.
+          # renovate: datasource=github-releases depName=jdx/mise
+          version: v2026.7.18
           cache: false
+          # NOTE: intentionally not scoped with install_args like the extract job.
+          # This job has no checkout, so `talosctl latest` below is the only tool
+          # spec; if a stale runner workspace leaves mise.lock behind, mise-action
+          # auto-adds --locked and a scoped `talosctl` would fail as "not in the
+          # lockfile".
           tool_versions: |
             talosctl latest
 


### PR DESCRIPTION
## Problem

`Image Pull` has been failing on **every** PR since #3827:

```
mise ERROR Failed to install aqua:kubernetes-sigs/kustomize@5.6.0:
  404 for https://api.github.com/repos/kubernetes-sigs/kustomize/releases/tags/5.6.0
  404 for .../releases/tags/v5.6.0
mise ERROR Version: 2026.7.17 linux-x64
```

kustomize tags releases as `kustomize/v5.6.0`, not `v5.6.0`. mise 2026.7.17 discards the (correct) `mise.lock` entry as stale and re-resolves via the GitHub release-by-tag API using the bare version, which 404s. One tool failing kills the whole `mise install`, so image pulling dies on unrelated branches.

#3823 pinned mise to 2026.7.16 to dodge this, deliberately *without* a `# renovate:` annotation on the theory that Renovate couldn't see a bare `version:`. It could — #3827 bumped both lines straight back into the broken release.

## Fix

**mise 2026.7.18** (published 2026-07-30 22:11Z, after #3823 picked 7.16) resolves prefixed aqua tags again. Verified locally against this repo's own `mise.lock`, everything else held constant:

| mise | `aqua:kubernetes-sigs/kustomize@5.6.0` |
|---|---|
| 2026.7.17 | 404 |
| 2026.7.18 | installed |

The lockfile is what triggers the bad path — without `mise.lock` present, 7.17 succeeds too, so any repro must include it.

- Both pins → `v2026.7.18`, now **annotated for Renovate**. A bare un-annotated pin demonstrably does not survive, and forward bumps are safe again; annotating at least makes a future breakage arrive as a reviewable PR instead of silently.
- `extract` job scoped with `install_args: github:home-operations/flate` — it only needs `flate`, and there is no reason for an unrelated tool in `.mise.toml` to be able to take down image pulling.
- `pull` job intentionally left unscoped, with a comment explaining why: it has no checkout step, so if a stale self-hosted-runner workspace leaves `mise.lock` behind, mise-action auto-adds `--locked` and a scoped `talosctl` fails as "not in the lockfile" (confirmed locally).

## Verifying

`extract`/`pull` are gated on `kubernetes/**/*` changes, so this PR touching only `.github/` will show them **skipped** — green here means "didn't run". Real verification needs a fresh `pull_request` event on a manifest-touching PR; `gh workflow run renovate.yaml` rebases the open Renovate PRs onto the new base and does that cleanly. Note `gh run rerun` replays the *old* workflow file and proves nothing.