### PR TITLE
fix(frigate): 200m CPU requests so scheduling fits without evictions

### DIFF
--- a/kubernetes/apps/home-automation/frigate/app/helmrelease.yaml
+++ b/kubernetes/apps/home-automation/frigate/app/helmrelease.yaml
@@ -93,7 +93,7 @@ spec:
               # there. The export just runs slower under contention — it is a
               # one-off. No CPU limit, so it uses idle cores when they exist.
               requests:
-                cpu: 500m
+                cpu: 200m
                 memory: 4Gi
                 ephemeral-storage: 12Gi
               limits:
@@ -132,7 +132,7 @@ spec:
               # Requesting less keeps the pod schedulable on the request-saturated
               # GPU node; there is no CPU limit to throttle real usage.
               requests:
-                cpu: 500m
+                cpu: 200m
                 memory: 3Gi
                 # Detection runs on the P100. This is one MPS slot, not a whole
                 # card, so it shares the GPU with Ollama. It also pins Frigate to


### PR DESCRIPTION
Follow-up to #3837: 500m still exceeded the ~235m of unrequested CPU on `talos-node-gpu-1`, and freeing more meant evicting unrelated workloads. 200m fits what the node has today. Requests only gate scheduling — neither container has a CPU limit, so real usage is unaffected.

The node-rebalance question from #3837 stands; this just stops Frigate from being hostage to it.