### PR TITLE
fix(frigate): disable built-in TLS on 8971 — Envoy forwards plaintext

### DIFF
--- a/kubernetes/apps/home-automation/frigate/app/config/config.yaml
+++ b/kubernetes/apps/home-automation/frigate/app/config/config.yaml
@@ -29,6 +29,13 @@ proxy:
   header_map:
     user: x-authentik-username
 
+# Frigate serves 8971 over TLS (self-signed) by default, but Envoy forwards to
+# backends in plain HTTP — with TLS on, every proxied request hits nginx's
+# "plain HTTP request was sent to HTTPS port" 400. TLS terminates at the
+# gateway, so the internal listener goes plaintext.
+tls:
+  enabled: false
+
 # Inference on the Tesla P100. Verified: compute capability 6.0 is supported by
 # the ONNX runtime's CUDA execution provider in the -tensorrt image. Note the
 # TensorRT *detector* is Jetson-only in 0.17 — discrete NVIDIA cards go through


### PR DESCRIPTION
After the SSO gate went live (#3860), the UI 400'd: `The plain HTTP request was sent to HTTPS port — nginx/1.27.4`. Frigate serves port 8971 over self-signed TLS by default, and Envoy Gateway originates plain HTTP to backends.

Sets `tls.enabled: false` (Frigate's documented reverse-proxy setting). TLS terminates at the gateway; auth is Authentik forward-auth at the edge; the :5000 API HA uses is unaffected. Validated with `--validate-config`.