### PR TITLE
fix(frigate): fsync the seeded config — a rollback reverted the unsynced write

### DIFF
--- a/kubernetes/apps/home-automation/frigate/app/helmrelease.yaml
+++ b/kubernetes/apps/home-automation/frigate/app/helmrelease.yaml
@@ -65,7 +65,12 @@ spec:
                 if [ -s /config/config.yml ]; then
                   echo "config exists on PVC — UI owns it, seed skipped"
                 else
-                  cp /seed/config.yml /config/config.yml
+                  # Atomic + fsync'd: a helm rollback once hard-killed the pod
+                  # right after a plain cp, and ext4 reverted the never-synced
+                  # write back to the empty placeholder on remount.
+                  cp /seed/config.yml /config/.config.seed.tmp
+                  mv /config/.config.seed.tmp /config/config.yml
+                  sync
                   echo "seeded config from git:"
                   ls -l /config/config.yml
                 fi


### PR DESCRIPTION
Sequence observed live: #3865's upgrade was declared *stalled* by helm-controller against the Deployment's stale `Failed` progress condition (left over from the previous crash-loop era) and remediation rolled back to v2 — hard-killing the just-seeded pod. The seed's plain `cp` was still un-fsync'd, so ext4 reverted `config.yml` to the 0-byte placeholder (original Jul 31 mtime preserved — the tell), and the v2 generation (`-f` guard) crash-looped on it again.

Seed now stages to a temp file, renames, and `sync`s, so a kill at any instant leaves either no config (reseeded next boot) or a complete one.