### PR TITLE
fix(frigate): lean CPU requests — the GPU node is request-saturated

### DIFF
--- a/kubernetes/apps/home-automation/frigate/app/helmrelease.yaml
+++ b/kubernetes/apps/home-automation/frigate/app/helmrelease.yaml
@@ -88,8 +88,12 @@ spec:
                 mv "$MODEL.partial" "$MODEL"
                 echo "export complete:"; ls -l "$MODEL"
             resources:
+              # Requests are deliberately lean: talos-node-gpu-1 sits near 100%
+              # CPU *requests* (though not usage), and this pod can only land
+              # there. The export just runs slower under contention — it is a
+              # one-off. No CPU limit, so it uses idle cores when they exist.
               requests:
-                cpu: "2"
+                cpu: 500m
                 memory: 4Gi
                 ephemeral-storage: 12Gi
               limits:
@@ -123,8 +127,12 @@ spec:
                   failureThreshold: 5
               readiness: *probe
             resources:
+              # With detection on the P100, steady-state CPU is go2rtc restream
+              # plus decode of three small substreams — about a core in practice.
+              # Requesting less keeps the pod schedulable on the request-saturated
+              # GPU node; there is no CPU limit to throttle real usage.
               requests:
-                cpu: 1500m
+                cpu: 500m
                 memory: 3Gi
                 # Detection runs on the P100. This is one MPS slot, not a whole
                 # card, so it shares the GPU with Ollama. It also pins Frigate to


### PR DESCRIPTION
Frigate stayed Pending after #3836: `0/11 nodes available … Insufficient cpu`. `talos-node-gpu-1` carries ~98% CPU *requests* (15715m/15950m — usage is far lower; limits are 351% overcommitted), and the GPU requirement pins Frigate to that node, so its 2-CPU effective request could never fit the ~235m that remain.

Drops requests to 500m on both the app container and the export init container. With detection on the P100 the app's steady-state CPU is go2rtc restream + three substream decodes; the one-off export just runs slower under contention. Neither has a CPU limit, so real usage can use idle cores.

Worth a separate look: the GPU node has accreted ~100 mostly GPU-irrelevant pods and is the most request-saturated node in the cluster — a rebalance would give GPU workloads room to breathe.