### PR TITLE
fix(paperless-ngx): escape filename format for app-template tpl rendering

### DIFF
--- a/kubernetes/apps/selfhosted/paperless-ngx/app/helmrelease.yaml
+++ b/kubernetes/apps/selfhosted/paperless-ngx/app/helmrelease.yaml
@@ -52,7 +52,9 @@ spec:
               PAPERLESS_CONSUMPTION_DIR: /media/consume
               PAPERLESS_DATA_DIR: /data/local
               PAPERLESS_MEDIA_ROOT: /media/paperless
-              PAPERLESS_FILENAME_FORMAT: "{{ created_year }}/{{ correspondent }}/{{ title }}"
+              # app-template runs env values through tpl, so the paperless v3
+              # double-brace placeholders must be emitted as a quoted literal.
+              PAPERLESS_FILENAME_FORMAT: '{{ "{{ created_year }}/{{ correspondent }}/{{ title }}" }}'
               PAPERLESS_FILENAME_FORMAT_REMOVE_NONE: "true"
 
               # Logging


### PR DESCRIPTION
#3896 broke HelmRelease rendering: app-template passes env values through `tpl`, so the v3-style `{{ created_year }}` placeholders were evaluated as Go template functions (`function "created_year" not defined` — the Extract Images check caught it, and it was merged past the red check by mistake). The running release was unaffected since helm-controller kept the last good revision.

Fix: wrap the format string as a quoted template literal so `tpl` emits the double braces verbatim. Verified with `flate build hr paperless-ngx --path .` — renders `{{ created_year }}/{{ correspondent }}/{{ title }}` exactly.

Note: `flate` without `--path` resolved the stale primary checkout from this worktree, which cost a few minutes of confusion.