### PR TITLE
feat(frigate): map 'authentik Admins' group to the admin role

### DIFF
--- a/kubernetes/apps/home-automation/frigate/app/config/config.yaml
+++ b/kubernetes/apps/home-automation/frigate/app/config/config.yaml
@@ -25,9 +25,18 @@ mqtt:
 auth:
   enabled: false
 
+# Role mapping: proxied users default to viewer in Frigate, so members of the
+# "authentik Admins" group are promoted via the groups header. Authentik's
+# outpost joins group names with "|" (not the default comma).
 proxy:
   header_map:
     user: x-authentik-username
+    role: x-authentik-groups
+    role_map:
+      admin:
+        - authentik Admins
+  default_role: viewer
+  separator: "|"
 
 # Frigate serves 8971 over TLS (self-signed) by default, but Envoy forwards to
 # backends in plain HTTP — with TLS on, every proxied request hits nginx's


### PR DESCRIPTION
SSO users landed as `viewer` — Frigate's `proxy.default_role` is viewer, and no role header was mapped. Maps `x-authentik-groups` with `role_map: admin: [authentik Admins]`, so admins get the admin UI and everyone else stays viewer.

Gotcha encoded in the config: Authentik's outpost pipe-joins the groups header (`strings.Join(c.Groups, "|")`), so `separator: "|"` is required — with the default comma the group list never splits and everyone silently stays viewer. Validated with `--validate-config`.