### PR TITLE
fix(frigate): 30m install timeout — first boot outlasts helm's 5m wait

### DIFF
--- a/kubernetes/apps/home-automation/frigate/app/helmrelease.yaml
+++ b/kubernetes/apps/home-automation/frigate/app/helmrelease.yaml
@@ -6,6 +6,12 @@ metadata:
   name: frigate
 spec:
   interval: 30m
+  # First boot pulls the ~9Gi tensorrt image and runs the ~15 minute YOLOv9
+  # export before the pod can go Ready. The default 5m helm wait times out and
+  # install remediation then uninstalls the release, killing the export mid-run
+  # (its work happens in container-ephemeral /tmp, so every retry starts over) —
+  # the release could never converge.
+  timeout: 30m
   chartRef:
     kind: OCIRepository
     name: app-template

--- a/kubernetes/apps/home-automation/frigate/ks.yaml
+++ b/kubernetes/apps/home-automation/frigate/ks.yaml
@@ -29,7 +29,9 @@ spec:
   wait: true
   interval: 30m
   retryInterval: 1m
-  timeout: 10m
+  # Matches the HelmRelease timeout: first boot includes the ~9Gi image pull and
+  # the one-off ~15 minute model export before anything reports healthy.
+  timeout: 30m
   postBuild:
     substitute:
       # VolSync protects the config volume only (frigate.db event metadata +


### PR DESCRIPTION
Helm's default 5m wait times out during Frigate's first boot (~9Gi tensorrt image pull + one-off ~15m YOLOv9 export in the init container). Install remediation then uninstalls the release, killing the export mid-run — its work is in container-ephemeral /tmp, so every retry starts from zero and the release can never converge. Observed live after merging #3833: pod deleted at the 5m mark, reinstalled, repeat.

Sets `spec.timeout: 30m` on the HelmRelease and matches the Flux Kustomization health-check timeout to it. Subsequent boots are fast (the model persists on the frigate-models PVC and the export no-ops).