### PR TITLE
feat(frigate): UI owns the live config; git becomes the seed

### DIFF
--- a/kubernetes/apps/home-automation/frigate/app/config/config.yaml
+++ b/kubernetes/apps/home-automation/frigate/app/config/config.yaml
@@ -1,14 +1,16 @@
 ---
-# Frigate NVR configuration.
+# Frigate NVR configuration — SEED ONLY.
 #
-# This file is mounted READ-ONLY from a ConfigMap, so the built-in config editor
-# and the zone/mask drawing tools in the web UI cannot save. Draw a zone in the
-# UI to get its coordinates, then paste them here and let Flux reconcile.
+# The LIVE config is owned by the Frigate UI and lives on the frigate-config PVC
+# (VolSync-backed hourly). This file is copied there by the seed-config init
+# container ONLY when no config exists yet (first boot or fresh restore); edits
+# here do NOT propagate to a running install.
 #
-# Frigate logs a harmless "Config file is read-only, unable to migrate config
-# file." on every boot — it checks writability before it checks the version. Keep
-# `version` matching CURRENT_CONFIG_VERSION so this file stays honest about which
-# schema it targets, and bump it deliberately on a Frigate major upgrade.
+# To snapshot the live config back into git once things stabilise:
+#   kubectl -n home-automation exec deploy/frigate -c app -- cat /config/config.yml
+# and paste it over this file — the {FRIGATE_*} credential placeholders survive
+# UI saves (Frigate substitutes env vars at load time and round-trips the raw
+# file), so no secrets ever land here.
 version: "0.17-0"
 
 mqtt:

--- a/kubernetes/apps/home-automation/frigate/app/helmrelease.yaml
+++ b/kubernetes/apps/home-automation/frigate/app/helmrelease.yaml
@@ -44,6 +44,28 @@ spec:
           reloader.stakater.com/auto: "true"
         strategy: Recreate
         initContainers:
+          # Config ownership lives in the Frigate UI (zones, masks, tuning).
+          # Git holds the SEED: copied onto the config PVC only when no config
+          # exists there yet (first boot / fresh restore). After that the UI
+          # saves to the PVC — VolSync backs it up hourly — and git edits to the
+          # seed deliberately do NOT propagate. To snapshot the live config back
+          # into git: kubectl exec deploy/frigate -c app -- cat /config/config.yml
+          # then paste over config/config.yaml (keep the {FRIGATE_*} placeholders).
+          seed-config:
+            image:
+              repository: busybox
+              tag: "1.37"
+            command:
+              - sh
+              - -c
+              - |
+                if [ -f /config/config.yml ]; then
+                  echo "config exists on PVC — UI owns it, seed skipped"
+                else
+                  cp /seed/config.yml /config/config.yml
+                  echo "seeded config from git:"
+                  ls -l /config/config.yml
+                fi
           # Frigate only auto-downloads Frigate+ models, so the community YOLOv9
           # export is built here rather than staged by hand. This is Frigate's
           # own documented export, run once: it no-ops on every subsequent start
@@ -177,20 +199,23 @@ spec:
                 port: http
 
     persistence:
-      # Event database + model cache. VolSync-backed (see ks.yaml).
+      # Event database, model cache — and the live config.yml, which the UI
+      # owns (see the seed-config init container). VolSync-backed (see ks.yaml).
       config:
         existingClaim: frigate-config
         globalMounts:
           - path: /config
-      # Mounted over the top of the config volume so the config itself stays
-      # declarative in git.
+      # Seed only: consumed by the seed-config init container, never mounted
+      # over the live config.
       config-file:
         type: configMap
         name: frigate-config-file
-        globalMounts:
-          - path: /config/config.yml
-            subPath: config.yml
-            readOnly: true
+        advancedMounts:
+          frigate:
+            seed-config:
+              - path: /seed/config.yml
+                subPath: config.yml
+                readOnly: true
       # Recordings and snapshots. Deliberately not backed up.
       media:
         existingClaim: frigate-media


### PR DESCRIPTION
Zone/mask edits in the UI were lost — Frigate's config API writes `/config/config.yml`, which was a read-only ConfigMap subPath mount. Deliberate trade-off in #3833, now reversed by choice: config ownership moves to the UI so zones/tuning can be managed live, with git holding the seed.

- `seed-config` init container copies the git config onto the `frigate-config` PVC **only if no config exists** (first boot or fresh VolSync restore); otherwise it logs and skips — no dual-source drift
- The ConfigMap is no longer mounted into the app container at all (`advancedMounts` scopes it to the init container)
- Live config is VolSync-backed hourly; `{FRIGATE_*}` env placeholders survive UI round-trips so secrets stay out of the file
- Copy-back procedure (once stable) documented in the seed header and the init comment