### PR TITLE
feat(frigate): 36h retention indoors, keep 7d/14d outside

### DIFF
--- a/kubernetes/apps/home-automation/frigate/app/config/config.yaml
+++ b/kubernetes/apps/home-automation/frigate/app/config/config.yaml
@@ -95,12 +95,14 @@ detect:
   enabled: true
   fps: 5
 
+# Global defaults suit the outdoor cameras: motion for a week, classified
+# events for a fortnight. The indoor cameras see near-constant motion, so they
+# override this down to 36 hours (1.5 days) — measured burn with everything at
+# 7d was ~205GB/day, mostly indoor footage nobody will scrub back through.
 record:
   enabled: true
-  # Any segment containing motion is kept for a week...
   motion:
     days: 7
-  # ...and anything Frigate actually classified is kept for a fortnight.
   alerts:
     retain:
       days: 14
@@ -134,6 +136,18 @@ birdseye:
 
 cameras:
   den:
+    record:
+      # Indoor: 36 hours across the board (see the global record comment).
+      motion:
+        days: 1.5
+      alerts:
+        retain:
+          days: 1.5
+          mode: motion
+      detections:
+        retain:
+          days: 1.5
+          mode: motion
     ffmpeg:
       inputs:
         - path: rtsp://127.0.0.1:8554/den
@@ -171,6 +185,18 @@ cameras:
         - cat
 
   living_room:
+    record:
+      # Indoor: 36 hours across the board (see the global record comment).
+      motion:
+        days: 1.5
+      alerts:
+        retain:
+          days: 1.5
+          mode: motion
+      detections:
+        retain:
+          days: 1.5
+          mode: motion
     ffmpeg:
       inputs:
         - path: rtsp://127.0.0.1:8554/living_room


### PR DESCRIPTION
Measured burn was ~205GB/day with everything at 7d — the indoor cameras see near-constant motion, so motion-mode retention behaved like continuous recording and the 1Ti media PVC would have filled around day 5 (Frigate would have pruned oldest-first rather than crash, but silently).

Per-camera override: den + living room retain 36h (motion, alerts, detections); driveway keeps the global 7d motion / 14d classified events.

Validated against Frigate's own parser (`--validate-config`, local docker). The reloader annotation restarts the pod on ConfigMap change; the model-export init no-ops since the model already exists, so the restart is quick. Existing indoor footage older than 36h gets pruned on the next cleanup cycle, which should free a few hundred GB.