### PR TITLE
chore(renovate): close automerge gaps for digest pins, hermes-agent, mise workflow pin

### DIFF
--- a/.renovate/autoMerge.json5
+++ b/.renovate/autoMerge.json5
@@ -53,6 +53,10 @@
         "/hotio/",
         // Docker Hub images pinned to a rolling tag + digest (kometa :nightly)
         "/kometateam/",
+        // Docker Hub library images pinned tag + digest (frigate's python init)
+        "python",
+        // ECR-public mirrors of docker library images (obsidian-couchdb busybox)
+        "/public.ecr.aws/",
       ],
       ignoreTests: false,
     },
@@ -97,6 +101,7 @@
         "/atuin/",
         "/searxng/",
         // AI apps
+        "/hermes-agent/",
         "/ollama/",
         "/open-webui/",
         "/litellm/",
@@ -181,6 +186,19 @@
         "/external-secrets/",
       ],
       ignoreTests: true,
+    },
+    {
+      description: "Auto-merge mise workflow-pin patch updates",
+      // The renovate.yaml workflow pins jdx/mise via github-releases. Patch bumps
+      // ride through to match the .mise.toml rule above; minors stay manual for
+      // the same reason (they can change tool output).
+      matchDatasources: ["github-releases"],
+      matchPackageNames: ["/jdx/mise/"],
+      automerge: true,
+      automergeType: "pr",
+      matchUpdateTypes: ["patch"],
+      minimumReleaseAge: "1 day",
+      ignoreTests: false,
     },
 
     // ------------------------------------------------------------------


### PR DESCRIPTION
Three classes of Renovate PRs get hand-merged every time despite being as mundane as things already automerged. Observed over the 2026-08-04/05 triage sweeps:

- **Docker Hub / ECR-public digest pins** — `python` (frigate model-export init) and `public.ecr.aws/docker/library/busybox` (obsidian-couchdb) are rolling-tag+digest pins, but the trusted-digest rule only matched ghcr/home-ops-style registries. Added `python` and `/public.ecr.aws/` to it.
- **`docker.io/nousresearch/hermes-agent`** — frequent calver releases, always hand-merged. Added to the standard-apps minor/patch rule.
- **`jdx/mise` workflow pin (github-releases)** — the `.mise.toml` mise rule already automerges patches, but the renovate.yaml workflow pin arrives via github-releases and stayed manual (#3863, #3884). New patch-only rule with the same 1-day age; minors stay manual for the same tool-output reason as the mise-manager rule.

Deliberately unchanged: oxfmt/zizmor minors (held on purpose), networking/storage deny block, kubernetes releases (weekend upgrades).

All additions sit above the deny block per the rule-order contract.