### PR TITLE
fix(paperless-ngx): use v3 double-brace filename format

### DIFF
--- a/kubernetes/apps/selfhosted/paperless-ngx/app/helmrelease.yaml
+++ b/kubernetes/apps/selfhosted/paperless-ngx/app/helmrelease.yaml
@@ -52,7 +52,7 @@ spec:
               PAPERLESS_CONSUMPTION_DIR: /media/consume
               PAPERLESS_DATA_DIR: /data/local
               PAPERLESS_MEDIA_ROOT: /media/paperless
-              PAPERLESS_FILENAME_FORMAT: "{created_year}/{correspondent}/{title}"
+              PAPERLESS_FILENAME_FORMAT: "{{ created_year }}/{{ correspondent }}/{{ title }}"
               PAPERLESS_FILENAME_FORMAT_REMOVE_NONE: "true"
 
               # Logging


### PR DESCRIPTION
Paperless v3 logs a deprecation warning for the old single-brace `PAPERLESS_FILENAME_FORMAT` style. Same format, new syntax: `{{ created_year }}/{{ correspondent }}/{{ title }}`. Values are plain data to Helm, so the braces pass through untouched.