### PR TITLE
fix(frigate): seed guard must test -s, not -f

### DIFF
--- a/kubernetes/apps/home-automation/frigate/app/helmrelease.yaml
+++ b/kubernetes/apps/home-automation/frigate/app/helmrelease.yaml
@@ -59,7 +59,10 @@ spec:
               - sh
               - -c
               - |
-                if [ -f /config/config.yml ]; then
+                # -s (non-empty), NOT -f: the old read-only subPath mount left a
+                # zero-byte placeholder on the PVC (kubelet creates the bind-mount
+                # target file), which -f would treat as a real config.
+                if [ -s /config/config.yml ]; then
                   echo "config exists on PVC — UI owns it, seed skipped"
                 else
                   cp /seed/config.yml /config/config.yml


### PR DESCRIPTION
After #3864 Frigate crash-looped: every internal service hit `'NoneType' object has no attribute 'get'` parsing `/config/config.yml` — the file on the PVC was **zero bytes, dated Jul 31**. That's kubelet's doing: a `subPath` file mount creates an empty placeholder file on the underlying volume as the bind-mount target, so the read-only era left a 0-byte `config.yml` sitting invisibly under the mount. The seed guard's `-f` saw it and skipped seeding.

`-s` (exists and non-empty) is the correct guard. UI-saved configs are never empty, so this can't mis-skip later.