### PR TITLE
feat(authentik): forward-auth provider + app for Frigate

### DIFF
--- a/kubernetes/apps/security/authentik/app/blueprints.yaml
+++ b/kubernetes/apps/security/authentik/app/blueprints.yaml
@@ -202,6 +202,14 @@ data:
       - model: authentik_core.application
         identifiers: { slug: nats-nui }
         attrs: { name: NATS NUI, group: internal, provider: !KeyOf natsnui-provider, meta_icon: "https://cdn.jsdelivr.net/gh/cncf/artwork/projects/nats/icon/color/nats-icon-color.svg", meta_launch_url: "https://nats-nui.${SECRET_DOMAIN}" }
+      # frigate
+      - model: authentik_providers_proxy.proxyprovider
+        identifiers: { name: Provider for Frigate }
+        id: frigate-provider
+        attrs: { <<: *proxy, external_host: "https://frigate.${SECRET_DOMAIN}" }
+      - model: authentik_core.application
+        identifiers: { slug: frigate }
+        attrs: { name: Frigate, group: home, provider: !KeyOf frigate-provider, meta_icon: "https://cdn.jsdelivr.net/gh/selfhst/icons/svg/frigate.svg", meta_launch_url: "https://frigate.${SECRET_DOMAIN}" }
       # Embedded outpost: disables the k8s Ingress AND declaratively owns the assigned-
       # provider list. Adding an app = its 2 entries above (with id:) + one !KeyOf line here.
       - model: authentik_outposts.outpost
@@ -229,6 +237,7 @@ data:
             kubernetes_ingress_annotations: {}
             kubernetes_ingress_secret_name: ${SECRET_DOMAIN_MEDIA/./-}-tls
           providers:
+            - !KeyOf frigate-provider
             - !KeyOf 4kradarr-provider
             - !KeyOf prowlarr-provider
             - !KeyOf 4ksonarr-provider


### PR DESCRIPTION
https://frigate.chelonianlabs.com returned an Authentik 404 (`x-powered-by: authentik`): the route annotation, Kyverno SecurityPolicy and ReferenceGrant were all in place from #3833, but the blueprint half was never added, so the outpost had no provider for the host.

Adds the proxy provider + application (group `home`, selfhst frigate icon) and assigns the provider to the embedded outpost. No API bypass — the UI's own /api calls carry the session cookie, and Home Assistant talks to port 5000 over cluster DNS which never crosses the gateway.